### PR TITLE
Centralise les requêtes à partir de l'utilisateur dérivé du jeton d'authentification

### DIFF
--- a/front/src/components/Article.jsx
+++ b/front/src/components/Article.jsx
@@ -4,6 +4,7 @@ import clsx from 'clsx'
 
 import styles from './articles.module.scss'
 import buttonStyles from './button.module.scss'
+import fieldStyles from './field.module.scss'
 
 import Modal from './Modal'
 import Export from './Export'
@@ -16,13 +17,14 @@ import etv from '../helpers/eventTargetValue'
 
 import Field from './Field'
 import Button from './Button'
-import { Check, ChevronDown, ChevronRight, Copy, Edit3, Eye, MessageSquare, Printer, Share2, Trash } from 'react-feather'
+import { Check, ChevronDown, ChevronRight, Copy, Edit3, MessageSquare, Printer, Share2, Trash } from 'react-feather'
 
 import { duplicateArticle } from './Acquintances.graphql'
 import { renameArticle } from './Article.graphql'
 import { useGraphQL } from '../helpers/graphQL'
+import { useCurrentUser } from '../contexts/CurrentUser'
 
-export default function Article ({ article, currentUser:activeUser, setNeedReload, updateTitleHandler, updateTagsHandler, masterTags }) {
+export default function Article ({ article, setNeedReload, updateTitleHandler, updateTagsHandler, masterTags }) {
   const [expanded, setExpanded] = useState(false)
   const [exporting, setExporting] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -32,6 +34,7 @@ export default function Article ({ article, currentUser:activeUser, setNeedReloa
   const [tempTitle, setTempTitle] = useState(article.title)
   const [sharing, setSharing] = useState(false)
   const runQuery = useGraphQL()
+  const activeUser = useCurrentUser()
 
   const isArticleOwner = activeUser._id === article.owner._id
 
@@ -98,7 +101,7 @@ export default function Article ({ article, currentUser:activeUser, setNeedReloa
         </h1>
       )}
       {renaming && (
-        <form className={styles.renamingForm} onSubmit={(e) => rename(e)}>
+        <form className={clsx(styles.renamingForm, fieldStyles.inlineFields)} onSubmit={(e) => rename(e)}>
           <Field autoFocus={true} type="text" value={tempTitle} onChange={(e) => setTempTitle(etv(e))} placeholder="Article Title" />
           <Button title="Save" primary={true} onClick={(e) => rename(e)}>
             <Check /> Save
@@ -183,7 +186,6 @@ export default function Article ({ article, currentUser:activeUser, setNeedReloa
           <h4>Tags</h4>
           <div className={styles.editTags}>
             <ArticleTags
-              currentUser={activeUser}
               article={article}
               masterTags={masterTags}
               stateTags={tags.map((t) => {

--- a/front/src/components/Article.jsx
+++ b/front/src/components/Article.jsx
@@ -72,7 +72,7 @@ export default function Article ({ article, setNeedReload, updateTitleHandler, u
     if (updateTitleHandler) {
       updateTitleHandler(article._id, tempTitle)
     }
-  }, [article.title])
+  }, [tempTitle])
 
   return (
     <article className={styles.article}>

--- a/front/src/components/ArticleTags.jsx
+++ b/front/src/components/ArticleTags.jsx
@@ -1,23 +1,23 @@
 import React, { useCallback } from 'react'
-import { shallowEqual, useSelector } from 'react-redux'
 import { useGraphQL } from '../helpers/graphQL'
 
 import ArticleTag from './Tag'
 
 import { addTags, removeTags } from './Articles.graphql'
+import { useCurrentUser } from '../contexts/CurrentUser'
 
-export default function ArticleTags ({ article, currentUser, masterTags, stateTags, setTags }) {
+export default function ArticleTags ({ article, masterTags, stateTags, setTags }) {
   const runQuery = useGraphQL()
   const articleId = article._id
-  const isArticleOwner = currentUser._id === article.owner._id
-  const activeUser = useSelector(state => state.activeUser, shallowEqual)
+  const activeUser = useCurrentUser()
+  const isArticleOwner = activeUser._id === article.owner._id
 
   const addToTags = useCallback(async (tag) => {
     setTags([...stateTags, { ...tag, selected: true }])
     const variables = {
       article: articleId,
       tags: [tag._id],
-      user: currentUser._id,
+      user: activeUser._id,
     }
     await runQuery({ query: addTags, variables })
   }, [stateTags])
@@ -27,7 +27,7 @@ export default function ArticleTags ({ article, currentUser, masterTags, stateTa
     const variables = {
       article: articleId,
       tags: [id],
-      user: currentUser._id,
+      user: activeUser._id,
     }
     await runQuery({ query: removeTags, variables })
   }, [stateTags])

--- a/front/src/components/Articles.jsx
+++ b/front/src/components/Articles.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { shallowEqual, useSelector, useDispatch } from 'react-redux'
+import { shallowEqual, useSelector } from 'react-redux'
 import { CurrentUserContext } from '../contexts/CurrentUser'
+import { Search } from 'react-feather'
 
 import { useGraphQL } from '../helpers/graphQL'
 import { getUserArticles as query } from './Articles.graphql'
@@ -10,17 +11,14 @@ import Article from './Article'
 import CreateArticle from './CreateArticle'
 
 import styles from './articles.module.scss'
-import buttonStyles from './button.module.scss'
 import TagManagement from './TagManagement'
+import SelectUser from './SelectUser'
 import Button from './Button'
 import Field from './Field'
 import Loading from './Loading'
-import { Search, Users } from 'react-feather'
 import ArticleTag from './Tag'
-import Select from './Select'
 
 export default function Articles () {
-  const dispatch = useDispatch()
   const activeUser = useSelector(state => state.activeUser, shallowEqual)
   const [selectedTagIds, setSelectedTagIds] = useState([])
 
@@ -35,7 +33,6 @@ export default function Articles () {
   const [userAccounts, setUserAccounts] = useState([])
 
   const currentUserId = useSelector(state => state.userPreferences.currentUser ?? state.activeUser._id)
-  const setCurrentUserId = useCallback((userId) => dispatch({ type: 'USER_PREFERENCES_TOGGLE', key: 'currentUser', value: userId }), [])
   const runQuery = useGraphQL()
 
   const handleReload = useCallback(() => setNeedReload(true), [])
@@ -50,13 +47,6 @@ export default function Articles () {
       ? setSelectedTagIds(selectedTagIds.filter(tagId => tagId !== id))
       : setSelectedTagIds([...selectedTagIds, id])
   }, [currentUserId, selectedTagIds])
-
-
-  const handleCurrentUserChange = useCallback((selectedItem) => {
-    setIsLoading(true)
-    setCurrentUserId(selectedItem)
-    setNeedReload(true)
-  }, [currentUserId])
 
   const handleUpdateTitle = useCallback((articleId, title) => {
     // shallow copy otherwise React won't render the components again
@@ -113,12 +103,7 @@ export default function Articles () {
     <section className={styles.section}>
       <header className={styles.articlesHeader}>
         <h1>{articles.length} articles for</h1>
-        <div className={styles.switchAccount}>
-          <Users/>
-          <Select className={[styles.accountSelect, buttonStyles.select].join(' ')} value={currentUserId} onChange={(e) => e.target.value && handleCurrentUserChange(e.target.value)}>
-            {userAccounts.map((userAccount) => <option key={`userAccount_${userAccount._id}`} value={userAccount._id}>{userAccount.displayName}</option>)}
-          </Select>
-        </div>
+        <SelectUser accounts={userAccounts} />
       </header>
       <ul className={styles.horizontalMenu}>
         <li>

--- a/front/src/components/Articles.jsx
+++ b/front/src/components/Articles.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { shallowEqual, useSelector, useDispatch } from 'react-redux'
+import { CurrentUserContext } from '../contexts/CurrentUser'
 
 import { useGraphQL } from '../helpers/graphQL'
 import { getUserArticles as query } from './Articles.graphql'
@@ -108,7 +109,7 @@ export default function Articles () {
     }
   }, [needReload, currentUserId])
 
-  return (
+  return (<CurrentUserContext.Provider value={currentUser}>
     <section className={styles.section}>
       <header className={styles.articlesHeader}>
         <h1>{articles.length} articles for</h1>
@@ -133,7 +134,6 @@ export default function Articles () {
         tags={tags}
         close={handleCloseTag}
         focus={tagManagement}
-        currentUser={currentUser}
         articles={articles}
         setNeedReload={handleReload}
       />
@@ -141,7 +141,6 @@ export default function Articles () {
       <div className={styles.actions}>
         {creatingArticle && (
           <CreateArticle
-            currentUserId={currentUserId}
             tags={tags}
             cancel={() => setCreatingArticle(false)}
             triggerReload={() => {
@@ -184,12 +183,11 @@ export default function Articles () {
             key={`article-${article._id}`}
             masterTags={tags}
             article={article}
-            currentUser={currentUser}
             setNeedReload={handleReload}
             updateTagsHandler={handleUpdateTags}
             updateTitleHandler={handleUpdateTitle}
           />
         ))}
     </section>
-  )
+  </CurrentUserContext.Provider>)
 }

--- a/front/src/components/ArticlesAccountSwitcher.jsx
+++ b/front/src/components/ArticlesAccountSwitcher.jsx
@@ -1,10 +1,10 @@
 import React, { useState, forwardRef } from 'react'
 import { useCombobox } from 'downshift'
-import { ChevronDown, X, Search, User } from 'react-feather'
+import { ChevronDown, X, User } from 'react-feather'
 import Field from './Field'
 import styles from './articles.module.scss'
 
-const ArticlesAccountSwitcher = forwardRef(({ accounts, onChange, activeUser, selectedUserId }, forwardedRef) => {
+export default forwardRef(function ArticlesAccountSwitcher ({ accounts, onChange, activeUser, selectedUserId }, forwardedRef) {
   const [inputItems, setInputItems] = useState(accounts)
   const selectedItem = accounts.find((user) => user._id === selectedUserId)
   const {
@@ -75,7 +75,3 @@ const ArticlesAccountSwitcher = forwardRef(({ accounts, onChange, activeUser, se
     </div>
   )
 })
-
-ArticlesAccountSwitcher.displayName = 'ArticlesAccountSwitcher'
-
-export default ArticlesAccountSwitcher

--- a/front/src/components/Books.graphql
+++ b/front/src/components/Books.graphql
@@ -7,6 +7,18 @@ mutation updateTag($user: ID!, $tag: ID!, $name: String, $description: String) {
 }
 
 query getTags($user: ID!) {
+  user(user: $user) {
+    _id
+    displayName
+
+    permissions {
+      user {
+        _id
+        displayName
+      }
+    }
+  }
+
   tags(user: $user) {
     _id
     name
@@ -22,5 +34,10 @@ query getTags($user: ID!) {
         message
       }
     }
+  }
+
+  userGrantedAccess {
+    _id
+    displayName
   }
 }

--- a/front/src/components/Books.jsx
+++ b/front/src/components/Books.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
-import { useSelector } from 'react-redux'
+import { shallowEqual, useSelector } from 'react-redux'
+import { CurrentUserContext } from '../contexts/CurrentUser'
 
 import { useGraphQL } from '../helpers/graphQL'
 import { getTags as query } from './Books.graphql'
@@ -7,12 +8,16 @@ import styles from './articles.module.scss'
 
 import Book from './Book'
 import Loading from './Loading'
+import SelectUser from './SelectUser'
 
 export default function Books () {
+  const activeUser = useSelector(state => state.activeUser, shallowEqual)
   const [isLoading, setIsLoading] = useState(true)
   const [tags, setTags] = useState([])
-  const displayName = useSelector(state => state.activeUser.displayName)
-  const userId = useSelector(state => state.activeUser._id)
+  const [currentUser, setCurrentUser] = useState(activeUser)
+  const [userAccounts, setUserAccounts] = useState([])
+  const currentUserId = useSelector(state => state.userPreferences.currentUser ?? state.activeUser._id)
+
   const runQuery = useGraphQL()
 
   useEffect(() => {
@@ -20,20 +25,23 @@ export default function Books () {
     (async () => {
       try {
         setIsLoading(true)
-        const data = await runQuery({ query, variables: { user: userId } })
+        const data = await runQuery({ query, variables: { user: currentUserId } })
         //Need to sort by updatedAt desc
         setTags(data.tags.reverse())
+        setCurrentUser(data.user)
+        setUserAccounts(data.userGrantedAccess)
         setIsLoading(false)
       } catch (err) {
         alert(err)
       }
     })()
-  }, [])
+  }, [currentUserId])
 
-  return (
+  return (<CurrentUserContext.Provider value={currentUser}>
     <section className={styles.section}>
       <header className={styles.articlesHeader}>
-        <h1>{tags.length} books for {displayName}</h1>
+        <h1>{tags.length} books for </h1>
+        <SelectUser accounts={userAccounts} />
       </header>
 
       <p>
@@ -45,11 +53,8 @@ export default function Books () {
       <hr className={styles.horizontalSeparator} />
 
       {isLoading ? <Loading /> : tags.map((t) => (
-          <Book
-            key={`book-${t._id}`}
-            {...t}
-          />
+          <Book key={`book-${t._id}`} {...t} />
         ))}
     </section>
-  )
+  </CurrentUserContext.Provider>)
 }

--- a/front/src/components/Chapter.jsx
+++ b/front/src/components/Chapter.jsx
@@ -9,6 +9,7 @@ import Button from './Button'
 import buttonStyles from './button.module.scss'
 import styles from './chapter.module.scss'
 import Field from './Field'
+import { useCurrentUser } from '../contexts/CurrentUser'
 
 export default function Chapter ({ article }) {
   const articleId = article._id
@@ -22,13 +23,13 @@ export default function Chapter ({ article }) {
   const [renaming, setRenaming] = useState(false)
   const [title, setTitle] = useState(article.title)
   const [tempTitle, setTempTitle] = useState(article.title)
-  const userId = useSelector(state => state.activeUser._id)
+  const activeUser = useCurrentUser()
   const runQuery = useGraphQL()
 
   const rename = async (e) => {
     e.preventDefault()
     const variables = {
-      user: userId,
+      user: activeUser._id,
       article: articleId,
       title: tempTitle,
     }

--- a/front/src/components/CreateArticle.jsx
+++ b/front/src/components/CreateArticle.jsx
@@ -9,15 +9,17 @@ import styles from './createArticle.module.scss'
 import Button from './Button'
 import Field from './Field'
 import ArticleTag from './Tag'
+import { useCurrentUser } from '../contexts/CurrentUser'
 
-export default function CreateArticle ({ currentUserId, tags, cancel, triggerReload }) {
+export default function CreateArticle ({ tags, cancel, triggerReload }) {
   const [title, setTitle] = useState('')
   const [selectedTagIds, setSelectedtagIds] = useState([])
   const runQuery = useGraphQL()
+  const activeUser = useCurrentUser()
 
 
   const handleSubmit = useCallback(async (event) => {
-    const variables = { user: currentUserId, title, tags: selectedTagIds }
+    const variables = { user: activeUser._id, title, tags: selectedTagIds }
 
     event.preventDefault()
     await runQuery({ query, variables })

--- a/front/src/components/CreateTag.jsx
+++ b/front/src/components/CreateTag.jsx
@@ -9,16 +9,18 @@ import styles from './createTag.module.scss'
 import Field from './Field'
 import Button from './Button'
 import { Check } from 'react-feather'
+import { useCurrentUser } from '../contexts/CurrentUser'
 
-export default function CreateTag ({ currentUserId, cancel, triggerReload }) {
+export default function CreateTag ({ cancel, triggerReload }) {
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [tempColor, setTempColor] = useState('#ccc')
+  const activeUser = useCurrentUser()
 
   const runQuery = useGraphQL()
 
   const variables = {
-    user: currentUserId,
+    user: activeUser._id,
     name,
     description,
     color: tempColor,
@@ -83,6 +85,5 @@ export default function CreateTag ({ currentUserId, cancel, triggerReload }) {
 
 CreateTag.propTypes = {
   cancel: PropTypes.func.isRequired,
-  currentUserId: PropTypes.string.isRequired,
   triggerReload: PropTypes.func.isRequired
 }

--- a/front/src/components/Credentials.jsx
+++ b/front/src/components/Credentials.jsx
@@ -4,11 +4,13 @@ import { useSelector } from 'react-redux'
 import { useGraphQL } from '../helpers/graphQL'
 import { changePassword as query } from './Credentials.graphql'
 import styles from './credentials.module.scss'
+import fieldStyles from './field.module.scss'
 import Loading from "./Loading";
 import UserInfos from "./UserInfos";
 import CredentialsAccountSharing from "./CredentialsAccountSharing";
 import Button from "./Button";
 import Field from "./Field";
+import clsx from 'clsx'
 
 export default function Credentials () {
   const [password, setPassword] = useState('')
@@ -54,7 +56,7 @@ export default function Credentials () {
           having access to one or more of your available accounts won&apos;t be
           affected.
         </p>
-        <form className={styles.passwordForm} onSubmit={(e) => changePassword(e)}>
+        <form className={clsx(styles.passwordForm, fieldStyles.inlineFields)} onSubmit={(e) => changePassword(e)}>
           <Field
             type="password"
             placeholder="Old password"

--- a/front/src/components/SelectUser.jsx
+++ b/front/src/components/SelectUser.jsx
@@ -1,0 +1,29 @@
+import React, { useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Users } from 'react-feather'
+
+import Select from './Select'
+
+import styles from './articles.module.scss'
+import buttonStyles from './button.module.scss'
+import clsx from 'clsx'
+
+export default function SelectUser ({ accounts }) {
+  const dispatch = useDispatch()
+
+  const currentUserId = useSelector(state => state.userPreferences.currentUser ?? state.activeUser._id)
+  const setCurrentUserId = useCallback((userId) => dispatch({ type: 'USER_PREFERENCES_TOGGLE', key: 'currentUser', value: userId }), [])
+
+  const handleCurrentUserChange = useCallback((event) => {
+    setCurrentUserId(event.target.value)
+  }, [currentUserId])
+
+  return (<div className={styles.switchAccount}>
+    <Users/>
+    <Select className={clsx(styles.accountSelect, buttonStyles.select)} value={currentUserId} onChange={handleCurrentUserChange}>
+      {accounts.map((userAccount) => <option key={`userAccount_${userAccount._id}`} value={userAccount._id}>
+        {userAccount.displayName}
+      </option>)}
+    </Select>
+  </div>)
+}

--- a/front/src/components/Share.jsx
+++ b/front/src/components/Share.jsx
@@ -11,12 +11,13 @@ import Button from './Button'
 import * as queries from './Acquintances.graphql'
 import { useGraphQL } from '../helpers/graphQL'
 import { merge } from '../helpers/acquintances.js'
+import { useCurrentUser } from '../contexts/CurrentUser'
 
 export default function ArticleShare ({ article, setNeedReload, cancel }) {
   const [acquintances, setAcquintances] = useState([])
   const [loading, setLoading] = useState(true)
   const [contributors, setContributors] = useState(article.contributors)
-  const activeUser = useSelector(state => state.activeUser, shallowEqual)
+  const activeUser = useCurrentUser()
   const userId = activeUser._id
   const runQuery = useGraphQL()
 

--- a/front/src/components/TagManagement.jsx
+++ b/front/src/components/TagManagement.jsx
@@ -29,7 +29,6 @@ export default function TagManagement (props) {
 
           {creatingTag && (
             <CreateTag
-              currentUserId={props.currentUser._id}
               cancel={() => setCreatingTag(false)}
               triggerReload={() => {
                 setCreatingTag(false)
@@ -45,7 +44,6 @@ export default function TagManagement (props) {
           .filter((t) => t.name.toLocaleLowerCase().indexOf(filter.toLocaleLowerCase()) > -1)
           .map((t) => (
             <TagManagementSolo
-              currentUser={props.currentUser}
               {...props}
               t={t}
               key={'thistag' + t._id}

--- a/front/src/components/TagManagementSolo.jsx
+++ b/front/src/components/TagManagementSolo.jsx
@@ -7,6 +7,7 @@ import etv from '../helpers/eventTargetValue'
 import styles from './tagManagementSolo.module.scss'
 import Button from './Button'
 import Field from './Field'
+import { useCurrentUser } from '../contexts/CurrentUser'
 
 export default function tagManagementSolo (props) {
   const [expanded, setExpanded] = useState(false)
@@ -15,16 +16,17 @@ export default function tagManagementSolo (props) {
   const [tempDescription, setTempDescription] = useState(props.t.description)
   const [tempColor, setTempColor] = useState(props.t.color)
   const runQuery = useGraphQL()
+  const activeUser = useCurrentUser()
 
   const deleteTag = async (id) => {
-    const variables = { user: props.currentUser._id, tag: id }
+    const variables = { user: activeUser._id, tag: id }
     await runQuery({ query: queries.deleteTag, variables })
     props.setNeedReload()
   }
 
   const saveTag = async () => {
     const variables = {
-      user: props.currentUser._id,
+      user: activeUser._id,
       tag: props.t._id,
       name: tempName,
       description: tempDescription,

--- a/front/src/components/field.module.scss
+++ b/front/src/components/field.module.scss
@@ -17,7 +17,7 @@
   display: flex;
   align-items: flex-start;
 
-  &, & + button {
+  &, & ~ button {
     margin-bottom: .5rem;
     margin-top: .5rem;
   }

--- a/front/src/components/field.module.scss
+++ b/front/src/components/field.module.scss
@@ -16,8 +16,11 @@
 .field {
   display: flex;
   align-items: flex-start;
-  margin-bottom: .5rem;
-  margin-top: .5rem;
+
+  &, & + button {
+    margin-bottom: .5rem;
+    margin-top: .5rem;
+  }
 
   label {
     flex-shrink: 0;
@@ -96,6 +99,7 @@
 
 .inlineFields {
   display: flex;
+  gap: .5rem;
 
   > * {
     flex: 0 0 auto;

--- a/front/src/contexts/CurrentUser.js
+++ b/front/src/contexts/CurrentUser.js
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react'
+
+export const CurrentUserContext = createContext(null)
+
+export function useCurrentUser () {
+  return useContext(CurrentUserContext)
+}

--- a/front/src/createReduxStore.js
+++ b/front/src/createReduxStore.js
@@ -33,7 +33,6 @@ const initialState = {
     pandocExportEndpoint: import.meta.env.SNOWPACK_PUBLIC_PANDOC_EXPORT_ENDPOINT,
     humanIdRegisterEndpoint: import.meta.env.SNOWPACK_PUBLIC_HUMAN_ID_REGISTER_ENDPOINT,
   },
-  activeUser: {},
   articleStructure: [],
   articleVersions: [],
   articlePreferences: localStorage.getItem('articlePreferences') ? JSON.parse(localStorage.getItem('articlePreferences')) : {
@@ -48,7 +47,10 @@ const initialState = {
     charCountPlusSpace: 0,
     citationNb: 0,
   },
+  // Logged in user — we use their token
+  activeUser: {},
   userPreferences: localStorage.getItem('userPreferences') ? JSON.parse(localStorage.getItem('userPreferences')) : {
+    // The user we impersonate
     currentUser: null,
     trackingConsent: true /* default value should be false */
   },

--- a/graphql/helpers/token.js
+++ b/graphql/helpers/token.js
@@ -34,7 +34,7 @@ module.exports.populateUserFromJWT = function populateUserFromJWT ({ jwtSecret }
 
     // 2. Fetch associated user, only if not populated by Passport Session before
     if (req.token._id && !req.user) {
-      req.user = await User.findById(req.token._id).populate({ path: 'permissions' })
+      req.user = await User.findById(req.token._id).populate({ path: 'permissions grantees' })
       // question: should we throw an error is the user does not exist?
     }
 

--- a/graphql/models/article.js
+++ b/graphql/models/article.js
@@ -109,12 +109,13 @@ articleSchema.statics.findManyByOwner = function findManyByOwner ({ userId }) {
  * Returns a single article, fully populated for a given user, or a list of users with sharing permissions
  *
  * @param {String} articleId
- * @param {Array<String>} users
+ * @param {String} userId active user
+ * @param {User[]} grantees list of accounts in which we can request this article for
  * @returns Article
  */
-articleSchema.statics.findAndPopulateOneByOwners = function findAndPopulateOneByOwners (articleId, users) {
+articleSchema.statics.findAndPopulateOneByOwners = function findAndPopulateOneByOwners (articleId, user) {
   // if $in is empty, we are in a case where we have an admin token fetching the data
-  const $in = users.flatMap(d => d).filter(d => d)
+  const $in = user.$inFromGrantees()
   const _id = articleId
 
   // We want to query an article with a given ID

--- a/graphql/models/article.js
+++ b/graphql/models/article.js
@@ -91,10 +91,9 @@ articleSchema.virtual('workingVersion.yamlReformated').get(function () {
  * @param {{ userId: String }}
  * @returns {Array<Article>}
  */
-articleSchema.statics.findManyByOwner = function findManyByOwner ({ userId, fromSharedUserId }) {
-  const $in = fromSharedUserId ?? userId
+articleSchema.statics.findManyByOwner = function findManyByOwner ({ userId }) {
   return this
-    .find({ $or: [{ owner: { $in } }, { contributors: { $elemMatch: { user: { $in } } } }] })
+    .find({ $or: [{ owner: userId }, { contributors: { $elemMatch: { user: userId } } }] })
     .sort({ updatedAt: -1 })
     .populate([
       { path: 'versions', options: { sort: { createdAt: -1 } } },

--- a/graphql/models/user.js
+++ b/graphql/models/user.js
@@ -80,6 +80,25 @@ userSchema.methods.comparePassword = function (password) {
   return bcrypt.compare(password, this.password)
 }
 
+/**
+ * Returns a lean list of user accounts which granted access to this current one
+ */
+userSchema.virtual('grantees', {
+  ref: 'User',
+  localField: '_id',
+  foreignField: 'permissions.user',
+})
+
+/**
+ * Checks wether the requested userId has granded access to the current user object
+ *
+ * @param {String} remoteUserId
+ * @returns {Boolean}
+ */
+userSchema.methods.isGrantedBy = function isGrantedBy (remoteUserId) {
+  return this.id === remoteUserId || this.grantees.find((user) => String(user._id) === remoteUserId)
+}
+
 userSchema.methods.createDefaultArticle = async function createDefaultArticle () {
   const newArticle = await this.model('Article').create({
     title: defaultArticle.title,

--- a/graphql/models/user.js
+++ b/graphql/models/user.js
@@ -170,18 +170,6 @@ userSchema.statics.findAccountAccessUsers = async function (userId, role = 'writ
     .lean()
 }
 
-/**
- * Find all the account identifiers a user can _switch to_
- *
- * @param {String} userId
- * @param {String} role
- * @returns {String[]}
- */
-userSchema.statics.findAccountAccessUserIds = async function (userId, role = 'write') {
-  return this.findAccountAccessUsers(userId, role)
-    .then(users => users.map(({ _id }) => String(_id)).concat(String(userId)))
-}
-
 userSchema.statics.findAccountAccessArticles = function (user, role = 'read') {
   return this
     .find({ permissions: { $elemMatch: { user, scope: 'user', roles: { $in: role } } } })

--- a/graphql/models/user.js
+++ b/graphql/models/user.js
@@ -114,6 +114,15 @@ userSchema.methods.createDefaultArticle = async function createDefaultArticle ()
   return this.save()
 }
 
+/**
+ * Builds a `$in` clause with the user and its grantees
+ * @returns {String[]}
+ */
+userSchema.methods.$inFromGrantees = function $inFromGrantees () {
+  return [String(this._id)]
+    .concat(this.grantees.flat(2).map(({ _id }) => String(_id)))
+}
+
 userSchema.statics.findAllArticles = async function ({ userId, fromSharedUserId }) {
   // if fromSharedUserId is provided
   // we check if it allowed userId to look into their articles

--- a/graphql/policies/isUser.js
+++ b/graphql/policies/isUser.js
@@ -2,7 +2,9 @@ const { format } = require('util')
 
 module.exports = function resolveUserIdFromContext (args, { token, user } = {}, allowedIds = []) {
   const isAdmin = token.admin || user?.admin || false
+  // This is the user we ask the data for
   const resolvedUserId = args.user || user?.id.toString() || token._id || null
+  // This is the user asking the data (the grantee)
   const fromSharedUserId = !isAdmin && args.user !== token._id ? token._id : null
 
   const context = [
@@ -32,9 +34,7 @@ module.exports = function resolveUserIdFromContext (args, { token, user } = {}, 
     }
 
     // A user requests something for someone else, and is not admin:
-    // - allowedIds contains the list of userIds it can impersonate
-    // @TODO resolve the permissions at object level (like user.isGrantedAccessBy(args.user) or workspace.isSharedWith(user) or article.isSharedWith(user))
-    if (Array.isArray(allowedIds) && allowedIds.includes(token._id)) {
+    if (user.isGrantedBy(resolvedUserId)) {
       return { userId: resolvedUserId, fromSharedUserId }
     }
 

--- a/graphql/policies/isUser.js
+++ b/graphql/policies/isUser.js
@@ -1,6 +1,6 @@
 const { format } = require('util')
 
-module.exports = function resolveUserIdFromContext (args, { token, user } = {}, allowedIds = []) {
+module.exports = function resolveUserIdFromContext (args, { token, user } = {}) {
   const isAdmin = token.admin || user?.admin || false
   // This is the user we ask the data for
   const resolvedUserId = args.user || user?.id.toString() || token._id || null

--- a/graphql/policies/isUser.test.js
+++ b/graphql/policies/isUser.test.js
@@ -2,10 +2,10 @@ const isUser = require('./isUser.js')
 const UserModel = require('../models/user.js')
 
 const user = '63977de2f83aa77c5f92cb1c'
-const sameUserObject = new UserModel({ _id: user })
+const sameUserObject = new UserModel({ _id: user, grantees: [] })
 const sameUserToken = { _id: user, email: 'test@example.com', admin: false, session: true, authType: 'oidc' }
 
-const differentUserObject = new UserModel({ _id: '1234567890abcde'})
+const differentUserObject = new UserModel({ _id: '00000de2f83aa77c5f92dc2f'})
 
 const adminToken = { admin: true, roles: ['read'], readonly: true }
 
@@ -38,7 +38,8 @@ describe('isUser', () => {
   test('with token, explicit user is different than user token', () => {
     expect(() => isUser({ user: differentUserObject.id }, { token: sameUserToken, user: sameUserObject })).toThrow(/Forbidden/)
 
-    expect(isUser({ user: differentUserObject.id }, { token: sameUserToken, user: sameUserObject }, [sameUserToken._id])).toEqual({
+    sameUserObject.grantees.push(differentUserObject)
+    expect(isUser({ user: differentUserObject.id }, { token: sameUserToken, user: sameUserObject })).toEqual({
       userId: differentUserObject.id,
       fromSharedUserId: sameUserToken._id
     })

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -107,11 +107,10 @@ module.exports = {
      * @returns
      */
     async duplicateArticle (_, args, context) {
-      const userIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, userIds)
+      const { userId } = isUser(args, context)
 
       //Fetch article and user to send to
-      const fetchedArticle = await Article.findAndPopulateOneByOwners(args.article, [userId, userIds])
+      const fetchedArticle = await Article.findAndPopulateOneByOwners(args.article, context.user)
 
       if(!fetchedArticle){
         throw new Error('Unable to find article')
@@ -157,7 +156,7 @@ module.exports = {
      * @returns
      */
     async article (_, args, context) {
-      const { userId } = isUser(args, context)
+      isUser(args, context)
 
       if (context.token.admin === true) {
         const article = await Article
@@ -173,8 +172,7 @@ module.exports = {
         return article
       }
 
-      const userIds = await User.findAccountAccessUserIds(context.token._id)
-      const article = await Article.findAndPopulateOneByOwners(args.article, [userId, userIds])
+      const article = await Article.findAndPopulateOneByOwners(args.article, context.user)
 
       if (!article) {
         throw new ApiError('NOT_FOUND', `Unable to find article with id ${args.article}`)

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -184,22 +184,22 @@ module.exports = {
     },
 
     /**
-     * Fetch all the articles related to a user, given the logged in user has access to it
+     * Fetch all the articles related to a user:
+     * - one stated by the JWT token (context.user), a User object
+     * - one we are supposedly able ot impersonate (args.user), an ID
      *
-     * @param {*} args
-     * @param {*} param1
-     * @returns
+     * We list:
+     * - their articles
+     * - their directly shared articles
+     * - BUT not the granted account shared articles — we switch into their view for this
+     *
+     * @param {null} _
+     * @param {{ user?: String }} args
+     * @param {{ user: User, token: Object, userId: String }} context
+     * @returns {Promise<Article[]>}
      */
     async articles (_, args, context) {
       const { userId, fromSharedUserId } = isUser(args, context)
-
-      if (fromSharedUserId) {
-        const sharedUserIds = await User.findAccountAccessUserIds(userId)
-
-        if (!sharedUserIds.includes(fromSharedUserId)) {
-          throw new Error("Forbidden")
-        }
-      }
 
       return Article.findManyByOwner({ userId, fromSharedUserId })
     },

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -18,8 +18,7 @@ module.exports = {
      */
     async createArticle (_, args, context) {
       //filter bad requests
-      const allowedIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, allowedIds)
+      const { userId } = isUser(args, context)
 
       //fetch user
       const user = await User.findById(userId)
@@ -53,8 +52,7 @@ module.exports = {
      * @returns
      */
     async shareArticle (_, args, context) {
-      const allowedIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, allowedIds)
+      const { userId } = isUser(args, context)
 
       //Fetch article and user to send to
       const article = await Article.findOneByOwner({ _id: args.article, user: userId })
@@ -80,8 +78,7 @@ module.exports = {
      * @returns
      */
     async unshareArticle (_, args, context) {
-      const allowedIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, allowedIds)
+      const { userId } = isUser(args, context)
 
       //Fetch article and user to send to
       const article = await Article.findOneByOwner({ _id: args.article, user: userId })

--- a/graphql/resolvers/tagResolver.js
+++ b/graphql/resolvers/tagResolver.js
@@ -8,8 +8,7 @@ const { ApiError } = require('../helpers/errors')
 module.exports = {
   Mutation: {
     async createTag (_, args, context){
-      const allowedIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, allowedIds)
+      const { userId } = isUser(args, context)
 
       //fetch user
       const thisUser = await User.findById(userId)
@@ -31,8 +30,7 @@ module.exports = {
       return newTag
     },
     async deleteTag (_, args, context) {
-      const allowedIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, allowedIds)
+      const { userId } = isUser(args, context)
 
       //Recover tag, and all articles
       const tag = await Tag.findOne({ _id: args.tag, owner: userId })
@@ -46,8 +44,7 @@ module.exports = {
       return tag.$isDeleted()
     },
     async updateTag (_, args, context) {
-      const allowedIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, allowedIds)
+      const { userId } = isUser(args, context)
 
       const thisTag = await Tag.findOne({ _id: args.tag, owner: userId })
       if (!thisTag) {
@@ -67,8 +64,7 @@ module.exports = {
 
   Query: {
     async tag (_, args, context) {
-      const allowedIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, allowedIds)
+      const { userId } = isUser(args, context)
 
       const tag = Tag.findOne({ _id: args.tag, owner: userId }).populate({
         path: 'articles',
@@ -83,8 +79,7 @@ module.exports = {
     },
 
     async tags (_, args, context) {
-      const allowedIds = await User.findAccountAccessUserIds(context.token._id)
-      const { userId } = isUser(args, context, allowedIds)
+      const { userId } = isUser(args, context)
 
       return Tag.find({ owner: userId }).populate({
         path: 'articles',

--- a/graphql/resolvers/userResolver.js
+++ b/graphql/resolvers/userResolver.js
@@ -138,17 +138,13 @@ module.exports = {
       return User.find().populate('tags articles acquintances')
     },
     async user (_, args, context) {
-      const { userId, fromSharedUserId } = isUser(args, context)
+      const { userId } = isUser(args, context)
 
-      if (fromSharedUserId) {
-        const sharedUserIds = await User.findAccountAccessUserIds(context.token._id)
-
-        if (!sharedUserIds.includes(fromSharedUserId)) {
-          throw new Error('Forbidden')
-        }
+      if (!context.user.isGrantedBy(userId)) {
+        throw new Error('Forbidden')
       }
 
-      return User.findById(fromSharedUserId ?? userId)
+      return User.findById(userId)
         .populate('tags acquintances')
         .populate({ path: 'permissions', populate: 'user' })
     },

--- a/graphql/resolvers/userResolver.js
+++ b/graphql/resolvers/userResolver.js
@@ -145,7 +145,7 @@ module.exports = {
       }
 
       return User.findById(userId)
-        .populate('tags acquintances')
+        .populate('tags acquintances grantees')
         .populate({ path: 'permissions', populate: 'user' })
     },
 
@@ -167,14 +167,8 @@ module.exports = {
       return user.articles
     },
 
-    async article (user, { id: _id }) {
-      await user.populate({
-        path: 'articles',
-        match: { _id },
-        populate: { path: 'owner tags' }
-      }).execPopulate()
-
-      return user.articles[0]
+    async article (user, { id }) {
+      return User.model('Article').findAndPopulateOneByOwners(id, user)
     }
   },
 }

--- a/graphql/resolvers/versionResolver.js
+++ b/graphql/resolvers/versionResolver.js
@@ -18,10 +18,9 @@ module.exports = {
       }
 
       // fetch article
-      const userIds = await User.findAccountAccessUserIds(userId)
       const article = await Article.findAndPopulateOneByOwners(
         args.version.article,
-        [userId, userIds]
+        context.user
       )
 
       if (!article) {


### PR DESCRIPTION
Plusieurs scénarios : 

- une liste : on affiche les contenus de l'utilisateur·ce connecté, le compte partagé sélectionné, ou partagé directement avec cette personne/compte partagé
- un contenu : on l'affiche si l'owner ou contributeur·ice est l'utilisateur·ice connecté·e, ou qui possède les permissions d'être owner/contributor

Idem avec les actions (merci le _drill_ dans le graph).

## Côté front

Beaucoup moins d'erreurs sur _qui_ effectue les actions en utilisant le `ActiveUserContext`.

Sur un compte à bascule, j'ai la même liste de contacts sur un compte basculé que si je me signais sur le compte.

## Côté back

Beaucoup moins d'embrouilles en ajoutant la propriété virtuelle `grantees`, qui ramène au niveau d'un objet la liste des comptes qui ont autorisés un accès.


fixes #748
fixes #764 (via 2d7c26ee)
fixes #756
refs #649
refs #738