### PR TITLE
Unifie le style des modales

### DIFF
--- a/front/src/components/ArticleCreate.jsx
+++ b/front/src/components/ArticleCreate.jsx
@@ -85,7 +85,7 @@ export default function ArticleCreate({ onSubmit }) {
 
   return (
     <section>
-      <form onSubmit={handleSubmit} className={styles.form}>
+      <form onSubmit={handleSubmit} className={styles.form} id="article-create-form">
         <Field
           ref={titleInputRef}
           {...titleBindings}
@@ -111,18 +111,6 @@ export default function ArticleCreate({ onSubmit }) {
             </ul>
           </div>
         )}
-        <ul className={styles.actions}>
-          <li>
-            <Button
-              type="secondary"
-              className={styles.button}
-              title={t('article.createForm.buttonTitle')}
-              onClick={handleSubmit}
-            >
-              {t('article.createForm.buttonText')}
-            </Button>
-          </li>
-        </ul>
       </form>
     </section>
   )

--- a/front/src/components/Articles.jsx
+++ b/front/src/components/Articles.jsx
@@ -18,6 +18,7 @@ import Article from './Article'
 import ArticleCreate from './ArticleCreate.jsx'
 
 import styles from './articles.module.scss'
+import buttonStyles from './button.module.scss'
 import Field from './Field'
 import { useActiveUserId } from '../hooks/user'
 import WorkspaceLabel from './workspace/WorkspaceLabel.jsx'
@@ -281,6 +282,9 @@ export default function Articles() {
             onClick={() => setCreateArticleVisible(false)}
           >
             {t('modal.close.text')}
+          </GeistModal.Action>
+          <GeistModal.Action type="submit" form="article-create-form" className={buttonStyles.primary}>
+            {t('article.createForm.buttonText')}
           </GeistModal.Action>
         </GeistModal>
 

--- a/front/src/components/button.module.scss
+++ b/front/src/components/button.module.scss
@@ -106,8 +106,8 @@ a.icon:not(.primary) {
 .primary {
   @extend .button;
 
-  background-color: #000;
-  color: #fff;
+  background-color: #000 !important;
+  color: #fff !important;
   border: 1px solid #000;
 
   &:disabled {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eb5174f4-5693-4ffe-9a11-0408cf957c6c)

- [x] création d'article
- [ ] partage d'article (en double dans `Article.jsx` ??)
- [ ] création d'une copie d'article
- [ ] suppression d'article
- [ ] message d'erreur (`ErrorMessageCard`)
- [ ] export d'article (session collaborative)
- [ ] export d'article (session solo)
- [ ] rejoindre une session collaborative
- [ ] terminer la session collaborative
- [ ] créer un corpus
- [ ] supprimer un corpus
- [ ] exporter un corpus
- [ ] modifier un corpus
- [ ] modifier les métadonnées d'un corpus
- [ ] créer un espace de travail
- [ ] quitter un espace de travail
- [ ] gérer les membres d'un espace de travail

Deux hics : 
- pas possible de changer l'apparence d'un bouton Geist (on ne peut pas dire `type="secondary` comme un bouton Geist)
- pas possible de déclencher à distance l'envoi d'un formulaire. `<button form="...">` n'a pas l'air de fonctionner avec un `type="button"`, et Geist ne permet pas de le surcharger. On n'a donc pas de moyen facile de déclencher une action en dehors du composant enfant (le contenu de la modale).

Cette librairie me laisse vraiment perplexe (cf. #1150).

refs #1149
fixes #1132