### PR TITLE
Preview HTML + bibliographie basée sur Pandoc Export 🎁 🎄 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       - graphql-stylo
 
   export-gateway:
-    image: "davidbgk/stylo-export:0.0.9"
+    image: "davidbgk/stylo-export:0.0.10"
     environment:
       - SE_PANDOC_API_BASE_URL=${SE_PANDOC_API_BASE_URL:-http://pandoc-api:8000/latest/}
       - SE_ALLOWED_INSTANCE_DOMAINS=${SE_ALLOWED_INSTANCE_DOMAINS:-localhost:3000,localhost:3030}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       - graphql-stylo
 
   export-gateway:
-    image: "davidbgk/stylo-export:0.0.7"
+    image: "davidbgk/stylo-export:0.0.9"
     environment:
       - SE_PANDOC_API_BASE_URL=${SE_PANDOC_API_BASE_URL:-http://pandoc-api:8000/latest/}
       - SE_ALLOWED_INSTANCE_DOMAINS=${SE_ALLOWED_INSTANCE_DOMAINS:-localhost:3000,localhost:3030}

--- a/front/src/components/Article.jsx
+++ b/front/src/components/Article.jsx
@@ -121,7 +121,7 @@ export default function Article ({ article, currentUser:activeUser, setNeedReloa
           <Copy />
         </Button>
 
-        <Link title="Annotate with Stylo users and other people (open a new window)" target="_blank" className={clsx(buttonStyles.button, buttonStyles.icon)} to={`/article/${article._id}/annotate`}>
+        <Link title="Annotate with Stylo users and other people (open a new window)" target="_blank" className={buttonStyles.icon} to={`/article/${article._id}/annotate`}>
           <MessageSquare />
         </Link>
 
@@ -133,11 +133,11 @@ export default function Article ({ article, currentUser:activeUser, setNeedReloa
           <Printer />
         </Button>
 
-        <Link title="Edit article" className={clsx(buttonStyles.button, buttonStyles.primary)} to={`/article/${article._id}`}>
+        <Link title="Edit article" className={buttonStyles.primary} to={`/article/${article._id}`}>
           <Edit3 />
         </Link>
 
-        <Link title="Preview article" className={buttonStyles.button} to={`/article/${article._id}/preview`}>
+        <Link title="Preview article" className={buttonStyles.icon} to={`/article/${article._id}/preview`}>
           <Eye />
         </Link>
       </aside>

--- a/front/src/components/Article.jsx
+++ b/front/src/components/Article.jsx
@@ -74,13 +74,13 @@ export default function Article ({ article, currentUser:activeUser, setNeedReloa
   return (
     <article className={styles.article}>
       {exporting && (
-        <Modal cancel={() => setExporting(false)}>
+        <Modal title="Export" cancel={() => setExporting(false)}>
           <Export articleVersionId={article._id} articleId={article._id} />
         </Modal>
       )}
 
       {sharing && (
-        <Modal cancel={() => setNeedReload() || setSharing(false)}>
+        <Modal title="Share with Stylo users" cancel={() => setNeedReload() || setSharing(false)}>
           <Acquintances article={article} setNeedReload={setNeedReload} cancel={() => setSharing(false)} />
         </Modal>
       )}

--- a/front/src/components/Article.jsx
+++ b/front/src/components/Article.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
+import clsx from 'clsx'
 
 import styles from './articles.module.scss'
 import buttonStyles from './button.module.scss'
@@ -15,7 +16,7 @@ import etv from '../helpers/eventTargetValue'
 
 import Field from './Field'
 import Button from './Button'
-import { Check, ChevronDown, ChevronRight, Copy, Edit3, Eye, Printer, Share2, Trash } from 'react-feather'
+import { Check, ChevronDown, ChevronRight, Copy, Edit3, Eye, MessageSquare, Printer, Share2, Trash } from 'react-feather'
 
 import { duplicateArticle } from './Acquintances.graphql'
 import { renameArticle } from './Article.graphql'
@@ -116,29 +117,29 @@ export default function Article ({ article, currentUser:activeUser, setNeedReloa
           <Trash />
         </Button>}
 
-        <Link title="Preview" target="_blank" className={[buttonStyles.button, buttonStyles.icon].join(' ')} to={`/article/${article._id}/preview`}>
-          <Eye />
-        </Link>
-
-        {<Button title="Share" icon={true} onClick={() => setSharing(true)}>
-          <Share2 />
-        </Button>}
-
         <Button title="Duplicate" icon={true} onClick={() => fork()}>
           <Copy />
         </Button>
 
-        <Button title="Export" icon={true} onClick={() => setExporting(true)}>
+        <Link title="Annotate with Stylo users and other people (open a new window)" target="_blank" className={clsx(buttonStyles.button, buttonStyles.icon)} to={`/article/${article._id}/annotate`}>
+          <MessageSquare />
+        </Link>
+
+        {<Button title="Share with Stylo users" icon={true} onClick={() => setSharing(true)}>
+          <Share2 />
+        </Button>}
+
+        <Button title="Download a printable version" icon={true} onClick={() => setExporting(true)}>
           <Printer />
         </Button>
 
-        <Link title="Edit" className={[buttonStyles.button, buttonStyles.primary].join(' ')} to={`/article/${article._id}`}>
+        <Link title="Edit article" className={clsx(buttonStyles.button, buttonStyles.primary)} to={`/article/${article._id}`}>
           <Edit3 />
         </Link>
       </aside>
 
       {deleting && (
-        <div className={[styles.alert, styles.deleteArticle].join(' ')}>
+        <div className={clsx(styles.alert, styles.deleteArticle)}>
           <p>
             You are trying to delete this article, double click on the
             &quot;delete button&quot; below to proceed

--- a/front/src/components/Article.jsx
+++ b/front/src/components/Article.jsx
@@ -136,6 +136,10 @@ export default function Article ({ article, currentUser:activeUser, setNeedReloa
         <Link title="Edit article" className={clsx(buttonStyles.button, buttonStyles.primary)} to={`/article/${article._id}`}>
           <Edit3 />
         </Link>
+
+        <Link title="Preview article" className={buttonStyles.button} to={`/article/${article._id}/preview`}>
+          <Eye />
+        </Link>
       </aside>
 
       {deleting && (

--- a/front/src/components/Book.jsx
+++ b/front/src/components/Book.jsx
@@ -48,7 +48,7 @@ export default function Book ({ name: tagName, _id, updatedAt, articles }) {
   return (
     <article className={styles.article}>
       {exporting && (
-        <Modal cancel={() => setExporting(false)}>
+        <Modal title="Export" cancel={() => setExporting(false)}>
           <Export
             exportId={generateBookExportId(name)}
             bookId={_id}

--- a/front/src/components/Book.jsx
+++ b/front/src/components/Book.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Check, ChevronDown, ChevronRight, Edit3, Eye, Printer } from 'react-feather'
+import { Check, ChevronDown, ChevronRight, Edit3, MessageSquare, Printer } from 'react-feather'
 import { useSelector } from 'react-redux'
 
 import Modal from './Modal'
@@ -84,9 +84,9 @@ export default function Book ({ name: tagName, _id, updatedAt, articles }) {
           className={[buttonStyles.icon, buttonStyles.button, articles.length === 0 ? buttonStyles.isDisabled : ''].filter(d => d).join(' ')}
           title="Preview"
           target="_blank"
-          to={`/books/${_id}/preview`}
+          to={`/books/${_id}/annotate`}
         >
-          <Eye />
+          <MessageSquare />
         </Link>
         <Button className={buttonStyles.icon} title="Export" onClick={() => setExporting(true)}>
           <Printer />

--- a/front/src/components/Button.jsx
+++ b/front/src/components/Button.jsx
@@ -4,7 +4,6 @@ import styles from './button.module.scss'
 
 export default function Button (props) {
   const classNames = clsx({
-    [styles.button]: true,
     [styles.primary]: props.primary,
     [styles.secondary]: props.secondary || (!props.primary && !props.tertiary),
     [styles.tertiary]: props.tertiary,

--- a/front/src/components/Export.jsx
+++ b/front/src/components/Export.jsx
@@ -49,7 +49,7 @@ export default function Export ({ bookId, exportId, articleVersionId, articleId 
           <option value="icml">ICML</option>
         </Select>}
         {(articleId && !exportStyles.length) && <Loading inline size="24" />}
-        {(articleId && exportStyles.length) && <Select id="export-styles" label="Bibliography style" value={format} onChange={(e) => setCsl(e.target.value)}>
+        {(articleId && exportStyles.length) && <Select id="export-styles" label="Bibliography style" value={csl} onChange={(e) => setCsl(e.target.value)}>
           {exportStyles.map(({ title, name }) => <option value={name} key={name}>{ title }</option>)}
         </Select>}
         <div className={styles.bibliographyPreview}>

--- a/front/src/components/Export.jsx
+++ b/front/src/components/Export.jsx
@@ -20,8 +20,6 @@ export default function Export ({ bookId, exportId, articleVersionId, articleId 
   const { exportFormats, exportStyles, exportStylesPreview, isLoading } = useStyloExport(csl)
   const { host } = window.location
 
-  console.log({ csl })
-
   const exportUrl = bookId
     ? `${processEndpoint}/cgi-bin/exportBook/exec.cgi?id=${exportId}&book=${bookId}&processor=xelatex&source=${exportEndpoint}/&format=${format}&bibstyle=${csl}&toc=${Boolean(toc)}&tld=${tld}&unnumbered=${unnumbered}`
     // https://export.stylo-dev.huma-num.fr/generique/export/stylo-dev.huma-num.fr/60084903587dae0019eaf0d5/60084903587dae0019eaf0d5/?with_toc=1&with_ascii=0&formats=originals&formats=images&formats=html
@@ -29,8 +27,6 @@ export default function Export ({ bookId, exportId, articleVersionId, articleId 
 
   return (
     <section className={styles.export}>
-      <h1>Export</h1>
-
       <form className={clsx(formStyles.form, formStyles.verticalForm)}>
       {(articleId && !exportFormats.length) && <Loading inline size="24" />}
       {(articleId && exportFormats.length) && <Select id="export-formats" label="Formats" value={format} onChange={(e) => setFormat(e.target.value)}>

--- a/front/src/components/Footer.jsx
+++ b/front/src/components/Footer.jsx
@@ -10,7 +10,7 @@ function Footer () {
   const toggleConsent = useCallback(() => dispatch({ type: 'USER_PREFERENCES_TOGGLE', key: 'trackingConsent' }), [])
 
   return (<Switch>
-    <Route path="*/preview" />
+    <Route path="*/annotate" />
     <Route path="*">
       <footer className={styles.footerContainer}>
         <ul className={styles.footerList}>

--- a/front/src/components/Header.jsx
+++ b/front/src/components/Header.jsx
@@ -33,7 +33,7 @@ function Header () {
   )
 
   return (<Switch>
-    <Route path="*/preview" />
+    <Route path="*/annotate" />
     <Route path="*">
       <header className={styles.headerContainer}>
         <section className={styles.header}>

--- a/front/src/components/Modal.jsx
+++ b/front/src/components/Modal.jsx
@@ -7,12 +7,20 @@ import styles from './modal.module.scss'
 
 const noop = () => {}
 
-export default function Modal ({ children, cancel = noop}) {
+export default function Modal ({ title, children, cancel = noop}) {
   const ref = useRef()
-  useEffect(() => ref.current.showModal(), [])
+
+  useEffect(() => {
+    ref.current.showModal()
+    document.body.setAttribute('data-scrolling', false)
+
+    return function cleanup () {
+      document.body.removeAttribute('data-scrolling')
+    }
+  }, [])
 
   return (
-    <dialog open={false} className={styles.modal} ref={ref} onClose={cancel}>
+    <dialog open={false} className={styles.modal} ref={ref} onClose={cancel} aria-labelledby="modal-title">
       <Button
         aria-label="Close modal"
         icon={true}
@@ -22,12 +30,15 @@ export default function Modal ({ children, cancel = noop}) {
         <X aria-hidden />
       </Button>
 
-      {children}
+      <h1 id="modal-title" className={styles.title}>{title}</h1>
+
+      <div className={styles.modalBody}>{children}</div>
     </dialog>
   )
 }
 
 Modal.propTypes = {
+  title: PropTypes.string.isRequired,
   cancel: PropTypes.func,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),

--- a/front/src/components/Write/Biblio.jsx
+++ b/front/src/components/Write/Biblio.jsx
@@ -30,7 +30,7 @@ function Biblio ({ article, readOnly }) {
         </>
       )}
       {modal && (
-        <Modal cancel={closeModal}>
+        <Modal title="Bibliography" cancel={closeModal}>
           <Bibliographe cancel={closeModal} article={article} />
         </Modal>
       )}

--- a/front/src/components/Write/Preview.jsx
+++ b/front/src/components/Write/Preview.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { useStyloExportPreview } from '../../hooks/stylo-export.js'
+import styles from './write.module.scss'
+
+export default function Preview () {
+  const md_content = useSelector(state => state.workingArticle.text)
+  const yaml_content = useSelector(state => state.workingArticle.metadata)
+  const bib_content = useSelector(state => state.workingArticle.bibliography.text)
+  const { html: __html, isLoading } = useStyloExportPreview({ md_content, yaml_content, bib_content })
+
+  return (<section className={styles.previewPage} dangerouslySetInnerHTML={{ __html }} />)
+}

--- a/front/src/components/Write/Sommaire.jsx
+++ b/front/src/components/Write/Sommaire.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-
+import { useRouteMatch } from 'react-router-dom'
 import { ChevronDown, ChevronRight } from 'react-feather'
+import { usePandocAnchoring } from '../../hooks/pandoc.js'
 
 import styles from './sommaire.module.scss'
 import menuStyles from './menu.module.scss'
@@ -11,6 +12,14 @@ export default function Sommaire () {
   const articleStructure = useSelector(state => state.articleStructure)
   const [expand, setExpand] = useState(true)
   const dispatch = useDispatch()
+  const routeMatch = useRouteMatch()
+  const getAnchor = usePandocAnchoring()
+  const hasHtmlAnchors = routeMatch.path === '/article/:id/preview'
+  const handleTableEntryClick = useCallback(({ target }) => {
+    hasHtmlAnchors
+      ? document.querySelector(`#${target.dataset.headingAnchor}`)?.scrollIntoView()
+      : dispatch({ type: 'UPDATE_EDITOR_CURSOR_POSITION', lineNumber: parseInt(target.dataset.index, 10), column: 0 })
+  },[hasHtmlAnchors])
 
   return (
     <section className={[styles.section, menuStyles.section].join(' ')}>
@@ -22,7 +31,11 @@ export default function Sommaire () {
           <li
             className={styles.headlineItem}
             key={`line-${item.index}-${item.line}`}
-            onClick={() => dispatch({ type: 'UPDATE_EDITOR_CURSOR_POSITION', lineNumber: item.index, column: 0 })}
+            role="button"
+            tabIndex={0}
+            data-index={item.index}
+            data-heading-anchor={getAnchor(item.line)}
+            onClick={handleTableEntryClick}
           >
             {item.title}
           </li>

--- a/front/src/components/Write/Versions.jsx
+++ b/front/src/components/Write/Versions.jsx
@@ -126,12 +126,12 @@ const Versions = ({ article, selectedVersion, compareTo, readOnly }) => {
                   )}
                   <li>
                     <Link
-                      to={`/article/${article._id}/version/${v._id}/preview`}
+                      to={`/article/${article._id}/version/${v._id}/annotate`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className={[buttonStyles.button, buttonStyles.secondary].join(' ')}
                     >
-                      Preview
+                      Annotate
                     </Link>
                   </li>
                   <li>

--- a/front/src/components/Write/Versions.jsx
+++ b/front/src/components/Write/Versions.jsx
@@ -56,7 +56,7 @@ const Versions = ({ article, selectedVersion, compareTo, readOnly }) => {
         </Button>
       </h1>
       {exporting && (
-        <Modal cancel={() => setExporting(false)}>
+        <Modal title="Export" cancel={() => setExporting(false)}>
           <Export {...exportParams} />
         </Modal>
       )}

--- a/front/src/components/Write/WorkingVersion.jsx
+++ b/front/src/components/Write/WorkingVersion.jsx
@@ -1,109 +1,125 @@
-import React, { useEffect, useState } from 'react'
-import { connect } from 'react-redux'
-import styles from './workingVersion.module.scss'
-import Button from '../Button'
-import { AlertCircle, Loader, Check } from 'react-feather'
-import { Link } from 'react-router-dom'
-import buttonStyles from '../button.module.scss'
-import Modal from '../Modal'
-import Export from '../Export'
-import formatTimeAgo from '../../helpers/formatTimeAgo'
-import { generateArticleExportId } from '../../helpers/identifier'
+import React, { useEffect, useMemo, useState } from 'react'
+import { shallowEqual, useSelector } from 'react-redux'
+import { Link } from "react-router-dom";
+import { AlertCircle, AlignLeft, Check, Edit3, Eye, Loader, Printer } from 'react-feather'
 
-const mapStateToProps = ({ workingArticle }) => {
-  return { workingArticle }
-}
+import styles from './workingVersion.module.scss'
+import formatTimeAgo from '../../helpers/formatTimeAgo'
+import buttonStyles from "../button.module.scss";
+import Button from "../Button";
+import Modal from "../Modal";
+import Export from "../Export";
+import clsx from 'clsx';
+
+const ONE_MINUTE = 60000
 
 const stateUiProps = {
   saved: {
     text: 'Last saved',
-    icon: <Check />,
+    icon: <Check/>,
     style: styles.savedIndicator
   },
   saving: {
     text: 'Saving',
-    icon: <Loader />,
+    icon: <Loader/>,
     style: styles.savingIndicator
   },
   saveFailure: {
     text: 'Error',
-    icon: <AlertCircle />,
+    icon: <AlertCircle/>,
     style: styles.failureIndicator
   },
 }
 
-const WorkingVersion = ({ articleInfos, workingArticle, readOnly }) => {
-  const [exporting, setExporting] = useState(false)
-  const [savedAgo, setSavedAgo] = useState('')
+export function ArticleVersion ({ version }) {
+  return <span>
+    {!version && <>working copy</>}
+    {version && <>
+      <span className={styles.versionLabel}>{version.message || 'No label'}</span>
+      <span className={styles.versionNumber}>{version.major}.{version.minor}</span>
+    </>}
+  </span>
+}
 
-  const articleLastSavedAt = workingArticle.updatedAt
-  const state = workingArticle.state
+export function ArticleSaveState ({ state, updatedAt, stateMessage }) {
+  const [lastRefreshedAt, setLastRefresh] = useState(Date.now())
   const stateUi = stateUiProps[state]
+
+  const [savedAgo, isoString] = useMemo(() => ([
+    formatTimeAgo(updatedAt),
+    new Date(parseInt(updatedAt, 10)).toISOString()
+  ]), [lastRefreshedAt])
+
+  useEffect(() => {
+    const timer = setTimeout(() => setLastRefresh(Date.now() * 1000), ONE_MINUTE)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (<>
+    <span className={stateUi.style}>
+      {state !== 'saved' && stateUi.icon}
+      {state !== 'saveFailure' && stateUi.text}
+      {state === 'saveFailure' && (<span>
+        <strong>{stateUi.text}</strong>
+        {stateMessage}
+      </span>)}
+    </span>
+
+    {state === 'saved' && (<time dateTime={isoString}>{savedAgo}</time>)}
+  </>)
+}
+
+export default function WorkingVersion ({ articleInfos, selectedVersion }) {
+  const [exporting, setExporting] = useState(false)
+  const workingArticle = useSelector(state => state.workingArticle, shallowEqual)
 
   const articleOwnerAndContributors = [
     articleInfos.owner.displayName,
     ...articleInfos.contributors.map(contributor => contributor.user.displayName )
   ]
 
-  useEffect(() => {
-    setSavedAgo(formatTimeAgo(articleLastSavedAt))
-    const timer = setTimeout(() => {
-      setSavedAgo(formatTimeAgo(articleLastSavedAt))
-    }, 60000)
-    return () => clearTimeout(timer)
-  }, [articleLastSavedAt])
-
   return (
     <section className={styles.section}>
-      <header>
-        <h1 className={styles.title}>{articleInfos.title}</h1>
+      <header className={styles.header}>
+        <h1 className={styles.title}>
+          <AlignLeft />
+          {articleInfos.title}
+        </h1>
 
         <div className={styles.meta}>
-          <div className={styles.by}>by</div>
-          <div className={styles.byLine}>
-            <span className={styles.owners}>{articleOwnerAndContributors.join(', ')}</span>
-            <span className={styles.lastSaved}>
-              <span className={stateUi.style}>
-                {state !== 'saved' && stateUi.icon}
-                {state !== 'saveFailure' && stateUi.text}
-                {state === 'saveFailure' && (<span>
-                  <strong>{stateUi.text}</strong>
-                  {workingArticle.stateMessage}
-                </span>)}
-
-              </span>
-
-              {state === 'saved' && (<time dateTime={articleLastSavedAt}>{savedAgo}</time>)}
-
-            </span>
-          </div>
+          <ul className={styles.byLine}>
+            <li className={styles.owners}>by {articleOwnerAndContributors.join(', ')}</li>
+            <li className={styles.version}>
+              <ArticleVersion version={selectedVersion} />
+            </li>
+            <li className={styles.lastSaved}>
+              <ArticleSaveState state={workingArticle.state} updatedAt={workingArticle.updatedAt} stateMessage={workingArticle.stateMessage} />
+            </li>
+          </ul>
         </div>
       </header>
       {exporting && (
         <Modal cancel={() => setExporting(false)}>
-          <Export
-            articleId={articleInfos._id}
-            articleVersionId={articleInfos._id}
-          />
+          <Export articleVersionId={selectedVersion} articleId={articleInfos._id} />
         </Modal>
       )}
       <ul className={styles.actions}>
         <li>
-          <Link
-            to={`/article/${articleInfos._id}/annotate`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={[buttonStyles.button, buttonStyles.secondary].join(' ')}
-          >
-            Annotate
+          <Link to={`/article/${articleInfos._id}`} className={clsx(buttonStyles.button, buttonStyles.primary)}>
+            <Edit3 /> Edit
           </Link>
         </li>
         <li>
-          <Button onClick={() => setExporting(true)}>Export</Button>
+          <Link to={`/article/${articleInfos._id}/preview`} className={clsx(buttonStyles.button, buttonStyles.secondary)}>
+            <Eye /> Preview
+          </Link>
+        </li>
+        <li>
+          <Button secondary onClick={() => setExporting(true)}>
+            <Printer /> Export
+          </Button>
         </li>
       </ul>
     </section>
   )
 }
-
-export default connect(mapStateToProps)(WorkingVersion)

--- a/front/src/components/Write/WorkingVersion.jsx
+++ b/front/src/components/Write/WorkingVersion.jsx
@@ -49,7 +49,7 @@ export function ArticleSaveState ({ state, updatedAt, stateMessage }) {
 
   const [savedAgo, isoString] = useMemo(() => ([
     formatTimeAgo(updatedAt),
-    new Date(parseInt(updatedAt, 10)).toISOString()
+    new Date(updatedAt).toISOString()
   ]), [lastRefreshedAt])
 
   useEffect(() => {

--- a/front/src/components/Write/WorkingVersion.jsx
+++ b/front/src/components/Write/WorkingVersion.jsx
@@ -90,12 +90,12 @@ const WorkingVersion = ({ articleInfos, workingArticle, readOnly }) => {
       <ul className={styles.actions}>
         <li>
           <Link
-            to={`/article/${articleInfos._id}/preview`}
+            to={`/article/${articleInfos._id}/annotate`}
             target="_blank"
             rel="noopener noreferrer"
             className={[buttonStyles.button, buttonStyles.secondary].join(' ')}
           >
-            Preview
+            Annotate
           </Link>
         </li>
         <li>

--- a/front/src/components/Write/WorkingVersion.jsx
+++ b/front/src/components/Write/WorkingVersion.jsx
@@ -105,7 +105,7 @@ export default function WorkingVersion ({ articleInfos, selectedVersion }) {
         </div>
       </header>
       {exporting && (
-        <Modal cancel={cancelExport}>
+        <Modal title="Export" cancel={cancelExport}>
           <Export articleVersionId={selectedVersion} articleId={articleInfos._id} />
         </Modal>
       )}

--- a/front/src/components/Write/Write.graphql
+++ b/front/src/components/Write/Write.graphql
@@ -4,3 +4,52 @@ query compareVersion ($to: ID!) {
     md
   }
 }
+
+query getEditableArticle ($article: ID!, $hasVersion: Boolean!, $version: ID!) {
+  article(article: $article) {
+    _id
+    title
+    zoteroLink
+    updatedAt
+
+    owner {
+      displayName
+    }
+
+    contributors {
+      user {
+        displayName
+      }
+    }
+
+    versions {
+      _id
+      version
+      revision
+      message
+      updatedAt
+      owner {
+        displayName
+      }
+    }
+
+    workingVersion @skip(if: $hasVersion) {
+      md
+      bib
+      yaml
+    }
+  }
+
+  version(version: $version) @include(if: $hasVersion) {
+    _id
+    md
+    bib
+    yaml
+    message
+    revision
+    version
+    owner {
+      displayName
+    }
+  }
+}

--- a/front/src/components/Write/Write.jsx
+++ b/front/src/components/Write/Write.jsx
@@ -9,6 +9,7 @@ import debounce from 'lodash.debounce'
 import styles from './write.module.scss'
 
 import { useGraphQL } from '../../helpers/graphQL'
+import { getEditableArticle as query } from './Write.graphql'
 
 import WriteLeft from './WriteLeft'
 import WriteRight from './WriteRight'
@@ -69,55 +70,6 @@ export default function Write() {
     []
   )
 
-  const fullQuery = `query($article:ID!, $hasVersion: Boolean!, $version:ID!) {
-    article(article:$article) {
-      _id
-      title
-      zoteroLink
-      updatedAt
-
-      owner {
-        displayName
-      }
-
-      contributors {
-        user {
-          displayName
-        }
-      }
-
-      versions {
-        _id
-        version
-        revision
-        message
-        updatedAt
-        owner {
-          displayName
-        }
-      }
-
-      workingVersion @skip (if: $hasVersion) {
-        md
-        bib
-        yaml
-      }
-    }
-
-    version(version: $version) @include (if: $hasVersion) {
-      _id
-      md
-      bib
-      yaml
-      message
-      revision
-      version
-      owner{
-        displayName
-      }
-    }
-  }`
-
   const variables = {
     user: userId,
     article: articleId,
@@ -153,7 +105,7 @@ export default function Write() {
     setIsLoading(true)
     setReadOnly(Boolean(currentVersion))
     ;(async () => {
-      const data = await runQuery({ query: fullQuery, variables })
+      const data = await runQuery({ query, variables })
         .then(({ version, article }) => ({ version, article }))
         .catch((error) => {
           setError(error)

--- a/front/src/components/Write/Write.jsx
+++ b/front/src/components/Write/Write.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
+import { Switch, Route } from 'react-router-dom'
 import { batch, useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import PropTypes from 'prop-types'
@@ -12,6 +13,7 @@ import { useGraphQL } from '../../helpers/graphQL'
 import WriteLeft from './WriteLeft'
 import WriteRight from './WriteRight'
 import WorkingVersion from './WorkingVersion'
+import Preview from './Preview'
 import Loading from '../Loading'
 import MonacoEditor from './providers/monaco/Editor'
 
@@ -185,12 +187,14 @@ export default function Write() {
           updatedAt: article.updatedAt,
         })
 
-        const { md, bib } = currentArticle
+        const { md, bib, yaml } = currentArticle
 
         batch(() => {
           dispatch({ type: 'SET_ARTICLE_VERSIONS', versions: article.versions })
           dispatch({ type: 'UPDATE_ARTICLE_STATS', md })
           dispatch({ type: 'UPDATE_ARTICLE_STRUCTURE', md })
+          dispatch({ type: 'SET_WORKING_ARTICLE_TEXT', text: md })
+          dispatch({ type: 'SET_WORKING_ARTICLE_METADATA', metadata: yaml })
           dispatch({ type: 'SET_WORKING_ARTICLE_BIBLIOGRAPHY', bibliography: bib })
           dispatch({
             type: 'SET_WORKING_ARTICLE_UPDATED_AT',
@@ -231,18 +235,28 @@ export default function Write() {
         handleYaml={handleYaml}
         readOnly={readOnly}
       />
-      <article>
-        <WorkingVersion articleInfos={articleInfos} selectedVersion={currentVersion} />
-        <MonacoEditor
-          text={live.md}
-          readOnly={readOnly}
-          onTextUpdate={handleMDCM}
-          articleId={articleInfos._id}
-          selectedVersion={currentVersion}
-          compareTo={compareTo}
-          currentArticleVersion={live.version}
-        />
+
+      <article className={styles.article}>
+        <WorkingVersion articleInfos={articleInfos} selectedVersion={currentVersion} readOnly={readOnly} />
+
+        <Switch>
+          <Route path="*/preview" exact>
+            <Preview />
+          </Route>
+          <Route path="*">
+            <MonacoEditor
+              text={live.md}
+              readOnly={readOnly}
+              onTextUpdate={handleMDCM}
+              articleId={articleInfos._id}
+              selectedVersion={currentVersion}
+              compareTo={compareTo}
+              currentArticleVersion={live.version} />
+          </Route>
+        </Switch>
       </article>
+
+
     </section>
   )
 }

--- a/front/src/components/Write/Write.jsx
+++ b/front/src/components/Write/Write.jsx
@@ -11,6 +11,7 @@ import { useGraphQL } from '../../helpers/graphQL'
 
 import WriteLeft from './WriteLeft'
 import WriteRight from './WriteRight'
+import WorkingVersion from './WorkingVersion'
 import Loading from '../Loading'
 import MonacoEditor from './providers/monaco/Editor'
 
@@ -231,6 +232,7 @@ export default function Write() {
         readOnly={readOnly}
       />
       <article>
+        <WorkingVersion articleInfos={articleInfos} selectedVersion={currentVersion} />
         <MonacoEditor
           text={live.md}
           readOnly={readOnly}

--- a/front/src/components/Write/WriteLeft.jsx
+++ b/front/src/components/Write/WriteLeft.jsx
@@ -8,7 +8,7 @@ import Sommaire from './Sommaire'
 import Versions from './Versions'
 import WorkingVersion from './WorkingVersion'
 
-function WriteLeft ({ articleInfos, readOnly, compareTo, selectedVersion }) {
+export default function WriteLeft ({ articleInfos, readOnly, compareTo, selectedVersion }) {
   const expanded = useSelector(state => state.articlePreferences.expandSidebarLeft)
   const articleStats = useSelector(state => state.articleStats, shallowEqual)
   const dispatch = useDispatch()
@@ -16,15 +16,11 @@ function WriteLeft ({ articleInfos, readOnly, compareTo, selectedVersion }) {
 
   return (
     <nav className={`${expanded ? styles.expandleft : styles.retractleft}`}>
-      <nav
-        onClick={toggleExpand}
-        className={expanded ? styles.close : styles.open}
-      >
+      <nav onClick={toggleExpand} className={expanded ? styles.close : styles.open}>
         {expanded ? 'close' : 'open'}
       </nav>
       {expanded && (
         <div>
-          <WorkingVersion articleInfos={articleInfos} readOnly={readOnly} />
           <Versions
             article={articleInfos}
             selectedVersion={selectedVersion}
@@ -39,5 +35,3 @@ function WriteLeft ({ articleInfos, readOnly, compareTo, selectedVersion }) {
     </nav>
   )
 }
-
-export default WriteLeft

--- a/front/src/components/Write/WriteLeft.jsx
+++ b/front/src/components/Write/WriteLeft.jsx
@@ -6,7 +6,6 @@ import Stats from './Stats'
 import Biblio from './Biblio'
 import Sommaire from './Sommaire'
 import Versions from './Versions'
-import WorkingVersion from './WorkingVersion'
 
 export default function WriteLeft ({ articleInfos, readOnly, compareTo, selectedVersion }) {
   const expanded = useSelector(state => state.articlePreferences.expandSidebarLeft)
@@ -19,19 +18,20 @@ export default function WriteLeft ({ articleInfos, readOnly, compareTo, selected
       <nav onClick={toggleExpand} className={expanded ? styles.close : styles.open}>
         {expanded ? 'close' : 'open'}
       </nav>
-      {expanded && (
-        <div>
-          <Versions
-            article={articleInfos}
-            selectedVersion={selectedVersion}
-            compareTo={compareTo}
-            readOnly={readOnly}
-          />
-          <Sommaire />
-          <Biblio readOnly={readOnly} article={articleInfos} />
-          <Stats stats={articleStats} />
-        </div>
-      )}
+      {expanded && (<div>
+        <header>
+          <h1>Summary</h1>
+        </header>
+        <Versions
+          article={articleInfos}
+          selectedVersion={selectedVersion}
+          compareTo={compareTo}
+          readOnly={readOnly}
+        />
+        <Sommaire />
+        <Biblio readOnly={readOnly} article={articleInfos} />
+        <Stats stats={articleStats} />
+      </div>)}
     </nav>
   )
 }

--- a/front/src/components/Write/WriteRight.jsx
+++ b/front/src/components/Write/WriteRight.jsx
@@ -46,83 +46,81 @@ export default function WriteRight({ handleYaml, readOnly, yaml }) {
         {expanded ? 'close' : 'Metadata'}
       </nav>
       {expanded && (
-        <>
-          <div className={styles.yamlEditor}>
-            <header>
-              <h1>Metadata</h1>
-            </header>
-            <NavTag
-              defaultValue={selector}
-              onChange={setSelector}
-              items={[
-                {
-                  value: 'basic',
-                  name: 'Basic Mode',
-                },
-                {
-                  value: 'editor',
-                  name: 'Editor Mode',
-                },
-                {
-                  value: 'raw',
-                  name: 'Raw Mode',
-                },
-              ]}
+        <div className={styles.yamlEditor}>
+          <header>
+            <h1>Metadata</h1>
+          </header>
+          <NavTag
+            defaultValue={selector}
+            onChange={setSelector}
+            items={[
+              {
+                value: 'basic',
+                name: 'Basic Mode',
+              },
+              {
+                value: 'editor',
+                name: 'Editor Mode',
+              },
+              {
+                value: 'raw',
+                name: 'Raw Mode',
+              },
+            ]}
+          />
+          {selector === 'raw' && (
+            <>
+              {error !== '' && <p className={styles.error}>{error}</p>}
+              <textarea
+                className={styles.rawYaml}
+                value={rawYaml}
+                wrap="off"
+                rows={20}
+                onChange={(event) => {
+                  const component = event.target
+                  const yaml = component.value
+                  try {
+                    YAML.loadAll(yaml)
+                    setError('')
+                    handleYaml(yaml)
+                  } catch (err) {
+                    setError(err.message)
+                  } finally {
+                    setRawYaml(yaml)
+                  }
+                }}
+              />
+            </>
+          )}
+          {selector !== 'raw' && readOnly && (
+            <YamlEditor
+              yaml={yaml}
+              basicMode={selector === 'basic'}
+              error={(reason) => {
+                setError(reason)
+                if (reason !== '') {
+                  setSelector('raw')
+                }
+              }}
             />
-            {selector === 'raw' && (
-              <>
-                {error !== '' && <p className={styles.error}>{error}</p>}
-                <textarea
-                  className={styles.rawYaml}
-                  value={rawYaml}
-                  wrap="off"
-                  rows={20}
-                  onChange={(event) => {
-                    const component = event.target
-                    const yaml = component.value
-                    try {
-                      YAML.loadAll(yaml)
-                      setError('')
-                      handleYaml(yaml)
-                    } catch (err) {
-                      setError(err.message)
-                    } finally {
-                      setRawYaml(yaml)
-                    }
-                  }}
-                />
-              </>
-            )}
-            {selector !== 'raw' && readOnly && (
-              <YamlEditor
-                yaml={yaml}
-                basicMode={selector === 'basic'}
-                error={(reason) => {
-                  setError(reason)
-                  if (reason !== '') {
-                    setSelector('raw')
-                  }
-                }}
-              />
-            )}
-            {selector !== 'raw' && !readOnly && (
-              <YamlEditor
-                yaml={yaml}
-                basicMode={selector === 'basic'}
-                error={(reason) => {
-                  setError(reason)
-                  if (reason !== '') {
-                    setSelector('raw')
-                  }
-                }}
-                onChange={(yaml) => {
-                  setRawYaml(yaml)
-                  handleYaml(yaml)
-                }}
-              />
-            )}
-          </div>
-        </>
+          )}
+          {selector !== 'raw' && !readOnly && (
+            <YamlEditor
+              yaml={yaml}
+              basicMode={selector === 'basic'}
+              error={(reason) => {
+                setError(reason)
+                if (reason !== '') {
+                  setSelector('raw')
+                }
+              }}
+              onChange={(yaml) => {
+                setRawYaml(yaml)
+                handleYaml(yaml)
+              }}
+            />
+          )}
+        </div>
       )}
     </nav>
   )

--- a/front/src/components/Write/bibliographe/Bibliographe.jsx
+++ b/front/src/components/Write/bibliographe/Bibliographe.jsx
@@ -175,7 +175,6 @@ export default function Bibliographe({ article, cancel }) {
 
   return (
     <article>
-      <h1 className={styles.title}>Bibliography</h1>
       <NavTag defaultValue={selector} onChange={(value) => setSelector(value)} items={[
         {
           value: 'zotero',

--- a/front/src/components/Write/bibliographe/Bibliographe.jsx
+++ b/front/src/components/Write/bibliographe/Bibliographe.jsx
@@ -21,6 +21,7 @@ import { linkToZotero as query } from '../../Article.graphql'
 export default function Bibliographe({ article, cancel }) {
   const [selector, setSelector] = useState('zotero')
   const [isSaving, setSaving] = useState(false)
+  const workingArticleBibliography = useSelector(state => state.workingArticle.bibliography, shallowEqual)
   const [bib, setBib] = useState(workingArticleBibliography.text)
   const [bibTeXEntries, setBibTeXEntries] = useState(workingArticleBibliography.entries)
   const [addCitation, setAddCitation] = useState('')
@@ -28,7 +29,6 @@ export default function Bibliographe({ article, cancel }) {
   const [rawBibTeXValidationResult, setRawBibTeXValidationResult] = useState({ valid: false })
   const [zoteroLink, setZoteroLink] = useState(article.zoteroLink || '')
   const [zoteroCollectionHref, setZoteroCollectionHref] = useState(null)
-  const workingArticleBibliography = useSelector(state => state.workingArticle.bibliography, shallowEqual)
   const backendEndpoint = useSelector(state => state.applicationConfig.backendEndpoint)
   const zoteroToken = useSelector(state => state.activeUser.zoteroToken)
   const userId = useSelector(state => state.activeUser._id)

--- a/front/src/components/Write/bibliographe/bibliographe.module.scss
+++ b/front/src/components/Write/bibliographe/bibliographe.module.scss
@@ -1,25 +1,6 @@
 @use '../../../styles/defaults' as *;
 @use '../../../styles/variables' as *;
 
-.selector {
-  display: flex;
-  width: 100%;
-  margin: 1rem 0;
-  border-right: 1px solid $main-border-color;
-
-  > button {
-    border: 1px solid #000;
-    flex: 1 1 50%;
-    @extend .clickable;
-    background-color: $main-background-color;
-    padding: 0.5rem 1rem;
-
-    &.selected {
-      @extend .primary-button;
-    }
-  }
-}
-
 .actions {
   display: flex;
 }

--- a/front/src/components/Write/bibliographe/bibliographe.module.scss
+++ b/front/src/components/Write/bibliographe/bibliographe.module.scss
@@ -1,10 +1,6 @@
 @use '../../../styles/defaults' as *;
 @use '../../../styles/variables' as *;
 
-.title {
-  font-size: 1.3rem;
-}
-
 .selector {
   display: flex;
   width: 100%;

--- a/front/src/components/Write/providers/monaco/TextEditor.jsx
+++ b/front/src/components/Write/providers/monaco/TextEditor.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react'
+import { useRef, useEffect, useMemo, useCallback } from 'react'
 import { useSelector, shallowEqual } from 'react-redux'
 
 import Editor from '@monaco-editor/react'
@@ -10,6 +10,20 @@ export default function MonacoTextEditor ({ text, readOnly, onTextUpdate }) {
   const articleBibTeXEntries = useSelector(state => state.workingArticle.bibliography.entries, shallowEqual)
   const editorCursorPosition = useSelector(state => state.editorCursorPosition, shallowEqual)
   const editorRef = useRef(null)
+  const options = useMemo(() => ({
+    readOnly: readOnly,
+    contextmenu: !readOnly,
+    wordBasedSuggestions: false,
+    overviewRulerLanes: 0,
+    hideCursorInOverviewRuler: true,
+    overviewRulerBorder: false,
+    scrollBeyondLastLine: false,
+    wordWrap: 'on',
+    wrappingIndent: 'none',
+    minimap: {
+      enabled: false
+    }
+  }), [readOnly])
 
   useEffect(() => {
     const line = editorCursorPosition.lineNumber
@@ -22,13 +36,13 @@ export default function MonacoTextEditor ({ text, readOnly, onTextUpdate }) {
 
   const setTheme = useCallback((monaco) => monaco.editor.setTheme(readOnly ? 'styloReadOnly' : 'vs'), [readOnly])
 
-  function handleEditorDidMount (editor, monaco) {
+  const handleEditorDidMount = useCallback((editor, monaco) => {
     editorRef.current = editor
     const bibliographyCompletionProvider = registerBibliographyCompletion(monaco, articleBibTeXEntries)
     registerReadOnlyTheme(monaco)
     setTheme(monaco)
     editor.onDidDispose(() => bibliographyCompletionProvider.dispose())
-  }
+  }, [])
 
   const handleEditorChange = useCallback((value) => onTextUpdate(undefined, undefined, value), [])
   return (
@@ -37,20 +51,7 @@ export default function MonacoTextEditor ({ text, readOnly, onTextUpdate }) {
       className={styles.editor}
       defaultLanguage="markdown"
       onChange={handleEditorChange}
-      options={{
-        readOnly: readOnly,
-        contextmenu: !readOnly,
-        wordBasedSuggestions: false,
-        overviewRulerLanes: 0,
-        hideCursorInOverviewRuler: true,
-        overviewRulerBorder: false,
-        scrollBeyondLastLine: false,
-        wordWrap: 'on',
-        wrappingIndent: 'none',
-        minimap: {
-          enabled: false
-        }
-      }}
+      options={options}
       onMount={handleEditorDidMount}
     />
   )

--- a/front/src/components/Write/workingVersion.module.scss
+++ b/front/src/components/Write/workingVersion.module.scss
@@ -2,55 +2,65 @@
 @use '../../styles/variables' as *;
 
 .section {
-  margin: 0.5em;
+  margin: 0 .5em 0.5em;
+  display: flex;
+  flex-direction: row;
+}
+
+.header {
+  flex-grow: 1;
 }
 
 .title {
   font-size: 1.65rem;
   padding: 0;
-  margin: 0;
+  margin-top: 0.5rem;
+
+  svg {
+    margin: 0 .3em -0.1em 0;
+  }
 }
 
 .owners {
-  font-size: 1rem;
   padding: 0;
-  font-weight: normal;
-  font-weight: 600;
+}
+
+.owners:after {
+  content: "-";
+  margin: 0 0.5em;
+}
+
+.version:after {
+  content: "-";
+  margin: 0 0.5em;
+}
+
+.versionNumber:before {
+  content: '('
+}
+
+.versionNumber:after {
+  content: ')'
 }
 
 .meta {
   display: flex;
-  margin-top: 0.25rem;
   align-items: center;
-}
-
-.by {
-  background: #dbdbdb;
-  width: 2.25rem;
-  height: 2.25rem;
-  color: #fff;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-family: "Noto Serif", serif;
-  font-style: italic;
-  border-radius: 100%;
-  font-size: 1.25rem;
-  margin-right: .5rem;
-  line-height: 2.75rem;
-  flex-shrink: 0;
+  color: #4a4a4a;
+  font-size: 0.75rem;
 }
 
 .byLine {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  min-height: 2em;
 }
 
 .lastSaved {
   display: flex;
   align-items: center;
   gap: 0.15em;
-  color: #4a4a4a;
   flex: 1 0 3em;
   font-size: 0.75rem;
   font-weight: 400;
@@ -64,8 +74,6 @@
   display: inline-flex;
   justify-content: center;
   line-height: 1.5;
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
   margin-right: auto;
 }
 
@@ -75,21 +83,22 @@
   padding: 0.25em;
 }
 
-  .savingIndicator > svg {
-    animation: rotation 2.5s;
-    animation-iteration-count: infinite;
-    animation-timing-function: linear;
-    flex-shrink: 0;
-  }
+.savingIndicator > svg {
+  animation: rotation 2.5s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+  flex-shrink: 0;
+}
 
-  @keyframes rotation {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(359deg);
-    }
+@keyframes rotation {
+  from {
+    transform: rotate(0deg);
   }
+  to {
+    transform: rotate(359deg);
+  }
+}
+
 .savedIndicator,
 .savingIndicator {
   // background-color: #f5f5f5;
@@ -122,4 +131,30 @@ time {
   font-size: 0.9em;
   justify-content: flex-end;
   gap: 0.5em;
+}
+
+.focusButton {
+  margin-left: 2em;
+  border-radius: 2em;
+  border: 1px solid currentColor;
+}
+
+.focusButton:hover:not([disabled]),
+.focusButton:focus:not([disabled]) {
+  background-color: white;
+}
+
+.focusButton > svg {
+  margin-right: 0.3em;
+  margin-left: 0
+}
+
+.focusActiveButton {
+  background-color: $button-primary-background;
+  color: $button-primary-color;
+}
+
+.focusActiveButton:hover:not([disabled]),
+.focusActiveButton:focus:not([disabled]) {
+  background-color: $button-primary-background;
 }

--- a/front/src/components/Write/write.module.scss
+++ b/front/src/components/Write/write.module.scss
@@ -14,6 +14,21 @@
   background-color: $extra-background-color;
   box-shadow: 1px 2px 4px rgba(0, 0, 0, .3);
   min-height: 200px;
+  padding: 2rem;
+
+  :global {
+    header:first-of-type,
+    hr#startArticle {
+      display: none;
+    }
+
+    [role="doc-bibliography"] {
+      margin-top: 3em;
+    }
+    [role="doc-biblioentry"]:not(:last-of-type) {
+      margin-bottom: 0.5em;
+    }
+  }
 }
 
 .article {

--- a/front/src/components/Write/write.module.scss
+++ b/front/src/components/Write/write.module.scss
@@ -9,6 +9,34 @@
   width: 50%;
 }
 
+.previewPage {
+  @extend .wrapped-center;
+  background-color: $extra-background-color;
+  box-shadow: 1px 2px 4px rgba(0, 0, 0, .3);
+  min-height: 200px;
+}
+
+.article {
+  @extend .wrapped-center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  textarea {
+    padding: 1rem;
+    width: 100%;
+  }
+
+  > pre,
+  > div > pre {
+    margin-top: 0;
+    padding: 1rem;
+    width: 100%;
+    white-space: pre-wrap;
+    flex: 1 1 50%;
+  }
+}
+
 .error {
   @extend .simplePage;
   color: $error-color;

--- a/front/src/components/Write/writeRight.module.scss
+++ b/front/src/components/Write/writeRight.module.scss
@@ -61,21 +61,7 @@
   flex-direction: column;
   overflow-y: scroll;
   overflow-x: hidden;
-  > nav {
-    margin: 1rem 0;
-    display: flex;
-    flex-wrap: nowrap;
-    > p {
-      flex: 1 1 calc(100% / 3);
-      text-align: center;
-      padding: 0.5rem 1rem;
-      background-color: $main-background-color;
-    }
-    > p.selected {
-      background-color: $main-color;
-      color: $main-background-color;
-    }
-  }
+
   > section {
     :global {
       .addToArray {

--- a/front/src/components/button.module.scss
+++ b/front/src/components/button.module.scss
@@ -81,6 +81,8 @@ a.button:not(.primary), a.icon:not(.primary) {
 }
 
 .primary {
+  @extend .button;
+
   background-color: #000;
   color: #fff;
   border: 1px solid #000;
@@ -99,6 +101,8 @@ a.button:not(.primary), a.icon:not(.primary) {
 }
 
 .secondary {
+  @extend .button;
+
   background-color: #fff;
   color: #000;
   border: 1px solid #000;
@@ -115,6 +119,8 @@ a.button:not(.primary), a.icon:not(.primary) {
 }
 
 .tertiary {
+  @extend .button;
+
   background-color: transparent;
   text-decoration: underline;
 
@@ -129,7 +135,14 @@ a.button:not(.primary), a.icon:not(.primary) {
   pointer-events: none;
 }
 
+.primaryDisabled {
+  @extend .primary;
+  @extend .isDisabled;
+}
+
 .icon {
+  @extend .button;
+
   background: none;
   border: none;
   transition: color 1s ease, background 1s ease;

--- a/front/src/components/modal.module.scss
+++ b/front/src/components/modal.module.scss
@@ -5,8 +5,22 @@ dialog::backdrop {
   background-color: rgba(0, 0, 0, 0.7);
 }
 
+:global {
+  body[data-scrolling="false"] {
+    overflow: hidden;
+  }
+}
+
+:root {
+  --spacing: 1rem;
+}
+
+.title {
+  font-size: 1.3rem;
+}
+
 .modal {
-  padding: 1rem;
+  padding: var(--spacing);
   width: 90vw;
   max-width: 750px;
   max-height: 90vh;
@@ -14,8 +28,12 @@ dialog::backdrop {
   background-color: $extra-background-color;
 
   footer {
-    margin-top: 1.5rem;
+    margin-top: calc(var(--spacing) * 1.5);
   }
+}
+
+.modalBody {
+  margin: var(--spacing) 0;
 }
 
 .closeButton {

--- a/front/src/components/navTab.module.scss
+++ b/front/src/components/navTab.module.scss
@@ -4,7 +4,7 @@
 .selector {
   display: flex;
   width: 100%;
-  margin: 1rem 0;
+  margin: 0 0 1rem;
   border-right: 1px solid $main-border-color;
 
   > button {

--- a/front/src/createReduxStore.js
+++ b/front/src/createReduxStore.js
@@ -103,10 +103,10 @@ const createNewArticleVersion = store => {
         const userId = activeUser._id
         const { articleId, text } = action
         try {
-          const { updateWorkingVersion } = await new ArticleService(userId, articleId, sessionToken, applicationConfig).saveText(text)
+          const { article } = await new ArticleService(userId, articleId, sessionToken, applicationConfig).saveText(text)
           store.dispatch({ type: 'SET_WORKING_ARTICLE_STATE', workingArticleState: 'saved' })
           store.dispatch({ type: 'SET_WORKING_ARTICLE_TEXT', text })
-          store.dispatch({ type: 'SET_WORKING_ARTICLE_UPDATED_AT', updatedAt: updateWorkingVersion.updatedAt })
+          store.dispatch({ type: 'SET_WORKING_ARTICLE_UPDATED_AT', updatedAt: article.updatedAt })
         } catch (err) {
           console.error(err)
           store.dispatch({
@@ -122,10 +122,10 @@ const createNewArticleVersion = store => {
         const userId = activeUser._id
         const { articleId, metadata } = action
         try {
-          const { updateWorkingVersion } = await new ArticleService(userId, articleId, sessionToken, applicationConfig).saveMetadata(metadata)
+          const { article } = await new ArticleService(userId, articleId, sessionToken, applicationConfig).saveMetadata(metadata)
           store.dispatch({ type: 'SET_WORKING_ARTICLE_STATE', workingArticleState: 'saved' })
           store.dispatch({ type: 'SET_WORKING_ARTICLE_METADATA', metadata })
-          store.dispatch({ type: 'SET_WORKING_ARTICLE_UPDATED_AT', updatedAt: updateWorkingVersion.updatedAt })
+          store.dispatch({ type: 'SET_WORKING_ARTICLE_UPDATED_AT', updatedAt: article.updatedAt })
         } catch (err) {
           console.error(err)
           store.dispatch({ type: 'SET_WORKING_ARTICLE_STATE', workingArticleState: 'saveFailure' })
@@ -137,10 +137,10 @@ const createNewArticleVersion = store => {
         const userId = activeUser._id
         const { articleId, bibliography } = action
         try {
-          const { updateWorkingVersion } = await new ArticleService(userId, articleId, sessionToken, applicationConfig).saveBibliography(bibliography)
+          const { article } = await new ArticleService(userId, articleId, sessionToken, applicationConfig).saveBibliography(bibliography)
           store.dispatch({ type: 'SET_WORKING_ARTICLE_STATE', workingArticleState: 'saved' })
           store.dispatch({ type: 'SET_WORKING_ARTICLE_BIBLIOGRAPHY', bibliography })
-          store.dispatch({ type: 'SET_WORKING_ARTICLE_UPDATED_AT', updatedAt: updateWorkingVersion.updatedAt })
+          store.dispatch({ type: 'SET_WORKING_ARTICLE_UPDATED_AT', updatedAt: article.updatedAt })
         } catch (err) {
           console.error(err)
           store.dispatch({ type: 'SET_WORKING_ARTICLE_STATE', workingArticleState: 'saveFailure' })

--- a/front/src/createReduxStore.js
+++ b/front/src/createReduxStore.js
@@ -133,11 +133,11 @@ const createNewArticleVersion = store => {
         return next(action)
       }
       if (action.type === 'UPDATE_WORKING_ARTICLE_BIBLIOGRAPHY') {
-        const { activeUser, applicationConfig } = store.getState()
+        const { activeUser, sessionToken, applicationConfig } = store.getState()
         const userId = activeUser._id
         const { articleId, bibliography } = action
         try {
-          const { updateWorkingVersion } = await new ArticleService(userId, articleId, applicationConfig).saveBibliography(bibliography)
+          const { updateWorkingVersion } = await new ArticleService(userId, articleId, sessionToken, applicationConfig).saveBibliography(bibliography)
           store.dispatch({ type: 'SET_WORKING_ARTICLE_STATE', workingArticleState: 'saved' })
           store.dispatch({ type: 'SET_WORKING_ARTICLE_BIBLIOGRAPHY', bibliography })
           store.dispatch({ type: 'SET_WORKING_ARTICLE_UPDATED_AT', updatedAt: updateWorkingVersion.updatedAt })

--- a/front/src/helpers/formatTimeAgo.js
+++ b/front/src/helpers/formatTimeAgo.js
@@ -13,7 +13,7 @@ const DIVISIONS = [
 ]
 
 export default (sDate) => {
-  let duration = (new Date(parseInt(sDate, 10)) - new Date()) / 1000
+  let duration = (new Date(sDate) - new Date()) / 1000
 
   if (Math.abs(duration) < 60) {
     return 'a few seconds ago'

--- a/front/src/hooks/pandoc.js
+++ b/front/src/hooks/pandoc.js
@@ -1,0 +1,33 @@
+const SLUG_SEPARATOR = '-'
+
+function slugify (string, { separator }) {
+  return string
+    .replace(/#/g, '')
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/\s+/g, separator)
+
+}
+
+export function usePandocAnchoring (separator = SLUG_SEPARATOR) {
+  const state = new Map()
+
+  return function getAnchor (string) {
+    let slug = slugify(string, { separator: SLUG_SEPARATOR })
+
+    if (state.has(slug)) {
+      const index = state.get(slug)
+      state.set(slug, index + 1)
+
+      // we also keep track of this repeated heading
+      // We then avoid 'Part 1' to collide with 'Part' then 'Part'
+      slug = `${slug}${separator}${index}`
+      state.set(slug, 1)
+    }
+    else {
+      state.set(slug, 1)
+    }
+
+    return slug
+  }
+}

--- a/front/src/hooks/pandoc.test.js
+++ b/front/src/hooks/pandoc.test.js
@@ -1,0 +1,21 @@
+import { usePandocAnchoring } from './pandoc.js'
+
+describe('usePandocAnchoring()', () => {
+  test('generate expected anchors', () => {
+    const getAnchor = usePandocAnchoring()
+
+    expect(getAnchor('# Test')).toEqual('test')
+    expect(getAnchor('## Section Title')).toEqual('section-title')
+    expect(getAnchor('## Héo')).toEqual('héo')
+  })
+
+  test('handle duplicate headings', () => {
+    const getAnchor = usePandocAnchoring()
+
+    expect(getAnchor('## Héo')).toEqual('héo')
+    expect(getAnchor('## Héo')).toEqual('héo-1')
+
+    expect(getAnchor('## Héo 1')).toEqual('héo-1-1')
+    expect(getAnchor('## Héo 1')).toEqual('héo-1-2')
+  })
+})

--- a/front/src/hooks/stylo-export.js
+++ b/front/src/hooks/stylo-export.js
@@ -24,7 +24,7 @@ export default function useStyloExport (bibStyle) {
 
   const { data: exportFormats } = useSWR(`${pandocExportEndpoint}/api/available_exports`, fetcher, { fallbackData: [] })
   const { data: exportStyles } = useSWR(`${pandocExportEndpoint}/api/available_bibliographic_styles`, fetcher, { fallbackData: [] })
-  const { data: exportStylesPreview, isLoading } = useSWR([`${pandocExportEndpoint}/api/bibliography_preview`, { excerpt: bib , name: bibStyle}], postFetcher, { fallbackData: '' })
+  const { data: exportStylesPreview, isLoading } = useSWR([`${pandocExportEndpoint}/api/bibliography_preview`, { excerpt: bib , bibliography_style: bibStyle}], postFetcher, { fallbackData: '' })
 
   return { exportFormats, exportStyles, exportStylesPreview, isLoading }
 }

--- a/front/src/hooks/stylo-export.js
+++ b/front/src/hooks/stylo-export.js
@@ -28,3 +28,17 @@ export default function useStyloExport (bibStyle) {
 
   return { exportFormats, exportStyles, exportStylesPreview, isLoading }
 }
+
+export function useStyloExportPreview ({ md_content, bib_content, yaml_content }) {
+  const pandocExportEndpoint = useSelector(state => state.applicationConfig.pandocExportEndpoint)
+  const previewArgs = {
+    bibliography_style: 'chicagomodified',
+    md_content,
+    yaml_content,
+    bib_content
+  }
+
+  const { data: html, isLoading } = useSWR([`${pandocExportEndpoint}/api/article_preview`, previewArgs], postFetcher, { fallbackData: '' })
+
+  return { html, isLoading }
+}

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -115,15 +115,15 @@ render(
               <ArticlePreview />
             </Route>
             {/* Write and Compare */}
-            <PrivateRoute path={[`/article/:id/compare/:compareTo`, `/article/:id/version/:version/compare/:compareTo`]}>
+            <PrivateRoute path={[`/article/:id/compare/:compareTo`, `/article/:id/version/:version/compare/:compareTo`]} exact>
               <Write />
             </PrivateRoute>
             {/* Write with a given version */}
-            <PrivateRoute path={`/article/:id/version/:version`}>
+            <PrivateRoute path={`/article/:id/version/:version`} exact>
               <Write />
             </PrivateRoute>
             {/* Write and/or Preview */}
-            <PrivateRoute path={[`/article/:id`, `/article/:id/preview`]}>
+            <PrivateRoute path={[`/article/:id/preview`, `/article/:id`]} exact>
               <Write />
             </PrivateRoute>
             <Route exact path="/privacy">

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -98,7 +98,7 @@ render(
             <PrivateRoute path="/books" exact>
               <Books />
             </PrivateRoute>
-            <Route path={`/books/:bookId/preview`}>
+            <Route path={`/books/:bookId/annotate`}>
               <ArticlePreview />
             </Route>
             <PrivateRoute path="/articles" exact>
@@ -110,10 +110,10 @@ render(
             <PrivateRoute path={`/article/:id/compare/:compareTo`}>
               <Write />
             </PrivateRoute>
-            <Route path={`/article/:id/preview`}>
+            <Route path={`/article/:id/annotate`}>
               <ArticlePreview />
             </Route>
-            <Route path={`/article/:id/version/:version/preview`}>
+            <Route path={`/article/:id/version/:version/annotate`}>
               <ArticlePreview />
             </Route>
             <PrivateRoute path={`/article/:id/version/:version/compare/:compareTo`}>

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -95,34 +95,35 @@ render(
             <Route path="/login" exact>
               <Login />
             </Route>
+            {/* Articles index */}
+            <PrivateRoute path={['/articles', '/']} exact>
+              <Articles />
+            </PrivateRoute>
+            {/* Books index */}
             <PrivateRoute path="/books" exact>
               <Books />
-            </PrivateRoute>
-            <Route path={`/books/:bookId/annotate`}>
-              <ArticlePreview />
-            </Route>
-            <PrivateRoute path="/articles" exact>
-              <Articles />
             </PrivateRoute>
             <PrivateRoute path="/credentials" exact>
               <Credentials />
             </PrivateRoute>
-            <PrivateRoute path={`/article/:id/compare/:compareTo`}>
-              <Write />
-            </PrivateRoute>
-            <Route path={`/article/:id/annotate`}>
+            {/* Annotate a Book */}
+            <Route path={[`/books/:bookId/annotate`]} exact>
               <ArticlePreview />
             </Route>
-            <Route path={`/article/:id/version/:version/annotate`}>
+            {/* Annotate an article or its version */}
+            <Route path={[`/article/:id/version/:version/annotate`, `/article/:id/annotate`]} exact>
               <ArticlePreview />
             </Route>
-            <PrivateRoute path={`/article/:id/version/:version/compare/:compareTo`}>
+            {/* Write and Compare */}
+            <PrivateRoute path={[`/article/:id/compare/:compareTo`, `/article/:id/version/:version/compare/:compareTo`]}>
               <Write />
             </PrivateRoute>
+            {/* Write with a given version */}
             <PrivateRoute path={`/article/:id/version/:version`}>
               <Write />
             </PrivateRoute>
-            <PrivateRoute path={`/article/:id`}>
+            {/* Write and/or Preview */}
+            <PrivateRoute path={[`/article/:id`, `/article/:id/preview`]}>
               <Write />
             </PrivateRoute>
             <Route exact path="/privacy">
@@ -154,9 +155,6 @@ render(
               <h4>Tabs</h4>
               <h4>Form actions</h4>
             </Route>
-            <PrivateRoute exact path="/">
-              <Articles />
-            </PrivateRoute>
             <Route exact path="/error">
               <Error />
             </Route>

--- a/front/src/services/ArticleService.graphql
+++ b/front/src/services/ArticleService.graphql
@@ -1,15 +1,9 @@
 
-query updateWorkingVersion ($userId: ID!, $articleId: ID!, $content: WorkingVersionInput!) {
+query updateWorkingVersion ($articleId: ID!, $content: WorkingVersionInput!) {
   article (article: $articleId) {
     updatedAt
 
-    updateWorkingVersion (content: $content) {
-      workingVersion {
-        md
-        bib
-        yaml
-      }
-    }
+    updateWorkingVersion (content: $content)
   }
 }
 

--- a/front/src/services/ArticleService.js
+++ b/front/src/services/ArticleService.js
@@ -7,7 +7,7 @@ export default class ArticleService {
     this.userId = userId
     this.articleId = articleId
     this.sessionToken = sessionToken
-    this.applicationConfig = applicationConfig
+    this.graphqlEndpoint = applicationConfig.graphqlEndpoint
   }
 
   async saveText (md) {

--- a/front/src/styles/defaults.scss
+++ b/front/src/styles/defaults.scss
@@ -80,6 +80,8 @@
     height: 100%;
 
     > header {
+      margin-bottom: 1rem;
+
       > h1 {
         font-size: 1.5rem;
         padding: 0.5rem 1rem 0 1rem;

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -314,9 +314,9 @@ module.exports = {
       Object.entries(content)
         .forEach(([key, value]) => article.workingVersion[key] = value)
 
-      await article.save()
+      const result = await article.save()
 
-      return article.workingVersion
+      return result === article
     }
   }
 }

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -83,7 +83,7 @@ type Article {
   delete(dryRun: Boolean): Boolean
   addTags(tags: [ID]!): [Tag]
   removeTags(tags: [ID]!): [Tag]
-  updateWorkingVersion(content: WorkingVersionInput!): WorkingVersion
+  updateWorkingVersion(content: WorkingVersionInput!): Boolean
 }
 
 type ArticleContributor {


### PR DESCRIPTION
Je suis parti de plusieurs principes : 

- prévisualiser et annoter sont 2 actions différentes
- obtenir une prévisualisation avec styles bibliographiques c'est facile grâce à l'export créé par @davidbgk
- il manquait un truc dans l'interface d'écriture pour "faire autre chose" sans ouvrir un panneau de métadonnées

J'ai emprunté le style visuel de #500 (merci @Mogztter et @maiwann 🙏🏻)

Au passage, j'ai corrigé des bugs (certains introduits par #483) : 

- la bibliographie n'était pas sauvegardée
- le store de `workingCopy` n'était pas entièrement initialisé au chargement du composant `Write`
- on ne pouvait pas déplier les détails d'un article avec une navigation clavier
- suppression de re-renders dans le composant `Write`
- correction de l'`ArticleService` où il manquait un câblage entre deux fonctions

Les trucs dont je suis fier et content : 

- si on met à jour la bibliographie (import, suppression de référence), la preview est actualisée automatiquement
- idem si on met à jour une métadonnée

# Todo

- [x] j'ai cassé quelques apparences de bouton en factorisant `.button`, `.primary`, etc. (New Version
- [x] le bouton de fermeture de modale est toujours accessible
- [x] décaler le contenu du panneau latéral de gauche pour que "New Version" n'empiète pas avec le bouton de fermeture
- [x] quand on clique sur une entrée de la table des matières, ça emmène vers le titre dans la preview

## Liste d'articles

![image](https://user-images.githubusercontent.com/138627/209418204-aca151dc-6bdc-4ef7-aa73-5bcc4f6e6470.png)


## Interface d'écriture

![image](https://user-images.githubusercontent.com/138627/209418073-01c60481-6002-483d-9130-90c965051f44.png)

refs #708
refs #676
refs #706
