### PR TITLE
Corrige le schéma de formulaire

### DIFF
--- a/front/.eslintrc.cjs
+++ b/front/.eslintrc.cjs
@@ -1,31 +1,42 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true,
-        "jest/globals": true,
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    'jest/globals': true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:jsonc/recommended-with-json',
+  ],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended"
-    ],
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": 13,
-        "sourceType": "module"
+    ecmaVersion: 13,
+    sourceType: 'module',
+  },
+  overrides: [
+    {
+      files: ["**/*.json", "**/*.json5", "**/*.jsonc"],
+      parser: "jsonc-eslint-parser",
     },
-    "plugins": [
-        "react",
-        "jest"
-    ],
-    "settings": {
-      "react": {
-        "version": "16.13"
-      }
+  ],
+  plugins: ['react', 'jest'],
+  settings: {
+    react: {
+      version: '16.13',
     },
-    "rules": {
-      'react/prop-types': ['warn'],
-      'no-unused-vars': ['warn']
-    }
-};
+  },
+  rules: {
+    'react/prop-types': ['warn'],
+    'no-unused-vars': ['warn'],
+    'jsonc/indent': ['error', 2],
+    // 'jsonc/sort-keys': ['warn'],
+    'jsonc/key-spacing': ['error'],
+    'jsonc/no-irregular-whitespace': ['error'],
+    'jsonc/object-curly-newline': ['error'],
+    'jsonc/object-property-newline': ['error']
+  },
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -41,6 +41,7 @@
         "@welldone-software/why-did-you-render": "^6.2.3",
         "eslint": "^8.2.0",
         "eslint-plugin-jest": "^25.2.4",
+        "eslint-plugin-jsonc": "^2.5.0",
         "eslint-plugin-react": "^7.27.0",
         "jest": "^29.3.1",
         "prettier": "^2.3.0"
@@ -3844,6 +3845,26 @@
         }
       }
     },
+    "node_modules/eslint-plugin-jsonc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.5.0.tgz",
+      "integrity": "sha512-G257khwkrOQ5MJpSzz4yQh5K12W4xFZRcHmVlhVFWh2GCLDX+JwHnmkQoUoFDbOieSPBMsPFZDTJScwrXiWlIg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "jsonc-eslint-parser": "^2.0.4",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.31.11",
       "dev": true,
@@ -6484,6 +6505,39 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.1.0.tgz",
+      "integrity": "sha512-qCRJWlbP2v6HbmKW7R3lFbeiVWHo+oMJ0j+MizwvauqnCV/EvtAeEeuCgoc/ErtsuoKgYB8U4Ih8AxJbXoE6/g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jsonpointer": {
@@ -10764,6 +10818,17 @@
         "@typescript-eslint/experimental-utils": "^5.0.0"
       }
     },
+    "eslint-plugin-jsonc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.5.0.tgz",
+      "integrity": "sha512-G257khwkrOQ5MJpSzz4yQh5K12W4xFZRcHmVlhVFWh2GCLDX+JwHnmkQoUoFDbOieSPBMsPFZDTJScwrXiWlIg==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "jsonc-eslint-parser": "^2.0.4",
+        "natural-compare": "^1.4.0"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.31.11",
       "dev": true,
@@ -12344,6 +12409,29 @@
     },
     "json5": {
       "version": "2.2.1"
+    },
+    "jsonc-eslint-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.1.0.tgz",
+      "integrity": "sha512-qCRJWlbP2v6HbmKW7R3lFbeiVWHo+oMJ0j+MizwvauqnCV/EvtAeEeuCgoc/ErtsuoKgYB8U4Ih8AxJbXoE6/g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "jsonpointer": {
       "version": "5.0.1"

--- a/front/package.json
+++ b/front/package.json
@@ -63,6 +63,7 @@
     "@welldone-software/why-did-you-render": "^6.2.3",
     "eslint": "^8.2.0",
     "eslint-plugin-jest": "^25.2.4",
+    "eslint-plugin-jsonc": "^2.5.0",
     "eslint-plugin-react": "^7.27.0",
     "jest": "^29.3.1",
     "prettier": "^2.3.0"

