### PR TITLE
Rend le code plus defensif par rapport aux informations renvoyées par le parser

### DIFF
--- a/front/gatsby/src/components/Write/bibliographe/CitationsFilter.js
+++ b/front/gatsby/src/components/Write/bibliographe/CitationsFilter.js
@@ -7,9 +7,12 @@ const compare = (a, b) => {
 }
 
 const flatten = (entryTitle) => {
-  return entryTitle
-    .map(({ text }) => text)
-    .join('')
+  if (entryTitle) {
+    return entryTitle
+      .map(({ text }) => text)
+      .join('')
+  }
+  return ''
 }
 
 /**
@@ -26,7 +29,7 @@ export default (input) => {
   const {entries} = parser.parse()
 
   return Object.entries(entries)
-    .map(([key, entry]) => ({
+    .map(([_, entry]) => ({
       title: flatten(entry.fields.title),
       type: entry.bib_type,
       key: entry.entry_key,

--- a/front/gatsby/src/helpers/bibtex.js
+++ b/front/gatsby/src/helpers/bibtex.js
@@ -68,9 +68,11 @@ const IconNameMap = {
  * @returns {string}
  */
 export function iconName (bibtexType) {
-  const iconName = IconNameMap[bibtexType]
-  if (iconName) {
-    return iconName
+  if (bibtexType) {
+    const iconName = IconNameMap[bibtexType]
+    if (iconName) {
+      return iconName
+    }
   }
   return 'book'
 }


### PR DESCRIPTION
Notamment sur le titre et le type qui peuvent, dans certains cas, être `undefined`.

Pourrait corriger #257 et potentiellement #258