### PR TITLE
On ne doit pas enregistrer quand on clique sur "Close"

### DIFF
--- a/front/gatsby/src/components/Write/Versions.jsx
+++ b/front/gatsby/src/components/Write/Versions.jsx
@@ -217,7 +217,7 @@ const Versions = ({ article, versions, readOnly, version, revision, versionId, s
                       onChange={(e) => setMessage(etv(e))}
                     />
                     <ul className={styles.actions}>
-                      <li><Button icon={true} onClick={(e) => saveVersion(e, false)}>Close</Button></li>
+                      <li><Button icon={true} onClick={(e) => setExpandSaveForm(false)}>Close</Button></li>
                       <li><Button onClick={(e) => saveVersion(e, false)}>Save Minor</Button></li>
                       <li><Button onClick={(e) => saveVersion(e, true)}>Save Major</Button></li>
                     </ul>


### PR DESCRIPTION
Actuellement, quand on clique sur "Close" on enregistre une nouvelle version !