### PR TITLE
Expose les objets tags lors d'une requête GraphQL `user { articles }` et `user { article(id) }`

### DIFF
--- a/front/src/components/Write/Versions.jsx
+++ b/front/src/components/Write/Versions.jsx
@@ -7,24 +7,11 @@ import styles from './versions.module.scss'
 import menuStyles from './menu.module.scss'
 import buttonStyles from '../button.module.scss'
 
-import { generateArticleExportId } from '../../helpers/identifier'
-
 import Modal from '../Modal'
 import Export from '../Export'
 import Button from '../Button'
 import CreateVersion from './CreateVersion'
-
-const date = new Intl.DateTimeFormat(['en', 'fr'], {
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-  hour: 'numeric',
-  minute: 'numeric',
-  timeZone: 'UTC',
-  timeZoneName: 'short',
-})
-
-const dateFormat = date.format.bind(date)
+import formatTimeAgo from '../../helpers/formatTimeAgo.js'
 
 export default function Versions ({ article, selectedVersion, compareTo, readOnly }) {
   const articleVersions = useSelector(state => state.articleVersions, shallowEqual)
@@ -89,10 +76,12 @@ export default function Versions ({ article, selectedVersion, compareTo, readOnl
                 <p>
                   {v.owner && (
                     <span>
-                      by <strong>{v.owner.displayName}</strong>{' '}
+                      by <strong>{v.owner.displayName}</strong>{', '}
                     </span>
                   )}
-                  {<span>on <time dateTime={v.updatedAt}>{dateFormat(v.updatedAt)}</time></span>}
+                  <span>
+                    <time dateTime={v.updatedAt}>{formatTimeAgo(v.updatedAt)}</time>
+                  </span>
                 </p>
                 <ul className={styles.actions}>
                   {v._id !== compareTo && (

--- a/graphql/models/article.js
+++ b/graphql/models/article.js
@@ -183,7 +183,7 @@ articleSchema.methods.unshareWith = async function shareWith(user) {
 
 articleSchema.methods.createNewVersion = async function createNewVersion ({ mode, message, user }) {
   const { bib, yaml, md } = this.workingVersion
-  const mostRecentVersion = this.version.at(0)
+  const mostRecentVersion = this.versions.at(0)
 
   const { revision, version } = mode === 'MAJOR'
     ? computeMajorVersion(mostRecentVersion)

--- a/graphql/resolvers/userResolver.js
+++ b/graphql/resolvers/userResolver.js
@@ -164,13 +164,21 @@ module.exports = {
 
   User: {
     async articles(user, { limit }) {
-      await user.populate({ path: 'articles', options: { limit } }).execPopulate()
+      await user.populate({
+        path: 'articles',
+        options: { limit },
+        populate: { path: 'owner tags' }
+      }).execPopulate()
 
       return user.articles
     },
 
     async article (user, { id: _id }) {
-      await user.populate({ path: 'articles', match: { _id }}).execPopulate()
+      await user.populate({
+        path: 'articles',
+        match: { _id },
+        populate: { path: 'owner tags' }
+      }).execPopulate()
 
       return user.articles[0]
     }


### PR DESCRIPTION
Corrige au passage deux bugs qui empêchaient de créer une nouvelle version, et lié au nouveau format de date retournée par l'API.

fixes #681 
refs #703
fixes #722