### PR TITLE
Ajout d'un service systemd pour démarrer docker-compose

### DIFF
--- a/infrastructure/files/docker-compose-stylo.service
+++ b/infrastructure/files/docker-compose-stylo.service
@@ -4,13 +4,13 @@ Requires=docker.service
 After=docker.service
 StartLimitIntervalSec=60
 StartLimitBurst=3
-TimeoutStartSec=0
 
 [Service]
 WorkingDirectory=/home/stylo/stylo
 ExecStart=/usr/local/bin/docker-compose up
 ExecStop=/usr/local/bin/docker-compose down
 Restart=on-failure
+TimeoutStartSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/infrastructure/files/docker-compose-stylo.service
+++ b/infrastructure/files/docker-compose-stylo.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Docker Compose Stylo
+Requires=docker.service
+After=docker.service
+StartLimitIntervalSec=60
+StartLimitBurst=3
+TimeoutStartSec=0
+
+[Service]
+WorkingDirectory=/home/stylo/stylo
+ExecStart=/usr/local/bin/docker-compose up
+ExecStop=/usr/local/bin/docker-compose down
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/playbook.yml
+++ b/infrastructure/playbook.yml
@@ -29,6 +29,13 @@
         dest: /etc/nginx/sites-enabled/{{ site }}.conf
       notify: reload nginx
 
+    - name: Copy systemd service file
+      become: yes
+      copy:
+        src: ./docker-compose-stylo.service
+        dest: /etc/systemd/system/docker-compose-stylo.service
+      notify: start docker-compose-stylo
+
     - name: Checkout and update Stylo
       git:
         repo: 'https://github.com/EcrituresNumeriques/stylo.git'
@@ -54,3 +61,9 @@
       service:
         name: nginx
         state: reloaded
+    - name: start docker-compose-stylo
+      become: true
+      systemd:
+        name: docker-compose-stylo
+        state: started
+        enabled: yes


### PR DESCRIPTION
Permet (en théorie) de redémarrer les conteneurs via docker-composer lorsque le serveur (re)démarre.

fixes #186 