### PR TITLE
wip: corpus metadata JSON schema

### DIFF
--- a/front/corpus-metadata.schema.json
+++ b/front/corpus-metadata.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stylo.huma-num.fr/metadata.schema.json",
+  "title": "Metadata",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "book",
+        "journal"
+      ]
+    },
+    "publication": {
+      "type": "object",
+      "discriminator": {
+        "propertyName": "type"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/book"
+        },
+        {
+          "$ref": "#/$defs/journal"
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "book": {
+      "type": "object"
+    },
+    "journal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "issue": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "identifier": {
+              "type": "string"
+            },
+            "number": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Principes

- Ajout d'un `type` permettant de typer les différents corpus
  -  Chaque type a un schéma dédié dans le JSON schema
  - Pour le moment j'ai détaillé uniquement le type "journal" car je n'étais pas sûr des métadonnées à renseigner sur le type "book"

### Exemples

#### journal

```json
{
  "type": "journal",
  "name": "Sens public",
  "issue": {
    "title": "L’œuvre numérique à son miroir : regards sur les créations digitales contemporaines",
    "identifier": "https://www.sens-public.org/dossiers/1710/",
    "number": "2024/05/28"
  }
}
```

#### book

```json
{
  "type": "book"
}
```
