### PR TITLE
Ajout d'une page de maintenance

### DIFF
--- a/infrastructure/maintenance/index.html
+++ b/infrastructure/maintenance/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Stylo | Maintenance</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap');
+
+        body {
+            font-family: 'Open Sans', 'Helvetica', 'Arial', sans-serif;
+            margin: 0 auto;
+            max-width: 50em;
+            line-height: 1.5;
+            padding: 4em 1em;
+            color: #566b78;
+        }
+
+        h1,
+        h2,
+        strong {
+            color: #333;
+        }
+
+        p {
+            font-size: 1.2em;
+        }
+    </style>
+</head>
+<body>
+<h1>Maintenance</h1>
+<p>📢 Stylo is currently in maintenance.</p>
+
+</body>
+</html>


### PR DESCRIPTION
L'idée est d'afficher cette page quand on veut faire une maintenance mais aussi lorsque http://stylo.ecrituresnumeriques.ca/ sera redirigé sur le serveur stylo.huma-num.fr.

![maintenance-stylo](https://user-images.githubusercontent.com/333276/81784484-35e41c00-94fd-11ea-8004-d1b29e84f3b2.png)

A noter qu'il faudra surement générer un certificat let's encrypt pour stylo.ecrituresnumeriques.ca sur le serveur stylo.huma-num.fr sinon Chrome n'est pas content !


![stylo](https://user-images.githubusercontent.com/333276/81784746-9bd0a380-94fd-11ea-8452-701b66442dc1.png)

