### PR TITLE
Met à jour l'adresse du serveur stylo

### DIFF
--- a/docs/en_EN/pages/firststeps.md
+++ b/docs/en_EN/pages/firststeps.md
@@ -3,11 +3,11 @@
 ---
 
 ## Creating an account
-To use Stylo, creating a user account is necessary. To create an account, please click [here](https://front.stylo.ecrituresnumeriques.ca/register) and fill in the mandatory fields
+To use Stylo, creating a user account is necessary. To create an account, please click [here](https://stylo.huma-num.fr/register) and fill in the mandatory fields
 
 ![Register](uploads/images/Register.png)
 
-If you already have an account, sign-in [here](https://front.stylo.ecrituresnumeriques.ca/login).
+If you already have an account, sign-in [here](https://stylo.huma-num.fr).
 
 ## User page
 The home page for your Stylo account lists your personal articles as well as those that have been shared with you by other Stylo users.

--- a/docs/fr_FR/pages/premierspas.md
+++ b/docs/fr_FR/pages/premierspas.md
@@ -1,11 +1,11 @@
 # Premiers pas dans Stylo
 
 ## Création d'un compte
-Afin d'éditer dans Stylo, la création d'un compte utilisateur est nécessaire. Pour créer un compte, veuillez cliquer [ici](https://front.stylo.ecrituresnumeriques.ca/register) et fournir les infomations obligatoire :
+Afin d'éditer dans Stylo, la création d'un compte utilisateur est nécessaire. Pour créer un compte, veuillez cliquer [ici](https://stylo.huma-num.fr/register) et fournir les infomations obligatoire :
 
 ![Register](uploads/images/Register.png)
 
-Si vous possédez déjà un compte, connectez-vous [ici](https://front.stylo.ecrituresnumeriques.ca/login).
+Si vous possédez déjà un compte, connectez-vous [ici](https://stylo.huma-num.fr).
 
 ## Page d'utilisateur
 La page d'accueil de votre compte Stylo liste vos articles personnels ainsi que ceux qui ont été partagés avec vous par d'autres utilisateurs de Stylo.


### PR DESCRIPTION
Remplace https://front.stylo.ecrituresnumeriques.ca/ par https://stylo.huma-num.fr dans la documentation et supprime le `/login` en prevision de la suppression de cette page dans https://github.com/EcrituresNumeriques/stylo/pull/225