### PR TITLE
Statistiques d'instance interrogeables par API

### DIFF
--- a/graphql/resolvers/index.js
+++ b/graphql/resolvers/index.js
@@ -3,6 +3,7 @@ const { Article, Query: ArticleQuery, Mutation: ArticleMutation } = require('./a
 const { Tag, Query: TagQuery, Mutation: TagMutation } = require('./tagResolver')
 const { Version, Query: VersionQuery, Mutation: VersionMutation } = require('./versionResolver')
 const { Mutation: AuthMutation } = require('./authResolver')
+const { InstanceUsageStats, Query: StatsQuery } = require('./statsResolver')
 const { EmailAddressResolver, JWTResolver, HexColorCodeResolver, DateTimeResolver } = require('graphql-scalars')
 
 module.exports = {
@@ -17,12 +18,14 @@ module.exports = {
   Article,
   Tag,
   Version,
+  InstanceUsageStats,
   // Root queries & mutations
   Query: {
     ...UserQuery,
     ...ArticleQuery,
     ...TagQuery,
     ...VersionQuery,
+    ...StatsQuery,
   },
   Mutation: {
     ...UserMutation,

--- a/graphql/resolvers/statsResolver.js
+++ b/graphql/resolvers/statsResolver.js
@@ -1,0 +1,58 @@
+
+const Article = require('../models/article.js')
+const User = require('../models/user.js')
+
+// incorrect, because we also inject it at runtime, based on Git tag
+const { version } = require('../package.json')
+
+module.exports = {
+  Query: {
+    async stats () {
+      return {
+        version
+      }
+    }
+  },
+
+  InstanceUsageStats: {
+    async articles () {
+      const [total, years] = await Promise.all([
+        Article.estimatedDocumentCount(),
+        Article.aggregate([
+          { $project: { createdYear: {$year: "$createdAt"} }  },
+          { $group: { _id: '$createdYear', count: {$sum: 1} } }
+        ])
+      ])
+
+      return {
+        total,
+        years: years.map(({ _id: year, count }) => ({ year, count }))
+      }
+    },
+
+    async users () {
+      const [total, [{count: local}], [{count: openid}], years] = await Promise.all([
+        User.estimatedDocumentCount(),
+        User.aggregate([
+          { $match:{ authType: "local"} },
+          { $count: 'count'}
+        ]),
+        User.aggregate([
+          { $match:{ authType: { $ne : "local" }} },
+          { $count: 'count'}
+        ]),
+        User.aggregate([
+          { $project: { createdYear: {$year: "$createdAt"} }  },
+          { $group: { _id: '$createdYear', count: {$sum: 1} } }
+        ])
+      ])
+
+      return {
+        total,
+        local,
+        openid,
+        years: years.map(({ _id: year, count }) => ({ year, count }))
+      }
+    }
+  }
+}

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -93,6 +93,38 @@ type ArticleContributor {
   roles: [String]
 }
 
+type InstanceUsageStats {
+  version: String
+  users: InstanceUserStats
+  articles: InstanceArticleStats
+}
+
+interface InstanceObjectUsageStats {
+  total: Int!
+  # currentYear: Int!
+  years: [InstanceObjectUsageYearlyStats]
+}
+
+type InstanceObjectUsageYearlyStats {
+  year: Int
+  count: Int
+  # variation: Int
+}
+
+type InstanceUserStats implements InstanceObjectUsageStats {
+  total: Int!
+  # currentYear: Int!
+  local: Int
+  openid: Int
+  years: [InstanceObjectUsageYearlyStats]
+}
+
+type InstanceArticleStats implements InstanceObjectUsageStats {
+  total: Int!
+  # currentYear: Int!
+  years: [InstanceObjectUsageYearlyStats]
+}
+
 input VersionInput {
   article: ID!
   major: Boolean
@@ -150,6 +182,9 @@ type Query {
 
   "Fetch version info"
   version(version: ID!): Version
+
+  "Fetch instance stats"
+  stats: InstanceUsageStats
 }
 
 type Mutation {


### PR DESCRIPTION
Merci @Mogztter de les avoir partagé :-)

Interrogeables avec cette requête : 

```graphql
query {
  stats {
    version

    articles {
      total
      
      years {year count}
    }
    
    users {
      total
      local
      openid
      
      years {year count}
    }
  }
}
```

<img width="1512" alt="Screenshot 2023-01-08 at 12 06 36" src="https://user-images.githubusercontent.com/138627/211209370-35a74711-46d4-4439-b45f-122a4d0b92f7.png">


👀 @antoinentl @marviro @RochDLY @lakonis 
