### PR TITLE
Sauvegarde les modifications de l'éditeur de comparaisons

### DIFF
--- a/front/src/components/Header.jsx
+++ b/front/src/components/Header.jsx
@@ -2,11 +2,11 @@ import React from 'react'
 import { HelpCircle, LogOut } from 'react-feather'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link, Route, Switch } from 'react-router-dom'
+import logoContent from '../../public/images/logo.svg?inline'
 
 import Button from './Button'
 
 import styles from './header.module.scss'
-import { iconName } from "../helpers/bibtex.js";
 
 function Header () {
   const dispatch = useDispatch()
@@ -41,7 +41,7 @@ function Header () {
       <header className={styles.headerContainer}>
         <section className={styles.header}>
           <h1 className={styles.logo}>
-            <Link to="/"><img src={`/images/logo.svg`} alt="Stylo" title="Stylo"/></Link>
+            <Link to="/"><img src={logoContent} alt="Stylo" title="Stylo"/></Link>
           </h1>
           <nav>
             <ul className={styles.menuLinks}>

--- a/front/src/components/Write/WorkingVersion.jsx
+++ b/front/src/components/Write/WorkingVersion.jsx
@@ -32,11 +32,14 @@ const stateUiProps = {
 
 export function ArticleVersion ({ version }) {
   return <span>
-    {!version && <>working copy</>}
-    {version && <>
-      <span className={styles.versionLabel}>{version.message || 'No label'}</span>
-      <span className={styles.versionNumber}>{version.major}.{version.minor}</span>
-    </>}
+    {!version && <span>working copy</span>}
+    {version && version.message && <span>
+      <span className={styles.versionLabel}>{version.message}</span>
+      <span className={styles.versionNumber}>v{version.major}.{version.minor}</span>
+    </span>}
+    {version && !version.message && <span>
+      <span className={styles.versionNumber}>v{version.major}.{version.minor}</span>
+    </span>}
   </span>
 }
 
@@ -123,11 +126,11 @@ export default function WorkingVersion ({ articleInfos, live, selectedVersion, m
           <ul className={styles.byLine}>
             <li className={styles.owners}>by {articleOwnerAndContributors.join(', ')}</li>
             <li className={styles.version}>
-              <ArticleVersion version={selectedVersion}/>
+              <ArticleVersion version={live.version}/>
             </li>
-            <li className={styles.lastSaved}>
+            {!live.version && <li className={styles.lastSaved}>
               <ArticleSaveState state={workingArticle.state} updatedAt={workingArticle.updatedAt} stateMessage={workingArticle.stateMessage}/>
-            </li>
+            </li>}
           </ul>
         </div>
       </section>

--- a/front/src/components/Write/Write.jsx
+++ b/front/src/components/Write/Write.jsx
@@ -107,7 +107,7 @@ export default function Write() {
   )
 
 
-  const handleMDCM = (___, __, text) => {
+  const handleMDCM = (text) => {
     deriveArticleStructureAndStats({ text })
     updateWorkingArticleText({ text })
     setWorkingArticleDirty()

--- a/front/src/components/Write/providers/monaco/Editor.jsx
+++ b/front/src/components/Write/providers/monaco/Editor.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import MonacoTextEditor from './TextEditor'
 import MonacoDiffEditor from './DiffEditor'
 

--- a/front/src/components/Write/providers/monaco/TextEditor.jsx
+++ b/front/src/components/Write/providers/monaco/TextEditor.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, useCallback } from 'react'
+import React, { useRef, useEffect, useMemo, useCallback } from 'react'
 import { useSelector, shallowEqual } from 'react-redux'
 
 import Editor from '@monaco-editor/react'
@@ -45,7 +45,8 @@ export default function MonacoTextEditor ({ text, readOnly, onTextUpdate }) {
     editor.onDidDispose(() => bibliographyCompletionProvider.dispose())
   }, [])
 
-  const handleEditorChange = useCallback((value) => onTextUpdate(undefined, undefined, value), [])
+  const handleEditorChange = useCallback((value) => onTextUpdate(value), [])
+
   return (
     <Editor
       defaultValue={text}

--- a/front/src/components/Write/workingVersion.module.scss
+++ b/front/src/components/Write/workingVersion.module.scss
@@ -41,16 +41,20 @@
   margin: 0 0.5em;
 }
 
-.version:after {
+.version:not(:last-child):after {
   content: "-";
   margin: 0 0.5em;
 }
 
-.versionNumber:before {
+.versionLabel {
+  margin-right: .25em;
+}
+
+.versionLabel + .versionNumber:before {
   content: '('
 }
 
-.versionNumber:after {
+.versionLabel + .versionNumber:after {
   content: ')'
 }
 
@@ -60,7 +64,7 @@
   color: #4a4a4a;
   font-size: 0.75rem;
   margin-right: 0.5rem;
-  margin-left: 1rem;
+  margin-left: calc(24px + (0.3 * 1.65rem)); /* .icon width + (.title font-size * icon margin-right) */
   margin-bottom: 0.75em;
 }
 


### PR DESCRIPTION
L'éditeur n'enregistrait pas les changements en base de données : 

- donc toute nouvelle version se basait sur la dernière copie de travail avant modification
- donc les modifications n'étaient pas enregistrées

fixes #638 
fixes #752