### PR TITLE
Remove unused mutation

### DIFF
--- a/graphql/resolvers/authResolver.js
+++ b/graphql/resolvers/authResolver.js
@@ -28,22 +28,6 @@ const verifCreds = async ({ username, password }) => {
 
 module.exports = {
   verifCreds: verifCreds,
-  loginMutation: async (args,{req,_}) => {
-
-    //The resolver only logs the user + password in the req object
-    const fetchedPassword = await verifCreds(args);
-
-    //Add password to the req.created list + add users in the req.list
-    req.created = {...req.created, user:fetchedPassword.users[0].id, password:fetchedPassword.id}
-    req.user = {
-      usersIds:fetchedPassword.users.map(user => user._id.toString()),
-      passwordId:fetchedPassword.id,
-      admin:fetchedPassword.users.filter(user => user.admin).length > 0 ? true : false,
-    }
-    req.isAuth = true;
-
-    return populatePassword(fetchedPassword)
-  },
   login: async (args, {_,res}) => {
     try{
       const fetchedPassword = await verifCreds(args);

--- a/graphql/schema/index.js
+++ b/graphql/schema/index.js
@@ -139,9 +139,6 @@ type RootMutation {
   "Create user + password + default article"
   createUser(user:UserInput!):User!
 
-  "Log in the request, store user and password to be used as 'new' in userID fields"
-  loginMutation(username:String,email:String,password:String!):Password!
-
   "Add an email to your acquintances [need to be authentificated as user]"
   addAcquintance(email:String!,user:ID!):User!
 


### PR DESCRIPTION
Je suis à 95% sûr que cette mutation n'est pas/plus utilisée.

Si cette mutation était utilisée, on aurait surement des soucis car on renseigne le `user` dans la session avec `req.user` sauf qu'on ne renseigne pas `email` qui est notamment utilisé dans dans `/profile`...