### PR TITLE
Ajuste les règles Shinken

### DIFF
--- a/infrastructure/files/dev-nagios-nrpe-local.cfg
+++ b/infrastructure/files/dev-nagios-nrpe-local.cfg
@@ -9,4 +9,4 @@ allowed_hosts=134.158.33.139,192.168.33.139
 command[check_docker_app_mem]=/usr/local/bin/check_docker --memory 500:700:MB --containers graphql-stylo front-stylo export-stylo
 command[check_docker_db_mem]=/usr/local/bin/check_docker --memory 1800:2200:MB --containers mongodb-stylo
 command[check_docker_cpu]=/usr/local/bin/check_docker --cpu 25:50
-command[check_docker_running]=/usr/local/bin/check_docker --status running
+command[check_docker_running]=/usr/local/bin/check_docker --status running --containers mongodb-stylo graphql-stylo front-stylo export-stylo

--- a/infrastructure/files/nagios-nrpe-local.cfg
+++ b/infrastructure/files/nagios-nrpe-local.cfg
@@ -7,6 +7,6 @@ allowed_hosts=134.158.33.139,192.168.33.139
 #command[check_procs]=/usr/lib64/nagios/plugins/check_procs -w 1:1 -c 1:1 -C oplmgr
 #command[check_tcp]=/usr/lib64/nagios/plugins/check_tcp -H localhost -p 60001
 command[check_docker_app_mem]=/usr/local/bin/check_docker --memory 500:700:MB --containers graphql-stylo front-stylo export-stylo
-command[check_docker_db_mem]=/usr/local/bin/check_docker --memory 1500:2000:MB --containers mongodb-stylo
+command[check_docker_db_mem]=/usr/local/bin/check_docker --memory 1800:2200:MB --containers mongodb-stylo
 command[check_docker_cpu]=/usr/local/bin/check_docker --cpu 25:50
 command[check_docker_running]=/usr/local/bin/check_docker --status running

--- a/infrastructure/files/prod-nagios-nrpe-local.cfg
+++ b/infrastructure/files/prod-nagios-nrpe-local.cfg
@@ -1,0 +1,12 @@
+######################################
+# Do any local nrpe configuration here
+######################################
+
+allowed_hosts=134.158.33.139,192.168.33.139
+
+#command[check_procs]=/usr/lib64/nagios/plugins/check_procs -w 1:1 -c 1:1 -C oplmgr
+#command[check_tcp]=/usr/lib64/nagios/plugins/check_tcp -H localhost -p 60001
+command[check_docker_app_mem]=/usr/local/bin/check_docker --memory 500:700:MB --containers graphql-stylo front-stylo export-stylo
+command[check_docker_db_mem]=/usr/local/bin/check_docker --memory 1800:2200:MB --containers mongodb-stylo
+command[check_docker_cpu]=/usr/local/bin/check_docker --cpu 25:50
+command[check_docker_running]=/usr/local/bin/check_docker --status running

--- a/infrastructure/inventories/dev
+++ b/infrastructure/inventories/dev
@@ -1,4 +1,5 @@
 [stylo:vars]
+env=dev
 ansible_become_pass='{{ stylo_become_pass }}'
 site=stylo-dev.huma-num.fr
 https=true

--- a/infrastructure/inventories/prod
+++ b/infrastructure/inventories/prod
@@ -1,4 +1,5 @@
 [stylo:vars]
+env=prod
 ansible_become_pass='{{ stylo_become_pass }}'
 site=stylo.huma-num.fr
 https=true

--- a/infrastructure/playbook.yml
+++ b/infrastructure/playbook.yml
@@ -54,7 +54,7 @@
     - name: Copy Nagios configuration
       become: yes
       copy:
-        src: ./nagios-nrpe-local.cfg
+        src: ./{{ env }}-nagios-nrpe-local.cfg
         dest: /etc/nagios/nrpe_local.cfg
 
     - name: Checkout and update Stylo


### PR DESCRIPTION
- Un fichier spécifique par environnement (dev et prod)
- Précise la liste des conteneurs qui doivent être running en dev (sinon une alerte est déclenché quand un conteneur de build échoue)
- Augmente un peu la limite mémoire de MongoDB (limite basse de 1.5Gb à 1.8Gb et limite haute de 2Gb à 2.2Gb)