### PR TITLE
Nettoie le stockage en session

### DIFF
--- a/graphql/app.js
+++ b/graphql/app.js
@@ -17,7 +17,7 @@ const OAuthStrategy = require('passport-oauth').OAuthStrategy;
 const graphQlSchema = require('./schema/index')
 const graphQlResolvers = require('./resolvers/index')
 
-const { createJWTToken } = require('./helpers/token')
+const { createJWTToken, populateUserFromJWT } = require('./helpers/token')
 const User = require('./models/user')
 const Password = require('./models/user_password')
 const { postCreate } = User
@@ -317,7 +317,7 @@ app.post('/login',
     res.json({ error })
   })
 
-app.post('/graphql', graphqlHTTP((req, res) => ({
+app.post('/graphql', populateUserFromJWT({ jwtSecret }), graphqlHTTP((req, res) => ({
   schema: graphQlSchema,
   rootValue: graphQlResolvers,
   graphiql: false,

--- a/graphql/app.js
+++ b/graphql/app.js
@@ -109,12 +109,13 @@ passport.use(new LocalStrategy({ session: false },
 ))
 
 // mandatory
-passport.serializeUser((user, next) => {
-  next(null, user)
+passport.serializeUser((password, next) => {
+  next(null, password.id)
 })
 
-passport.deserializeUser((obj, next) => {
-  next(null, obj)
+passport.deserializeUser(async (id, next) => {
+  const {users} = await Password.findById(id).populate('users')
+  next(null, users[0])
 })
 
 app.set('trust proxy', true)
@@ -135,23 +136,6 @@ app.use(session({
 }))
 app.use(passport.initialize())
 app.use(passport.session())
-
-app.use(function (req, res, next) {
-  const jwtToken = req.headers.authorization
-    ? req.headers.authorization.replace(/^Bearer /, '')
-    : req.cookies['graphQL-jwt']
-
-  if (jwtToken) {
-    try {
-      req.user = jwt.verify(jwtToken, jwtSecret)
-      req.isAuth = true
-    } catch (error) {
-      return next(error)
-    }
-  }
-
-  return next()
-})
 
 app.get('/version', (req, res) => res.json({
   name: pkg.name,

--- a/graphql/helpers/token.js
+++ b/graphql/helpers/token.js
@@ -19,9 +19,29 @@ module.exports.createJWTToken = async function createJWTToken ({ email, jwtSecre
     session: true,
     ...optionalPayload
   }
- 
+
   return jwt.sign(
     payload,
     jwtSecret
   )
+}
+
+module.exports.populateUserFromJWT = function populateUserFromJWT ({ jwtSecret }) {
+  return function populateUserFromJWTMiddleware(req, res, next) {
+    const jwtToken = req.headers.authorization
+      ? req.headers.authorization.replace(/^Bearer /, '')
+      : req.cookies['graphQL-jwt']
+
+    if (jwtToken) {
+      try {
+        // this overrides the `passport.deserializeUser()` user session object
+        // so use it in a stateless environment, like the GraphQL API
+        req.user = jwt.verify(jwtToken, jwtSecret)
+      } catch (error) {
+        return next(error)
+      }
+    }
+
+    return next()
+  }
 }

--- a/graphql/resolvers/userResolver.js
+++ b/graphql/resolvers/userResolver.js
@@ -115,7 +115,7 @@ module.exports = {
   },
   user: async (args, {req}) => {
     // if the userId is not provided, we take it from the auth token
-    if (('user' in args) === false) {
+    if (('user' in args) === false && req.user) {
       args.user = req.user.usersIds[0]
     }
 


### PR DESCRIPTION
Cette pull request fait plusieurs choses : 

- le token JWT n'est plus décodé systématiquement… car sa valeur écrasait ce qu'on ressortait de la session (elle ne servait à rien en fin de compte)
- elle rend explicite que la session stocke… le `Password.id`, et non un objet `Password` complet (contrairement à ce qu'annonçait le nommage des variables) — c'est lié au fait que `verifCreds()` retourne un objet… `Password` superchargé avec `populatePassword()`)
- la route `/graphql` ne se base pas sur le cookie de session, mais juste sur la valeur du Cookie graphQL ou bien sur la valeur de l'entête `Authorization` (cf. #473)

fixes #438