### PR TITLE
Épingle `pandocfilters@1.4.3`

### DIFF
--- a/export/dockerfile
+++ b/export/dockerfile
@@ -32,7 +32,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && dpkg -i /pandoc.deb \
     && rm /pandoc.deb
 
-    RUN git clone https://github.com/jgm/pandocfilters.git /pandocfilters \
+    RUN git clone --single-branch --branch 1.4.3 https://github.com/jgm/pandocfilters.git /pandocfilters \
     && cd /pandocfilters \
     && python setup.py install \
     && python3 setup.py install \


### PR DESCRIPTION
La version 1.5/master est publiée avec des tests qui ne passent pas, ce qui cassent notre chaine de déploiement.