### PR TITLE
Documentation: correction hyperlien mort dans bibliographie.md

### DIFF
--- a/docs/src/fr/bibliographie.md
+++ b/docs/src/fr/bibliographie.md
@@ -19,7 +19,7 @@ La bibliographie liste les références bibliographiques que vous avez ajoutées
 
 Vous pouvez directement [structurer vos références en BibTeX](http://www.andy-roberts.net/writing/latex/bibliographies) ou exporter vos références en BibTeX grâce à votre outil de gestion de bibliographie :
 
-- voir tutoriels : <a class="btn btn-info" href="http://archive.sens-public.org/IMG/pdf/Utiliser_Zotero.pdf" role="button">Zotero</a> <a class="btn btn-info" href="https://libguides.usask.ca/c.php?g=218034&p=1446316" role="button">Mendeley</a>
+- voir tutoriels : <a class="btn btn-info" href="https://bib.umontreal.ca/en/citer/logiciels-bibliographiques/zotero/installer" role="button">Zotero</a> <a class="btn btn-info" href="https://libguides.usask.ca/c.php?g=218034&p=1446316" role="button">Mendeley</a>
 
 ## Synchroniser une collection Zotero
 


### PR DESCRIPTION
changement d'un seul lien renvoyant vers une erreur 404. Je n'ai pas touché au code