### PR TITLE
Affiche les erreurs de validation sur le raw BibTeX

### DIFF
--- a/front/gatsby/src/helpers/bibtex.js
+++ b/front/gatsby/src/helpers/bibtex.js
@@ -37,6 +37,15 @@ export function validate(bibtex) {
   }))
 }
 
+/**
+ * Filter invalid citation from a raw BibTeX
+ * @param {string} bibtex
+ * @returns {string}
+ */
+export function filter(bibtex) {
+  return bibtex.replace(/^@[a-z]+{noauthor_notitle_nodate\n}/gm, "")
+}
+
 const IconNameMap = {
   article: 'journal-article',
   book: 'book',

--- a/front/gatsby/src/helpers/zotero.js
+++ b/front/gatsby/src/helpers/zotero.js
@@ -1,4 +1,5 @@
 import LinkHeader from 'http-link-header'
+import {filter} from './bibtex.js'
 
 export const fetchBibliographyFromCollectionHref = async ({collectionHref, token: key = null}) => {
     const url = new URL(collectionHref + '/items')
@@ -31,7 +32,7 @@ export async function fetchZoteroFromUrl (url, agg = []) {
     const bib = await response.text()
 
     if (bib && bib.trim().length > 0) {
-        agg.push(bib)
+        agg.push(filter(bib))
     }
 
     const nextLink = getNextLink(headers)


### PR DESCRIPTION
#### Afficher les erreurs de validation sur le raw BibTeX

Les erreurs s'affichent en dessous de l'éditeur : 

![error](https://user-images.githubusercontent.com/333276/94126380-d2c5a700-fe57-11ea-8bf4-60967de01c5e.png)

Une fois le ou les erreurs corrigées, le bouton "Save" devient actif : 

![save](https://user-images.githubusercontent.com/333276/94126389-d3f6d400-fe57-11ea-9aa8-d82e69193e52.png)


#### Filtre les BibTeX vides lors de la récupération via Zotero


La citation ci-dessous est présente dans la bibliographie d'Antoine : https://www.zotero.org/groups/925666/bibliothque_du_muse_saint-raymond/collections/KLIRSWJ2 

```
@incollection{noauthor_notitle_nodate
}
```

Cette citation n'est pas valide pour `biblatex-csl-converter` et on obtient l'erreur suivante : 

```
missing_equal_sign at line 2529
```

Les citations renvoyées par Zotero ne sont pas validées lors de la récupération (car on suppose que Zotero retourne du BibTeX valide).
Pour contourner ce problème j'ai ajouté un filtre afin de supprimer les citations vides lorsque l'on récupére les citations de Zotero.

#### Ajout d'un debounce pour fluidifier l'édition du raw BibTeX ou de l'ajout d'une citation

J'ai importé `lodash.debounce` pour valider le BibTeX moins fréquemment lorsque l'on édite du BibTeX sur l'onglet raw BibTeX et sur l'onglet citations.



resolves #187 

//cc @antoinentl 