### PR TITLE
fix(test): versions are ordered by creation date descending

### DIFF
--- a/export/src/export.test.js
+++ b/export/src/export.test.js
@@ -52,12 +52,12 @@ test('should create a book export context', () => {
         title: 'Chapter 2: The Pool of Tears',
         versions: [
           {
-            bib: 'Bibliography of chapter 2, first version',
-            md: 'Content of chapter 2, first version',
-          },
-          {
             bib: 'Bibliography of chapter 2, second version',
             md: 'Content of chapter 2, second version',
+          },
+          {
+            bib: 'Bibliography of chapter 2, first version',
+            md: 'Content of chapter 2, first version',
           }
         ],
         workingVersion: {


### PR DESCRIPTION
The first version in `versions` is the latest version.