### PR TITLE
Gère la pagination sur l'ensemble des appels à l'API Zotero

### DIFF
--- a/front/gatsby/src/helpers/zotero.js
+++ b/front/gatsby/src/helpers/zotero.js
@@ -1,26 +1,62 @@
 import LinkHeader from 'http-link-header'
 import { filter } from './bibtex'
 
-export const fetchBibliographyFromCollectionHref = async ({
-  collectionHref,
-  token: key = null,
-}) => {
-  const url = new URL(collectionHref + '/items')
-  return fetchZoteroFromUrl(url, key, [])
-}
-
-function getNextLink(headers) {
+/**
+ * Get the next link from headers.
+ * @param headers HTTP headers (from a response)
+ * @returns {URL|null}
+ */
+function getNextLink (headers) {
   if (!headers.has('Link') || headers.get('Link') === '') {
     return null
   }
-
   const links = LinkHeader.parse(headers.get('Link'))
   // response has a Link header with a rel=next which indicate that there a next page
   const linkNext = links.refs.find((ref) => ref.rel === 'next')
+
   return linkNext && linkNext.uri ? new URL(linkNext.uri) : null
 }
 
-export async function fetchZoteroFromUrl(url, key, agg = []) {
+/**
+ *
+ * @param url
+ * @param key Zotero API key
+ * @param agg
+ * @returns {Promise<string[]>} - a list of JSON responses
+ */
+async function fetchAllJSON (url, key, agg = []) {
+  if (key) {
+    url.searchParams.set('key', key)
+  }
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    credentials: 'same-origin',
+    'Zotero-API-Version': '3',
+  })
+
+  const { headers } = response
+  const json = await response.json()
+
+  if (json) {
+    agg.push(json)
+  }
+
+  const nextLink = getNextLink(headers)
+
+  if (nextLink) {
+    await fetchAllJSON(nextLink, key, agg)
+  }
+
+  return agg
+}
+
+/**
+ * @param url
+ * @param key Zotero API key
+ * @param agg
+ * @returns {Promise<string[]>} - a list of bibliographical references (as BibTeX)
+ */
+async function fetchAllBibTeX (url, key, agg = []) {
   if (key) {
     url.searchParams.set('key', key)
   }
@@ -41,27 +77,41 @@ export async function fetchZoteroFromUrl(url, key, agg = []) {
   const nextLink = getNextLink(headers)
 
   if (nextLink) {
-    await fetchZoteroFromUrl(nextLink, key, agg)
+    await fetchAllBibTeX(nextLink, key, agg)
   }
 
   return agg
 }
 
-function fetchUserFromToken(token) {
-  return fetchJSON(`https://api.zotero.org/keys/${token}`)
-}
-
-function fetchJSON(url) {
+/**
+ * @param url
+ * @returns {Promise<string>} - a JSON response
+ */
+function fetchJSON (url) {
   return fetch(url).then((response) => response.json())
 }
 
-async function fetchAllCollections({ userID, key }) {
-  // let collections = []
-  const groups = await fetchJSON(`https://api.zotero.org/users/${userID}/groups?key=${key}`)
+/**
+ * @param token Zotero API token
+ * @returns {Promise<object>} - a JSON response (contains userID and key)
+ */
+function fetchUserFromToken (token) {
+  return fetchJSON(`https://api.zotero.org/keys/${token}`)
+}
 
-  const collections = await Promise.all(groups.map(group => {
-    return fetchJSON(`${group.links.self.href}/collections?key=${key}`)
-  })).then(groups => [].concat(...groups))
+/**
+ * @param userID
+ * @param key Zotero API key
+ * @returns {Promise<object[]>} - a list of Zotero collections
+ */
+async function fetchAllCollections ({ userID, key }) {
+  // let collections = []
+  const url = new URL(`https://api.zotero.org/users/${userID}/groups`)
+  const groups = (await fetchAllJSON(url, key)).flat()
+
+  const groupCollections = await Promise.all(groups.map(group => {
+    return fetchAllJSON(new URL(`${group.links.self.href}/collections`), key)
+  })).then(groups => [].concat(...groups.flat()))
   // concat dissolves empty arrays (groups without collections)
 
   // snowpack@3.2 cannot transform this for Safari11
@@ -72,13 +122,16 @@ async function fetchAllCollections({ userID, key }) {
   //     )
   //   )
   // }
+  const userCollections = (await fetchAllJSON(new URL(`https://api.zotero.org/users/${userID}/collections`), key)).flat()
 
-  return collections.concat(
-    await fetchJSON(`https://api.zotero.org/users/${userID}/collections?key=${key}`)
-  )
+  return groupCollections.concat(userCollections)
 }
 
-export async function fetchAllCollectionsPerLibrary({ token }) {
+/**
+ * @param token
+ * @returns {Promise<{}>}
+ */
+export async function fetchAllCollectionsPerLibrary ({ token }) {
   const { userID, key } = await fetchUserFromToken(token)
   const collections = await fetchAllCollections({ userID, key })
   const result = {}
@@ -88,11 +141,26 @@ export async function fetchAllCollectionsPerLibrary({ token }) {
     lib.push(collection)
     result[key] = lib
   }
+
   return result
 }
 
-export async function fetchUserCollections({ token }) {
+/**
+ *
+ * @param token
+ * @returns {Promise<string>}
+ */
+export async function fetchUserCollections ({ token }) {
   const { userID, key } = await fetchUserFromToken(token)
 
-  return fetchJSON(`https://api.zotero.org/users/${userID}/collections?key=${key}`)
+  return (await fetchAllJSON(new URL(`https://api.zotero.org/users/${userID}/collections`), key)).flat()
+}
+
+/**
+ * @param collectionHref
+ * @param key Zotero API key
+ * @returns {Promise<string[]>}
+ */
+export const fetchBibliographyFromCollectionHref = async ({ collectionHref, token: key = null, }) => {
+  return fetchAllBibTeX(new URL(collectionHref + '/items'), key)
 }


### PR DESCRIPTION
Gère la pagination sur l'ensemble des appels à l'API Zotero : 

- Pagination sur les groupes d'un utilisateur (25 groupes par page)
- Pagination sur les collections associées à un groupe (25 collections par page)
- Pagination sur les collections de l'utilisateur (25 collections par page)

resolves #419