### PR TITLE
fix: accepte un rendu de Yaml vide

### DIFF
--- a/front/src/components/Write/PreviewPaged.jsx
+++ b/front/src/components/Write/PreviewPaged.jsx
@@ -19,7 +19,7 @@ export default function Preview ({ preview, yaml }) {
 
   useEffect(() => {
     if (html && isLoading) {
-      const [metadata] = YAML.loadAll(yaml)
+      const [metadata = {}] = YAML.loadAll(yaml)
       const render = compileTemplate(template)
 
       const base64Stylesheet = `data:text/css;base64,${btoa(stylesheet)}`

--- a/front/src/components/Write/yamleditor/YamlEditor.jsx
+++ b/front/src/components/Write/yamleditor/YamlEditor.jsx
@@ -3,7 +3,7 @@ import Form from '../../Form'
 import YAML from 'js-yaml'
 
 export default function YamlEditor ({ yaml, basicMode, onChange }) {
-  const [parsed] = YAML.loadAll(yaml)
+  const [parsed = {}] = YAML.loadAll(yaml)
 
   // we convert YYYY/MM/DD dates into ISO YYYY-MM-DD
   if (parsed.date) {


### PR DESCRIPTION
Sinon l'interface casse quand on bascule en mode Basique ou Éditeur.

@RochDLY Je suis étonné qu'il n'y ait pas eu de bug saisi à ce propos alors que plusieurs utilisateurs ont rapporté ne plus pouvoir utiliser l'interface. Ou j'ai raté l'issue ?

fixes #982 
fixes #1004