### PR TITLE
Déclenche la construction de la documentation après la fusion d'une PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [$default-branch]
   # When PR is merged
-  # https://stackoverflow.com/questions/60710209/trigger-github-actions-only-when-pr-is-merged
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
   pull_request:
     types:
       - closed
@@ -30,6 +30,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Sinon ça déclenchait le build en erreur lors de toute PR (cf. [la liste des Actions](https://github.com/EcrituresNumeriques/stylo/actions/workflows/docs.yml))