### PR TITLE
Ajout d'un bouton (coin haut droit) permettant de fermer la modale

### DIFF
--- a/front/gatsby/src/components/Header.jsx
+++ b/front/gatsby/src/components/Header.jsx
@@ -47,7 +47,7 @@ const ConnectedHeader = (props) => {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <HelpCircle className={styles.linkIcon}size={14} />
+              <HelpCircle className={styles.linkIcon} size={14} />
               Documentation
             </a></li>
           </ul>

--- a/front/gatsby/src/components/Modal.jsx
+++ b/front/gatsby/src/components/Modal.jsx
@@ -1,21 +1,21 @@
 import React from 'react'
+import { X } from 'react-feather'
 import Button from './Button'
 
 import styles from './modal.module.scss'
 
-export default (props) => {
-  const defaultCancel = () => {}
-  const cancel = props.cancel || defaultCancel
-
+export default ({ children, cancel = () => {}, withCancelButton = true, withCloseButton = true }) => {
   return (
     <>
       <section className={styles.background} onClick={() => cancel()}></section>
       <article className={styles.modal}>
-        {props.children}
-
-        <Button className={styles.secondary} onClick={() => cancel()}>
+        {withCloseButton && <Button icon={true} className={[styles.secondary, styles.closeButton].join(' ')} onClick={() => cancel()}>
+          <X/>
+        </Button>}
+        {children}
+        {withCancelButton && <Button className={styles.secondary} onClick={() => cancel()}>
           Cancel
-        </Button>
+        </Button>}
       </article>
     </>
   )

--- a/front/gatsby/src/components/Write/Biblio.jsx
+++ b/front/gatsby/src/components/Write/Biblio.jsx
@@ -29,7 +29,7 @@ function Biblio ({ bib, article, readOnly, articleBibTeXEntries }) {
         </>
       )}
       {modal && (
-        <Modal cancel={() => setModal(false)}>
+        <Modal cancel={() => setModal(false)} withCancelButton={false}>
           <Bibliographe
             bib={bib}
             cancel={() => setModal(false)}

--- a/front/gatsby/src/components/modal.module.scss
+++ b/front/gatsby/src/components/modal.module.scss
@@ -26,3 +26,9 @@
   overflow: auto;
   background-color: $main-background-color;
 }
+
+.closeButton {
+  position: absolute;
+  right: 0;
+  top: 0;
+}


### PR DESCRIPTION
- Option permettant d'ajouter une icône/bouton "Fermer" dans le coin haut droit de la fenêtre modale
- Option permettant d'ajouter un bouton "Cancel" dans le coin bas gauche de la fenêtre modale
- Masque le bouton "Cancel" afin d'éviter le groupement de boutons dans le bas de la fenêtre des références bibliographiques.

| Avant | Après |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/333276/139016388-9554c44b-0168-4abc-ad2b-9a3d1488fc4a.png) | ![image](https://user-images.githubusercontent.com/333276/139016470-91fd4787-274d-4da9-9466-116a141aa00f.png) |
