### PR TITLE
Ajout de polyfills intelligents

### DIFF
--- a/front/gatsby/public/index.html
+++ b/front/gatsby/public/index.html
@@ -26,6 +26,7 @@
       content="Stylo, online text editor for scholars"
     />
     <meta name="twitter:image" content="/favicon.ico" />
+    <script src="https://polyfill.io/v3/polyfill.min.js"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Plutôt que d'imposer des polyfills dans le code, ce service fournit seulement les polyfills nécessaires, en fonction du navigateur qui charge la page.

fixes #344 