### PR TITLE
Améliore l'affichage des références bibliographiques

### DIFF
--- a/front/gatsby/src/components/Write/Reference.jsx
+++ b/front/gatsby/src/components/Write/Reference.jsx
@@ -7,26 +7,8 @@ import ReferenceTypeIcon from '../ReferenceTypeIcon'
 import Button from '../Button'
 
 export default function BibliographyReference ({ entry }) {
-  const { key, title, type } = entry
-  const author = entry.entry.fields?.author
-  const date = entry.entry.fields?.date
-  let authorName = ''
-  if (author) {
-    const { family, given, prefix, literal } = author?.[0]
-    if (literal) {
-      authorName = literal.map(o => o.text).join(' ')
-    } else {
-      const authorPrefix = prefix ? `${prefix.map(o => o.text).join(' ')} ` : ''
-      const authorNames = []
-      if (given) {
-        authorNames.push(given.map(o => o.text).join(' '))
-      }
-      if (family) {
-        authorNames.push(family.map(o => o.text).join(' '))
-      }
-      authorName = `${authorPrefix}${authorNames.join(', ')}`
-    }
-  }
+  const { key, title, type, date, authorName } = entry
+
   return (
     <div
       className={styles.reference}

--- a/front/gatsby/src/components/Write/Reference.jsx
+++ b/front/gatsby/src/components/Write/Reference.jsx
@@ -8,18 +8,43 @@ import Button from '../Button'
 
 export default function BibliographyReference ({ entry }) {
   const { key, title, type } = entry
-
+  const author = entry.entry.fields?.author
+  const date = entry.entry.fields?.date
+  let authorName = ''
+  if (author) {
+    const { family, given, prefix, literal } = author?.[0]
+    if (literal) {
+      authorName = literal.map(o => o.text).join(' ')
+    } else {
+      const authorPrefix = prefix ? `${prefix.map(o => o.text).join(' ')} ` : ''
+      const authorNames = []
+      if (given) {
+        authorNames.push(given.map(o => o.text).join(' '))
+      }
+      if (family) {
+        authorNames.push(family.map(o => o.text).join(' '))
+      }
+      authorName = `${authorPrefix}${authorNames.join(', ')}`
+    }
+  }
   return (
-    <p
+    <div
       className={styles.reference}
-      title={title}
     >
       <ReferenceTypeIcon type={type} className={styles.referenceTypeIcon} />
-      <span className={styles.referenceName}>@{key}</span>
-
+      <div className={styles.referenceInfo}>
+        <p className={styles.referencePrimaryInfo} title={authorName + " | " + title}>
+          {authorName && <div className={styles.referenceAuthor}>{authorName}</div>}
+          <div className={styles.referenceTitle} title={title}>{title}</div>
+          <div className={styles.referenceDate}>{date}</div>
+        </p>
+        <p className={styles.referenceSecondaryInfo}>
+          <span className={styles.referenceKey} title={"@" + key}>@{key}</span>
+        </p>
+      </div>
       <CopyToClipboard text={`[@${key}]`}>
         <Button title="Copy to clipboard" className={styles.copyToClipboard} icon={true}><Clipboard /></Button>
       </CopyToClipboard>
-    </p>
+    </div>
   )
 }

--- a/front/gatsby/src/components/Write/Reference.jsx
+++ b/front/gatsby/src/components/Write/Reference.jsx
@@ -16,9 +16,9 @@ export default function BibliographyReference ({ entry }) {
       <ReferenceTypeIcon type={type} className={styles.referenceTypeIcon} />
       <div className={styles.referenceInfo}>
         <p className={styles.referencePrimaryInfo} title={authorName + " | " + title}>
-          {authorName && <div className={styles.referenceAuthor}>{authorName}</div>}
-          <div className={styles.referenceTitle} title={title}>{title}</div>
-          <div className={styles.referenceDate}>{date}</div>
+          {authorName && <span className={styles.referenceAuthor}>{authorName}</span>}
+          <span className={styles.referenceTitle} title={title}>{title}</span>
+          <span className={styles.referenceDate}>{date}</span>
         </p>
         <p className={styles.referenceSecondaryInfo}>
           <span className={styles.referenceKey} title={"@" + key}>@{key}</span>

--- a/front/gatsby/src/components/Write/ReferenceList.jsx
+++ b/front/gatsby/src/components/Write/ReferenceList.jsx
@@ -8,14 +8,12 @@ import Field from '../Field'
 import Button from "../Button";
 
 function ReferenceList({ articleBibTeXEntries }) {
-  // state showAll boolean (default false)
   const [filter, setFilter] = useState('')
   const [showAll, setShowAll] = useState(false)
   let bibTeXFound
   if (filter) {
     bibTeXFound = articleBibTeXEntries
       .filter((entry) => entry.key.toLowerCase().indexOf(filter.toLowerCase()) > -1)
-      //.slice(0, 10)
   } else {
     if (showAll) {
       bibTeXFound = articleBibTeXEntries

--- a/front/gatsby/src/components/Write/ReferenceList.jsx
+++ b/front/gatsby/src/components/Write/ReferenceList.jsx
@@ -1,16 +1,28 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { connect } from 'react-redux'
+import { Search } from 'react-feather'
 
 import Reference from './Reference'
+import styles from './ReferenceList.module.scss'
+import Field from '../Field'
 
-function ReferenceList ({ articleBibTeXEntries }) {
+function ReferenceList({ articleBibTeXEntries }) {
+  const [filter, setFilter] = useState('')
+
+  const bibTeXFound = articleBibTeXEntries
+    .filter((entry) => entry.key.toLowerCase().indexOf(filter.toLowerCase()) > -1)
+
   return (
     <>
-      {articleBibTeXEntries
+      <Field className={styles.searchField} type="text" icon={Search} value={filter} placeholder="Search" onChange={(e) => setFilter(e.target.value)} />
+      <span className={styles.resultFoundCount}>{bibTeXFound.length} found</span>
+      {bibTeXFound
+        .slice(0, 10)
         .map((entry, index) => (
-          <Reference key={`ref-${entry.key}-${index}`} entry={entry}/>
+          <Reference key={`ref-${entry.key}-${index}`} entry={entry} />
         ))
       }
+      {bibTeXFound.length > 10 && <span className={styles.more}>&hellip;</span>}
     </>
   )
 }

--- a/front/gatsby/src/components/Write/ReferenceList.jsx
+++ b/front/gatsby/src/components/Write/ReferenceList.jsx
@@ -5,24 +5,34 @@ import { Search } from 'react-feather'
 import Reference from './Reference'
 import styles from './ReferenceList.module.scss'
 import Field from '../Field'
+import Button from "../Button";
 
 function ReferenceList({ articleBibTeXEntries }) {
+  // state showAll boolean (default false)
   const [filter, setFilter] = useState('')
-
-  const bibTeXFound = articleBibTeXEntries
-    .filter((entry) => entry.key.toLowerCase().indexOf(filter.toLowerCase()) > -1)
-
+  const [showAll, setShowAll] = useState(false)
+  let bibTeXFound
+  if (filter) {
+    bibTeXFound = articleBibTeXEntries
+      .filter((entry) => entry.key.toLowerCase().indexOf(filter.toLowerCase()) > -1)
+      //.slice(0, 10)
+  } else {
+    if (showAll) {
+      bibTeXFound = articleBibTeXEntries
+    } else {
+      bibTeXFound = articleBibTeXEntries.slice(0, 25)
+    }
+  }
   return (
     <>
       <Field className={styles.searchField} type="text" icon={Search} value={filter} placeholder="Search" onChange={(e) => setFilter(e.target.value)} />
-      <span className={styles.resultFoundCount}>{bibTeXFound.length} found</span>
+      {filter && <span className={styles.resultFoundCount}>{bibTeXFound.length} found</span>}
       {bibTeXFound
-        .slice(0, 10)
         .map((entry, index) => (
           <Reference key={`ref-${entry.key}-${index}`} entry={entry} />
         ))
       }
-      {bibTeXFound.length > 10 && <span className={styles.more}>&hellip;</span>}
+      {!showAll && <Button className={styles.showAll} onClick={(e) => setShowAll(true)}>Show all {articleBibTeXEntries.length} references</Button>}
     </>
   )
 }

--- a/front/gatsby/src/components/Write/ReferenceList.module.scss
+++ b/front/gatsby/src/components/Write/ReferenceList.module.scss
@@ -13,6 +13,14 @@
   justify-content: flex-end;
 }
 
+.showAll {
+  display: flex;
+  display: flex;
+  margin: auto;
+  margin-bottom: 1em;
+  margin-top: 1em;
+}
+
 .more {
   font-size: 0.9rem;
   display: flex;

--- a/front/gatsby/src/components/Write/reference.module.scss
+++ b/front/gatsby/src/components/Write/reference.module.scss
@@ -9,16 +9,59 @@
   &:nth-child(2n + 1) {
     background-color: $main-background-color;
   }
-
 }
 
 .referenceTypeIcon {
   width: 1em;
   height: 1em;
   margin-right: 0.35em;
+  margin-left: 0.35em;
 }
 
-.referenceName {
+.referenceInfo {
+  display: flex;
+  flex-direction: column;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  padding-left: 0.35em;
+  padding-right: 0.25em;
+  /* hack: takes the remaining space */
+  flex: 1;
+  width: 1px;
+}
+
+.referencePrimaryInfo {
+  display: flex;
+  gap: 0.35em;
+  font-size: 0.85em;
+}
+
+.referenceSecondaryInfo {
+  display: flex;
+  font-family: 'Operator Mono', 'Source Code Pro', Menlo, Monaco, Consolas, Courier New, monospace;
+  font-size: 0.7em;
+}
+
+.referenceAuthor {
+  white-space: nowrap;
+}
+
+.referenceAuthor:after {
+  content: " | ";
+}
+
+.referenceTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.referenceDate {
+  font-size: 0.8em;
+}
+
+.referenceKey {
   overflow-x: hidden;
   text-overflow: ellipsis;
 }

--- a/front/gatsby/src/components/button.module.scss
+++ b/front/gatsby/src/components/button.module.scss
@@ -83,6 +83,7 @@ a.button:not(.primary), a.icon:not(.primary) {
 .primary {
   background-color: #000;
   color: #fff;
+  border: 1px solid #000;
 
   &:disabled {
     color: rgb(170, 170, 170);

--- a/front/gatsby/src/helpers/bibtex.js
+++ b/front/gatsby/src/helpers/bibtex.js
@@ -38,6 +38,32 @@ export function validate(bibtex) {
   }))
 }
 
+export function deriveAuthorNameAndDate(entry) {
+  const author = entry.fields?.author
+  const date = entry.fields?.date
+  let authorName = ''
+
+  if (author) {
+    const { family, given, prefix, literal } = author?.[0]
+    if (literal) {
+      authorName = literal.map(o => o.text).join(' ')
+    }
+    else {
+      const authorPrefix = prefix ? `${prefix.map(o => o.text).join(' ')} ` : ''
+      const authorNames = []
+      if (given) {
+        authorNames.push(given.map(o => o.text).join(' '))
+      }
+      if (family) {
+        authorNames.push(family.map(o => o.text).join(' '))
+      }
+      authorName = `${authorPrefix}${authorNames.join(', ')}`
+    }
+  }
+
+  return { date, authorName }
+}
+
 /**
  * @param {string} Bibtex bibliography
  * @returns {Array.<{ title: string, key: string, type: string }}
@@ -56,6 +82,7 @@ export function toEntries(input) {
       type: entry.bib_type,
       key: entry.entry_key,
       entry,
+      ...deriveAuthorNameAndDate(entry),
     }))
     .sort(compare)
 }

--- a/front/gatsby/src/helpers/bibtex.test.js
+++ b/front/gatsby/src/helpers/bibtex.test.js
@@ -112,6 +112,7 @@ describe('parse', () => {
       language = {fr-FR},
       urldate = {2018-03-29},
       journal = {L’atelier des savoirs},
+      journaltitle = {L’atelier des savoirs},
       author = {Dehut, Julien},
       month = jan,
       year = {2018},
@@ -120,6 +121,7 @@ describe('parse', () => {
 
     const entries = toEntries(text).map(({ entry }) => entry)
 
+    expect(toBibtex(entries)).toMatch('journal = {L’atelier des savoirs}')
     expect(toBibtex(entries)).toMatch('journaltitle = {L’atelier des savoirs}')
     expect(toBibtex(entries)).toMatch(
       'file = {Snapshot:/home/antoine/Zotero/storage/VC32TEFF/Dehut - En finir avec Word ! Pour une analyse des enjeux r.html:text/html}'

--- a/front/gatsby/src/helpers/bibtex.test.js
+++ b/front/gatsby/src/helpers/bibtex.test.js
@@ -5,7 +5,7 @@ describe('parse', () => {
     const text = `@book{noauthor_test19_nodate,
             title = {test19
         }
-        
+
         @book{noauthor_test26_nodate,
             title = {test26}
         }`
@@ -21,7 +21,7 @@ describe('parse', () => {
     const text = `@book{noauthor_test19_nodate,
             title = {test19}
         }
-        
+
         @book{noauthor_test26_nodate,
             title = {test26}
         }`
@@ -69,7 +69,7 @@ describe('parse', () => {
     const text = `@book{noauthor_test26_nodate,
         title = {test26}
       }
-      
+
       @foo {
 
       @book {noauthor_test24_nodate,
@@ -167,7 +167,7 @@ describe('parse', () => {
     expect(resultAfter).toHaveProperty('warnings', [])
     expect(resultAfter).toHaveProperty('errors', [])
 
-    const entries = bib2key(filteredText).map(({ entry }) => entry)
+    const entries = toEntries(filteredText).map(({ entry }) => entry)
     expect(entries).toHaveLength(2)
     expect(entries[0].entry_key).toEqual('bonnet_rome_2013')
     expect(entries[1].entry_key).toEqual(
@@ -192,12 +192,35 @@ describe('toEntries', () => {
         key: 'noauthor_test19_nodate',
         type: 'book',
         entry: {},
+        date: undefined,
+        authorName: ''
       },
       {
         title: 'test26',
         key: 'noauthor_test26_nodate',
         type: 'book',
         entry: {},
+        date: undefined,
+        authorName: ''
+      },
+    ])
+  })
+
+  test('it should derive an authorName', () => {
+    const text = `@book{gelzer_eikones_1980,
+	    title = {Eikones: {Studien} zum griechischen und römischen {Bildnis} : {Hans} {Jucker} zum sechzigsten {Geburtstag} {Gewidmet}},
+      author = {Gelzer, Thomas},
+    }`
+
+    return expect(toEntries(text)).toMatchObject([
+      {
+        title:
+          'Eikones: Studien zum griechischen und römischen Bildnis : Hans Jucker zum sechzigsten Geburtstag Gewidmet',
+        key: 'gelzer_eikones_1980',
+        type: 'book',
+        entry: {},
+        date: undefined,
+        authorName: 'Thomas, Gelzer'
       },
     ])
   })
@@ -214,6 +237,8 @@ describe('toEntries', () => {
         key: 'dominik_org_2010',
         type: 'book',
         entry: {},
+        date: undefined,
+        authorName: ''
       },
     ])
   })


### PR DESCRIPTION
Repose sur #400 

Permet de filtrer/rechercher dans la bibliographie.
Par défaut on affiche au maximum 10 résultats : 

![filter-biblio](https://user-images.githubusercontent.com/333276/120676614-832f8480-c496-11eb-99f1-aa660cac0c73.gif)

Cela améliore drastiquement les performances : 

### Avant

![slow](https://user-images.githubusercontent.com/333276/120677101-05b84400-c497-11eb-8836-22744ff88ea1.gif)

### Après

![fast](https://user-images.githubusercontent.com/333276/120677111-08b33480-c497-11eb-983c-cdf4473a64c6.gif)

Ce n'est pas évident à voir sur le gif car le nombre d'images par seconde est faible mais on passe d'une interface avec des "lags" de 1 à 2 secondes, à un affichage quasiment instantanée.
