### PR TITLE
Transforme le champ `yamlReformated` en option de requête `strip_markdown`

### DIFF
--- a/export/src/export.test.js
+++ b/export/src/export.test.js
@@ -19,13 +19,13 @@ test('should create a book export context', () => {
         {
           bib: 'Bibliography of chapter 1, first version',
           md: 'Content of chapter 1, first version',
-          yamlReformated: 'metadata: "Metadata of chapter 1, first version"'
+          yaml: 'metadata: "Metadata of chapter 1, first version"'
         },
       ],
       workingVersion: {
         bib: 'Bibliography of chapter 1, working version',
         md: 'Content of chapter 1, working version',
-        yamlReformated: 'metadata: "Metadata of chapter 1, working version"'
+        yaml: 'metadata: "Metadata of chapter 1, working version"'
       }
     },
     {
@@ -57,7 +57,7 @@ test('should create a book export context', () => {
   expect(bookExportContext).toStrictEqual({
     bib: 'Bibliography of chapter 1, first version\nBibliography of chapter 2, second version\nBibliography of chapter 3, working version\nBibliography of the poem, working version',
     md: 'Content of chapter 1, first version\n\nContent of chapter 2, second version\n\nContent of chapter 3, working version\n\nContent of the poem, working version',
-    yamlReformated: 'metadata: "Metadata of chapter 1, first version"',
+    yaml: 'metadata: "Metadata of chapter 1, first version"',
     id: '1234',
     title: 'Alice\'s Adventures in Wonderland'
   })

--- a/export/src/graphql.js
+++ b/export/src/graphql.js
@@ -35,7 +35,7 @@ async function getArticleById (articleId) {
 
       workingVersion {
         bib
-        yamlReformated
+        yaml ({ strip_markdown: true })
         md
       }
     }
@@ -58,7 +58,7 @@ async function getVersionById (versionId) {
     version (version:$versionId) {
       _id
       bib
-      yamlReformated
+      yaml ({ strip_markdown: true })
       md
     }
   }`
@@ -88,13 +88,13 @@ async function getBookById (bookId) {
 
           md
           bib
-          yamlReformated
+          yaml ({ strip_markdown: true })
         }
 
         workingVersion {
           md
           bib
-          yamlReformated
+          yaml ({ strip_markdown: true })
         }
       }
     }

--- a/graphql/models/article.js
+++ b/graphql/models/article.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const { computeMajorVersion, computeMinorVersion } = require('../helpers/versions.js')
-const { reformat } = require('../helpers/metadata.js')
 const { previewEntries } = require('../helpers/bibliography.js')
 const { prefixRulesWith, sanitizeTemplate } = require('../helpers/preview.js')
 
@@ -68,10 +67,6 @@ const articleSchema = new Schema({
     }
   }
 }, {timestamps: true});
-
-articleSchema.virtual('workingVersion.yamlReformated').get(function () {
-  return reformat(this.workingVersion.yaml, { replaceBibliography: false })
-})
 
 articleSchema.virtual('workingVersion.bibPreview').get(function () {
   return previewEntries(this.workingVersion.bib)

--- a/graphql/models/version.js
+++ b/graphql/models/version.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const { deriveToc } = require('../helpers/markdown.js')
-const { reformat } = require('../helpers/metadata.js')
 const { previewEntries } = require('../helpers/bibliography.js')
 
 const versionSchema = new Schema({
@@ -43,10 +42,6 @@ const versionSchema = new Schema({
     default: ''
   },
 }, {timestamps:true});
-
-versionSchema.virtual('yamlReformated').get(function () {
-  return reformat(this.yaml, { replaceBibliography: false })
-})
 
 versionSchema.virtual('bibPreview').get(function () {
   return previewEntries(this.bib)

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -6,6 +6,7 @@ const Workspace = require('../models/workspace')
 
 const isUser = require('../policies/isUser')
 const { ApiError } = require('../helpers/errors')
+const { reformat } = require('../helpers/metadata.js')
 
 module.exports = {
   Mutation: {
@@ -282,5 +283,13 @@ module.exports = {
 
       return article.save()
     }
-  }
+  },
+
+  WorkingVersion: {
+    yaml ({ yaml }, { options }) {
+      return options?.strip_markdown
+        ? reformat(yaml, { replaceBibliography: false })
+        : yaml
+    }
+  },
 }

--- a/graphql/resolvers/index.js
+++ b/graphql/resolvers/index.js
@@ -1,5 +1,5 @@
 const { User, Query: UserQuery, Mutation: UserMutation } = require('./userResolver');
-const { Article, Query: ArticleQuery, Mutation: ArticleMutation } = require('./articleResolver')
+const { Article, WorkingVersion, Query: ArticleQuery, Mutation: ArticleMutation } = require('./articleResolver')
 const { Tag, Query: TagQuery, Mutation: TagMutation } = require('./tagResolver')
 const { Version, Query: VersionQuery, Mutation: VersionMutation } = require('./versionResolver')
 const { Workspace, Query: WorkspaceQuery, Mutation: WorkspaceMutation } = require('./workspaceResolver')
@@ -20,6 +20,7 @@ module.exports = {
   Tag,
   Version,
   InstanceUsageStats,
+  WorkingVersion,
   Workspace,
   // Root queries & mutations
   Query: {

--- a/graphql/resolvers/versionResolver.js
+++ b/graphql/resolvers/versionResolver.js
@@ -5,6 +5,7 @@ const User = require('../models/user')
 const isUser = require('../policies/isUser')
 
 const { ApiError } = require('../helpers/errors')
+const { reformat } = require('../helpers/metadata.js')
 
 module.exports = {
   Mutation: {
@@ -55,6 +56,12 @@ module.exports = {
       const result = await version.save({ timestamps: false })
 
       return result === version
+    },
+
+    yaml ({ yaml }, { options }) {
+      return options?.strip_markdown
+        ? reformat(yaml, { replaceBibliography: false })
+        : yaml
     }
-  },
+  }
 }

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -54,8 +54,7 @@ type WorkingVersion {
   bib: String
   bibPreview: String
   md: String
-  yaml: String
-  yamlReformated: String
+  yaml (options: YamlFormattingInput): String
 }
 
 type Version {
@@ -65,8 +64,7 @@ type Version {
   revision: Int
   md: String
   sommaire: String
-  yaml: String
-  yamlReformated: String
+  yaml (options: YamlFormattingInput): String
   bib: String
   bibPreview: String
   message: String
@@ -159,6 +157,10 @@ input WorkingVersionInput {
   bib: String,
   md: String,
   yaml: String,
+}
+
+input YamlFormattingInput {
+  strip_markdown: Boolean
 }
 
 input NewUserInput {


### PR DESCRIPTION
La nouvelle syntaxe est celle-ci : 

```diff
query ($article: ID!) {
  article (article: $article) {
    workingVersion {
      bib
      md
-     yamlReformated
+     yaml (options: { strip_markdown: true })
    }
  }
}
```

cc @davidbgk 