### PR TITLE
Écriture et comparaison ont lieu dans la même instance de composant

### DIFF
--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -186,21 +186,13 @@ root.render(
                 {/* Write and Compare */}
                 <PrivateRoute
                   path={[
-                    `/article/:id/compare/:compareTo`,
-                    `/article/:id/version/:version/compare/working-copy`,
-                    `/article/:id/version/:version/compare/:compareTo`,
+                    '/article/:id/compare/:compareTo',
+                    '/article/:id/version/:version/compare/working-copy',
+                    '/article/:id/version/:version/compare/:compareTo',
+                    '/article/:id/version/:version',
+                    '/article/:id/preview',
+                    '/article/:id'
                   ]}
-                  exact
-                >
-                  <Write />
-                </PrivateRoute>
-                {/* Write with a given version */}
-                <PrivateRoute path={`/article/:id/version/:version`} exact>
-                  <Write />
-                </PrivateRoute>
-                {/* Write and/or Preview */}
-                <PrivateRoute
-                  path={[`/article/:id/preview`, `/article/:id`]}
                   exact
                 >
                   <Write />


### PR DESCRIPTION
J'ai pas testé si le "state" du composant était cohérant en passant d'une route à l'autre (notamment quand on passe en comparaison de version / revient à l'écriture, etc.)