### PR TITLE
Mise à jour de l'export stylo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
     depends_on:
       - graphql-stylo
   export-gateway:
-    image: "davidbgk/stylo-export:0.0.3"
+    image: "davidbgk/stylo-export:0.0.4"
     environment:
       - SE_PANDOC_API_BASE_URL=http://pandoc-api:8000/latest/
     ports:


### PR DESCRIPTION
Cela devrait par défaut autoriser les articles depuis stylo-dev