### PR TITLE
Remplace dataloader.load par un appel direct à GraphQL

### DIFF
--- a/graphql/package-lock.json
+++ b/graphql/package-lock.json
@@ -477,11 +477,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "dataloader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
-      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -16,7 +16,6 @@
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.5",
-    "dataloader": "^2.0.0",
     "express": "^4.16.4",
     "express-graphql": "^0.11.0",
     "express-session": "^1.17.1",

--- a/graphql/resolvers/nestedModel.js
+++ b/graphql/resolvers/nestedModel.js
@@ -9,10 +9,6 @@ const Tag = require('../models/tag');
 const Article = require('../models/article');
 const Version = require('../models/version');
 
-
-const DataLoader = require('dataloader');
-
-
 /*
 ---------------------------------------------------------
 |                                                       |
@@ -45,39 +41,11 @@ const getUserById = async (userId) => {
         throw err;
     }
 };
+
 const getUsersByIds = async (usersIds,args) => {
-    //console.log("Entering getUsersByIds",usersIds,args);
-    try{
-        usersIds = paginate(usersIds,args.limit,args.page);
-        if(usersIds.length === 0){ return [] }
-        return usersIds.map((userId) => (getUsersByIdsLoader.load(userId)));
-    }
-    catch(err){
-        throw err
-    }
+    usersIds = paginate(usersIds,args.limit,args.page);
+    return usersIds.map((userId) => User.findById(userId).then(populateUser));
 };
-
-const getUsersByIdsNF = (usersIds) => {
-    const ids = usersIds
-    return User.find({ _id: { $in: usersIds } })
-    .then(users => users.map(populateUser))
-    .then(users => {
-        let byIdUsers = {}
-        for(let i = 0; i < users.length;i++){
-            byIdUsers[users[i]._id] = users[i]
-        }
-        return byIdUsers
-    })
-    .then(users => {
-        let response = []
-        for(let i = 0; i < ids.length;i++){
-            response.push(users[ids[i]] || null)
-        }
-        return response
-    })
-}
-
-const getUsersByIdsLoader = new DataLoader(getUsersByIdsNF);
 
 /*
 ---------------------------------------------------------


### PR DESCRIPTION
`dataloader` crée un cache avec les `Promise` contenant des utilisateurs.
La clé utilisée par ce cache est un identifiant numérique qui n'est pas lié à un id Stylo.
Le cache ajoute donc indéfiniment des nouvelles entrées.

![user](https://user-images.githubusercontent.com/333276/94662826-37c24680-0309-11eb-941f-f55931e4a450.png)