--- a/front/src/components/Form.jsx
+++ b/front/src/components/Form.jsx
@@ -77,20 +77,31 @@ function ObjectFieldTemplate(props) {
         .filter(
           (field) => (props.uiSchema[field] || {})['ui:widget'] !== 'hidden'
         )
-        .map(
-          (field) =>
-            props.properties.filter((element) => element.name === field)[0]
-        )
-      if (elements && elements.length > 0) {
-        return (
-          <fieldset className={styles.fieldset} key={fields.join('-')}>
-            {title && <legend>{title}</legend>}
-            {elements.map((element) => (
-              <Fragment key={element.name}>{element.content}</Fragment>
-            ))}
-          </fieldset>
-        )
-      }
+        .map((field) => {
+          const element = props.properties.find((element) => element.name === field)
+
+          if (!element) {
+            console.error('Field configuration not found for "%s" in \'ui:groups\' "%s" — part of %o', field, title, fields)
+          }
+
+          return [field, element]
+        })
+
+        if (elements && elements.length > 0) {
+          return (
+            <fieldset className={styles.fieldset} key={fields.join('-')}>
+              {title && <legend>{title}</legend>}
+              {elements.map(([field, element]) => (
+                element
+                  ? <Fragment key={field}>{element.content}</Fragment>
+                  : <p key={field} className={styles.fieldHasNoElementError}>
+                      Field <code>{field}</code> defined in <code>ui:groups</code> is not an
+                      entry of <code>data-schema.json[properties]</code> object.
+                    </p>
+              ))}
+            </fieldset>
+          )
+        }
     })
 
     return <>{groupedElements}</>
@@ -111,11 +122,11 @@ function ObjectFieldTemplate(props) {
   }
 }
 
-export default ({
+export default function SchemaForm ({
   formData: initialFormData,
   basicMode,
   onChange = () => {},
-}) => {
+}) {
   const [formData, setFormData] = useState(initialFormData)
   const [errors, setErrors] = useState({})
   const formContext = {

--- a/front/src/components/Write/Write.jsx
+++ b/front/src/components/Write/Write.jsx
@@ -14,7 +14,7 @@ import WriteRight from './WriteRight'
 import Loading from '../Loading'
 import MonacoEditor from './providers/monaco/Editor'
 
-function Write() {
+export default function Write() {
   const { version: currentVersion, id: articleId, compareTo } = useParams()
   const userId = useSelector((state) => state.activeUser._id)
   const [readOnly, setReadOnly] = useState(Boolean(currentVersion))
@@ -250,5 +250,3 @@ Write.propTypes = {
   id: PropTypes.string,
   compareTo: PropTypes.string
 }
-
-export default Write

--- a/front/src/components/Write/yamleditor/YamlEditor.jsx
+++ b/front/src/components/Write/yamleditor/YamlEditor.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Form from '../../Form'
 import YAML from 'js-yaml'
 
-export default ({ yaml, basicMode, onChange }) => {
+export default function YamlEditor ({ yaml, basicMode, onChange }) {
   const [parsed] = YAML.loadAll(yaml)
 
   // we convert YYYY/MM/DD dates into ISO YYYY-MM-DD

--- a/front/src/components/form.module.scss
+++ b/front/src/components/form.module.scss
@@ -215,3 +215,9 @@
 .output {
   color: gray;
 }
+
+.fieldHasNoElementError {
+  border: 1px solid red;
+  margin: .5em;
+  padding: .5rem;
+}

--- a/front/src/schemas/data-schema.json
+++ b/front/src/schemas/data-schema.json
@@ -266,6 +266,7 @@
           "type": "string",
           "title": "ID"
         }
+      }
     },
     "prodnum": {
       "type": "string"
@@ -274,4 +275,4 @@
       "type": "string"
     }
   }
-}}
+}

--- a/front/src/schemas/data-schema.json
+++ b/front/src/schemas/data-schema.json
@@ -257,14 +257,15 @@
     },
     "funder": {
       "type": "object",
+      "title": "",
       "properties": {
         "funder_name": {
           "type": "string",
-          "title": "Organisation name"
+          "title": "Funder organisation"
         },
         "funder_id": {
           "type": "string",
-          "title": "ID"
+          "title": "Funder ID"
         }
       }
     },

--- a/front/src/schemas/ui-schema-editor.json
+++ b/front/src/schemas/ui-schema-editor.json
@@ -42,7 +42,7 @@
     },
     {
       "title": "Funder",
-      "fields": ["funder_name", "funder_id"]
+      "fields": ["funder"]
     },
     {
       "title": "Translated title",
@@ -221,15 +221,6 @@
   },
   "prod": {
     "ui:title": "Productor"
-  },
-  "funder": {
-    "ui:title": "Funder"
-  },
-  "funder_name": {
-    "ui:title": "Funder organisation"
-  },
-  "funder_id": {
-    "ui:title": "Funder ID"
   },
   "prodnum": {
     "ui:title": "Prodnum"


### PR DESCRIPTION
Le formulaire affiche les désalignements entre le schéma de données et le schéma d'interface.


![image](https://user-images.githubusercontent.com/138627/207999908-853ec2f9-a8d8-4fd1-847c-9b4874d5a024.png)

## Erreurs repérées

1. une accolade placée sur une ligne inattendue, qui "déforme" la structure de l'objet `properties` (`prodnum` et `diffnum` se retrouvent englobée dans `funder`) — corrigé avec 66c77bc
2. les sous-propriétés `funder_id` et `funder_name` sont utilisées au lieu de `funder` — corrigé avec 8883183

fixes #686 