### PR TITLE
fix: prend en compte le statut de la session collaborative

### DIFF
--- a/front/src/components/collaborative/CollaborativeEditorStatus.jsx
+++ b/front/src/components/collaborative/CollaborativeEditorStatus.jsx
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
 import { StopCircle } from 'react-feather'
 import { useTranslation } from 'react-i18next'
-import { shallowEqual, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { useMutation } from '../../hooks/graphql.js'
 import CollaborativeEditorWebSocketStatus from './CollaborativeEditorWebSocketStatus.jsx'
@@ -22,21 +21,12 @@ import styles from './CollaborativeEditorStatus.module.scss'
 export default function CollaborativeEditorStatus({
   articleId,
   websocketStatus,
-  collaborativeSessionCreatorId,
+  collaborativeSessionState,
 }) {
   const { t } = useTranslation()
   const mutation = useMutation()
   const { setToast } = useToasts()
   const history = useHistory()
-  const activeUser = useSelector(
-    (state) => ({
-      _id: state.activeUser._id,
-      email: state.activeUser.email,
-      displayName: state.activeUser.displayName,
-      username: state.activeUser.username,
-    }),
-    shallowEqual
-  )
 
   const {
     visible: collaborativeSessionEndVisible,
@@ -74,18 +64,24 @@ export default function CollaborativeEditorStatus({
           <CollaborativeEditorWriters />
         </div>
         <div className={styles.status}>
-          <CollaborativeEditorWebSocketStatus status={websocketStatus} />
+          <CollaborativeEditorWebSocketStatus
+            status={websocketStatus}
+            state={collaborativeSessionState}
+          />
         </div>
-        <Button
-          className={clsx(styles.button)}
-          type="error"
-          ghost
-          auto
-          scale={0.4}
-          onClick={handleConfirmCollaborativeSessionEnd}
-        >
-          <StopCircle /> End collaborative session
-        </Button>
+        {websocketStatus === 'connected' &&
+          collaborativeSessionState === 'started' && (
+            <Button
+              className={clsx(styles.button)}
+              type="error"
+              ghost
+              auto
+              scale={0.4}
+              onClick={handleConfirmCollaborativeSessionEnd}
+            >
+              <StopCircle /> End collaborative session
+            </Button>
+          )}
       </div>
       <GeistModal
         width="35rem"
@@ -114,5 +110,5 @@ export default function CollaborativeEditorStatus({
 CollaborativeEditorStatus.propTypes = {
   articleId: PropTypes.string.isRequired,
   websocketStatus: PropTypes.string.isRequired,
-  collaborativeSessionCreatorId: PropTypes.string.isRequired,
+  collaborativeSessionState: PropTypes.string.isRequired,
 }

--- a/front/src/components/collaborative/CollaborativeEditorWebSocketStatus.jsx
+++ b/front/src/components/collaborative/CollaborativeEditorWebSocketStatus.jsx
@@ -1,10 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Dot, Loading } from '@geist-ui/core'
+import { Dot } from '@geist-ui/core'
+import { Loader } from 'react-feather'
 
 import styles from './CollaborativeEditorWebSocketStatus.module.scss'
 
-export default function CollaborativeEditorWebSocketStatus({ status }) {
+export default function CollaborativeEditorWebSocketStatus({ status, state }) {
+  if (state !== 'started') {
+    return (
+      <Dot type="warning" className={styles.dot}>
+        Connecting
+        <Loader className={styles.loadingIndicator} />
+      </Dot>
+    )
+  }
   return (
     <>
       {status === 'connected' && (
@@ -19,7 +28,8 @@ export default function CollaborativeEditorWebSocketStatus({ status }) {
       )}
       {status === 'connecting' && (
         <Dot type="warning" className={styles.dot}>
-          Connecting <Loading />
+          Connecting
+          <Loader className={styles.loadingIndicator} />
         </Dot>
       )}
     </>
@@ -27,5 +37,6 @@ export default function CollaborativeEditorWebSocketStatus({ status }) {
 }
 
 CollaborativeEditorWebSocketStatus.propTypes = {
+  state: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
 }

--- a/front/src/components/collaborative/CollaborativeEditorWebSocketStatus.module.scss
+++ b/front/src/components/collaborative/CollaborativeEditorWebSocketStatus.module.scss
@@ -1,3 +1,28 @@
 .dot {
   font-size: 0.8rem !important;
+  
+  :global {
+    .label {
+      display: flex;
+      gap: 0.25rem;
+    }
+  }
+}
+
+.loadingIndicator {
+  height: 1em;
+  width: 1em;
+  animation: rotation 2.5s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+  flex-shrink: 0;
+}
+
+@keyframes rotation {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(359deg);
+  }
 }


### PR DESCRIPTION
Bloque l'édition et le fait de pouvoir quitter la session collaborative (et donc de sauvegarder le contenu de l'éditeur texte) tant que la session collaborative n'est pas démarrée.

resolves #1119 