### PR TITLE
Ajout d'un logger afin de diagnostiquer l'erreur

### DIFF
--- a/export/src/export.js
+++ b/export/src/export.js
@@ -132,6 +132,7 @@ const errorHandler = (err, res) => {
     } else {
       error = {}
     }
+    logger.error({ cause: err }, 'Something went wrong!')
     res.status(500).send({ error })
   }
 }


### PR DESCRIPTION
Avec un peu de chance cela nous permettra de comprendre pourquoi l'erreur se déclenche et pourquoi la réponse a déjà était envoyée au client.