### PR TITLE
Honore la gestion du consentement de l'utilisateur·ice

### DIFF
--- a/front/src/components/Footer.jsx
+++ b/front/src/components/Footer.jsx
@@ -23,7 +23,7 @@ function Footer () {
           <li><Link to="/privacy">Privacy</Link></li>
           { import.meta.env.SNOWPACK_MATOMO_URL && (<li>
             <label className={styles.consentLabel}>
-              <input type="checkbox" checked={userHasConsent} onChange={toggleConsent} disabled={true} />
+              <input type="checkbox" checked={userHasConsent} onChange={toggleConsent} />
               I accept to share my navigation stats
             </label>
           </li>) }

--- a/front/src/createReduxStore.js
+++ b/front/src/createReduxStore.js
@@ -46,8 +46,8 @@ const initialState = {
     charCountPlusSpace: 0,
     citationNb: 0,
   },
-  userPreferences: {
-    trackingConsent: true /* default value should be false */
+  userPreferences: localStorage.getItem('userPreferences') ? JSON.parse(localStorage.getItem('userPreferences')) : {
+    trackingConsent: true,
   }
 }
 
@@ -137,6 +137,16 @@ function persistStateIntoLocalStorage ({ getState }) {
         const { articlePreferences } = getState()
         // we persist it for a later page reload
         localStorage.setItem('articlePreferences', JSON.stringify(articlePreferences))
+
+        return
+      }
+      else if (action.type === 'USER_PREFERENCES_TOGGLE') {
+        // we run the reducer first
+        next(action)
+        // we fetch the updated state
+        const { userPreferences } = getState()
+        // we persist it for a later page reload
+        localStorage.setItem('userPreferences', JSON.stringify(userPreferences))
 
         return
       }


### PR DESCRIPTION
Je fais un truc un peu crado pour contourner le fait que le `useSelector()` re-rend le composant lorsqu'il change, et que ça recréait des `history.listen()` (et donc des événements en doublon).

fixes #472