### PR TITLE
Montée en version de la pandoc-api

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,9 +61,7 @@ services:
     ports:
       - 127.0.0.1:3080:8001
   pandoc-api:
-    image: "davidbgk/pandoc-api:0.0.5"
-    environment:
-      - 'TEXINPUTS=.:/usr/pandoc-api/tmp/:'
+    image: "davidbgk/pandoc-api:0.0.6"
     ports:
       - 127.0.0.1:3090:8000
 


### PR DESCRIPTION
La variable d'environnement est maintenant définie dans https://gitlab.huma-num.fr/ecrinum/stylo/pandoc-api/-/blob/9643a5818a53ae7f419d677fc7cf72b7d6542a17/dockerfile#L41