### PR TITLE
Comparaison entre working copy et version

### DIFF
--- a/export/src/export.js
+++ b/export/src/export.js
@@ -91,7 +91,7 @@ const getArticleExportContext = async (articleId) => {
 
 const getBookExportContext = async (bookId) => {
   const book = await getCorpusById(bookId)
-  console.log({book})
+
   const { articles: chapters, _id: id, name: title } = book
 
   // we can create empty books… but no need to preview them

--- a/front/src/components/Write/Write.graphql
+++ b/front/src/components/Write/Write.graphql
@@ -1,7 +1,13 @@
-query compareVersion ($to: ID!) {
-  version(version: $to) {
+query compareVersion ($to: ID!, $article: ID!, $hasVersion: Boolean!) {
+  version(version: $to) @include(if: $hasVersion) {
     _id
     md
+  }
+
+  article (article: $article) {
+    workingVersion @skip(if: $hasVersion) {
+      md
+    }
   }
 }
 

--- a/front/src/components/Write/bibliographe/CitationsPanel.jsx
+++ b/front/src/components/Write/bibliographe/CitationsPanel.jsx
@@ -58,9 +58,6 @@ export default function CitationsPanel ({ onChange }) {
 
   const handleChanges = useCallback(() => onChange(bib), [bib])
 
-  console.log({ isValid, isEmpty})
-  console.log(citationValidationResult)
-
   return (<div className={styles.citations}>
     <section className={styles.section}>
       <MonacoBibtexEditor

--- a/front/src/components/Write/providers/monaco/DiffEditor.jsx
+++ b/front/src/components/Write/providers/monaco/DiffEditor.jsx
@@ -30,8 +30,8 @@ export default function MonacoDiffEditor ({ text, compareTo, articleId, selected
   }, [])
 
   useEffect(() => {
-    runQuery({ query, variables: { to: compareTo } })
-      .then(({ version }) => setModifiedText(version.md))
+    runQuery({ query, variables: { article: articleId, to: compareTo ?? 'working-copy', hasVersion: Boolean(compareTo) } })
+      .then(({ article, version }) => setModifiedText(version?.md ?? article.workingVersion?.md))
   }, [compareTo])
 
   const monacoOptions = useMemo(() => ({

--- a/front/src/components/Write/providers/monaco/Editor.jsx
+++ b/front/src/components/Write/providers/monaco/Editor.jsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
 import MonacoTextEditor from './TextEditor'
 import MonacoDiffEditor from './DiffEditor'
 
@@ -12,14 +13,17 @@ export default function Editor ({
                                   readOnly,
                                   onTextUpdate,
                                 }) {
+  const location = useLocation()
+  const isComparing = useMemo(() => location.pathname.includes('/compare'), [location.pathname, compareTo])
+
   return (
     <>
-      {!compareTo && <MonacoTextEditor
+      {!isComparing && <MonacoTextEditor
         text={text}
         readOnly={readOnly}
         onTextUpdate={onTextUpdate}/>
       }
-      {compareTo && <MonacoDiffEditor
+      {isComparing && <MonacoDiffEditor
         text={text}
         articleId={articleId}
         selectedVersion={selectedVersion}

--- a/front/src/components/Write/versions.module.scss
+++ b/front/src/components/Write/versions.module.scss
@@ -27,26 +27,23 @@
   padding: 0 .25em;
 }
 
-.momentAgo {
-  opacity: .5;
-  margin-left: .5em;
-}
-
 .version {
   border: 1px solid transparent;
   border-left: 4px solid;
   margin-bottom: 0.25em;
   margin-left: 0.5rem;
   margin-right: 0.25em;
-  cursor: pointer;
   display: flex;
 }
 
 .versionLink {
   color: inherit;
+  cursor: pointer;
   text-decoration: none;
   flex-grow: 1;
   background-color: transparent;
+  margin: -0.5rem;  /* counter act the 0.5rem padding of its container */
+  padding: 0.5rem;  /* ^^^^^^ */
 
   > header {
     max-width: 265px;

--- a/front/src/components/article.module.scss
+++ b/front/src/components/article.module.scss
@@ -130,9 +130,12 @@
   display: inline-flex;
 }
 
+.author {
+  margin-right: 0.5em;
+}
+
 .momentsAgo {
   opacity: .5;
-  margin-left: .5em;
 }
 
 .workspaces {

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -158,8 +158,8 @@ root.render(
                 </Route>
                 {/* Write and Compare */}
                 <PrivateRoute
-                  path={[`/article/:id/compare/:compareTo`, `/article/:id/version/:version/compare/:compareTo`]} exact>
-                  <Write/>
+                  path={[`/article/:id/compare/:compareTo`, `/article/:id/version/:version/compare/working-copy`, `/article/:id/version/:version/compare/:compareTo`]} exact>
+                  <Write />
                 </PrivateRoute>
                 {/* Write with a given version */}
                 <PrivateRoute path={`/article/:id/version/:version`} exact>


### PR DESCRIPTION
C'était pas évident de détricoter les différentes situations.
J'ai créé des variables intermédiaires pour mieux décrire les états des composants.

J'ai aussi opté pour une approche plus accessible, où les composants ne sont pas supprimés/recréés à chaque fois mais leur **état reflété par des attributs HTML** (en l'occurence, `hidden`).

Ce qui change aussi, c'est que la working copy apparait tout le temps dans la liste des versions :

![image](https://github.com/user-attachments/assets/0805579f-5b2a-412b-bdb1-f989c27046d8)

Peut-être que c'est un tremplin pour mieux comprendre le lien entre ce qu'on voit par défaut, et la transformation de cette working copy en version ? (à penser comme la création d'un point d'étape).

fixes #985
refs #986