### PR TITLE
Re-lax la portée des cookies

### DIFF
--- a/graphql/app.js
+++ b/graphql/app.js
@@ -59,7 +59,6 @@ const secureCookie = process.env.HTTPS === 'true'
 // Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 const allowedOrigins = (origin ?? '').split(' ').filter(v => v).map(o => new RegExp('^' + o))
 const sameSiteCookies = zoteroAuthorizeEndpoint || oicAuthUrl ? 'lax' : 'strict'
-                        
 if (sameSiteCookies === 'none') {
   console.warn('Cookies are configured with `sameSite: none`.')
 }

--- a/graphql/app.js
+++ b/graphql/app.js
@@ -58,8 +58,8 @@ const secureCookie = process.env.HTTPS === 'true'
 // When using 'strict' value, cookies will not be sent along with requests initiated by third-party websites.
 // Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 const allowedOrigins = (origin ?? '').split(' ').filter(v => v).map(o => new RegExp('^' + o))
-// Note that SameSite=none requires secure
-const sameSiteCookies = allowedOrigins.length === 1 ? 'strict' : secureCookie ? 'none' : 'lax'
+const sameSiteCookies = zoteroAuthorizeEndpoint || oicAuthUrl ? 'lax' : 'strict'
+                        
 if (sameSiteCookies === 'none') {
   console.warn('Cookies are configured with `sameSite: none`.')
 }

--- a/graphql/app.js
+++ b/graphql/app.js
@@ -58,7 +58,7 @@ const secureCookie = process.env.HTTPS === 'true'
 // When using 'strict' value, cookies will not be sent along with requests initiated by third-party websites.
 // Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 const allowedOrigins = (origin ?? '').split(' ').filter(v => v).map(o => new RegExp('^' + o))
-const sameSiteCookies = zoteroAuthorizeEndpoint || oicAuthUrl ? 'lax' : 'strict'
+const sameSiteCookies = process.env.NODE_ENV === 'production' ? 'lax' : 'none'
 if (sameSiteCookies === 'none') {
   console.warn('Cookies are configured with `sameSite: none`.')
 }


### PR DESCRIPTION
La conclusion que je vois, c'est qu'on n'a pas d'intérêt à utiliser `SameSite=None`. Et `SameSite=Strict`est trop strict quand on a besoin d'interagir avec d'autres domaines (genre Zotero ou le provider OpenID de connexion — HumanID).

fixes #370