### PR TITLE
Simplification de l'accès à l'API GraphQL

### DIFF
--- a/graphql/app.js
+++ b/graphql/app.js
@@ -332,15 +332,22 @@ app.post('/login',
     res.json({ error })
   })
 
-app.use(
-  '/graphql',
-  graphqlHTTP((req, res) => ({
+app.post('/graphql', graphqlHTTP((req, res) => ({
+  schema: graphQlSchema,
+  rootValue: graphQlResolvers,
+  graphiql: false,
+  context: { req, res }
+})))
+
+if (process.env.NODE_ENV === 'dev') {
+  app.get('/graphql', graphqlHTTP((req, res) => ({
     schema: graphQlSchema,
     rootValue: graphQlResolvers,
-    graphiql: process.env.NODE_ENV === 'dev',
+    graphiql: true,
     context: { req, res }
-  }))
-)
+  })))
+}
+
 
 // fix deprecation warnings: https://mongoosejs.com/docs/deprecations.html
 mongoose.set('useNewUrlParser', true)

--- a/graphql/app.js
+++ b/graphql/app.js
@@ -137,7 +137,10 @@ app.use(passport.initialize())
 app.use(passport.session())
 
 app.use(function (req, res, next) {
-  const jwtToken = req.cookies && req.cookies['graphQL-jwt']
+  const jwtToken = req.headers.authorization
+    ? req.headers.authorization.replace(/^Bearer /, '')
+    : req.cookies['graphQL-jwt']
+
   if (jwtToken) {
     try {
       req.user = jwt.verify(jwtToken, jwtSecret)

--- a/graphql/resolvers/userResolver.js
+++ b/graphql/resolvers/userResolver.js
@@ -118,8 +118,13 @@ module.exports = {
     const users = await User.find();
     return users.map(populateUser)
   },
-  user: async (args,{req}) => {
-    isUser(args,req)
+  user: async (args, {req}) => {
+    // if the userId is not provided, we take it from the auth token
+    if (('user' in args) === false) {
+      args.user = req.user.usersIds[0]
+    }
+
+    isUser(args, req)
 
     return getUserById(args.user)
   }

--- a/graphql/schema/index.js
+++ b/graphql/schema/index.js
@@ -112,15 +112,14 @@ input VersionInput {
 
 
 type RootQuery {
-  # admins only
-  "Reserved for admins"
+  "Fetch all articles [Reserved for admins]"
   articles:[Article!]!
-  "Reserved for admins"
+
+  "Fetch all users [Reserved for admins]"
   users:[User!]!
 
-
-  "Fetch user info [need to be authentificated as this user]"
-  user(user:ID!):User!
+  "Fetch authenticated user info"
+  user(user:ID):User!
 
   "Fetch bearer token based on your cookie graphQL-jwt [Need to be loged in previously and send the appropriate cookie]"
   refreshToken(expiration:String):AuthToken
@@ -130,7 +129,7 @@ type RootQuery {
 
   "Fetch version info"
   version(version:ID!):Version!
-  
+
   "Login using email/username and password, retrieve token+cookie"
   login(username:String,email:String,password:String!):AuthToken
 }
@@ -145,7 +144,7 @@ type RootMutation {
 
   "Add an email to your acquintances [need to be authentificated as user]"
   addAcquintance(email:String!,user:ID!):User!
-  
+
   "Change password"
   changePassword(password:ID!,old:String!,new:String!,user:ID!):Password!
 
@@ -171,7 +170,7 @@ type RootMutation {
 
   "Change default user when login in + for loginMutation"
   setPrimaryUser(password:ID!,user:ID!):Password!
-  
+
   "Create article for specified user [need to be authentificated as specified user]"
   createArticle(title:String!,user:ID!):Article!
 
@@ -180,13 +179,13 @@ type RootMutation {
 
   "Unlink a version from article [need to be authentificated as specified user]"
   unlinkVersion(version:ID!,user:ID!):Version!
-  
+
   "Create tag [need to be authentificated as specified user]"
   createTag(name:String!,description:String,user:ID!):Tag!
 
   "update name and description of a tag [need to be authentificated as specified user]"
   updateTag(name:String,description:String,color:String,tag:ID!,user:ID!):Tag!
-  
+
   "Delete tag and all articles carrying it"
   deleteTag(tag:ID!,user:ID!):User!
 


### PR DESCRIPTION
- [x] utilisation de l'entête `Authorization: Bearer <token>`
- [x] le userId de la query `user` est implicitement celui proposé par le token JWT

Une requête pour récupérer _ses_ articles devient : 


```sh
curl -H 'Content-Type: application/json' -H 'Authorization: Bearer …' -X POST -d '{ "query": "query { user { displayName articles { title owners { _id displayName } versions { _id } }} }" }' https://stylo-dev.huma-num.fr/graphql
```

cc @antoinentl 