### PR TITLE
Correction graphiques dans la prévisualisation

### DIFF
--- a/front/src/components/Preview.scss
+++ b/front/src/components/Preview.scss
@@ -94,6 +94,14 @@ body {
       > article {
         grid-area: article;
         max-width: 42em;
+
+        ol li {
+          list-style: decimal;
+        }
+
+        ul li {
+          list-style: disc;
+        }
       }
     }
   }
@@ -656,7 +664,7 @@ span.question:hover::after {
   counter-reset: para;
 
   section:not(#footnotes, #bibliographie) {
-    p, pre {
+    p, pre:not(.sourceCode) {
       counter-increment: para;
       position: relative;
 
@@ -669,8 +677,8 @@ span.question:hover::after {
         content: "(" counter(para) ")";
         position: absolute;
         text-align: right;
-        left: -2em;
-        top: calc(1em * 1.7 / 2); /* to match baseline of first line */
+        left: -2.8em;
+        top: calc(1em * 1.7 / 3); /* to match baseline of first line */
         font-size: 0.75rem;
       }
     }
@@ -679,4 +687,9 @@ span.question:hover::after {
 
 blockquote > p::before {
   content: none;
+}
+
+#footnotes ol {
+  padding-left: 0;
+  list-style-position: inside;
 }


### PR DESCRIPTION
- explicite la numérotation des listes (les styles généraux les déstyle)
- ne compte pas les extraits de code dans le comptage des paragraphes
- aligne un peu mieux les numéros de paragraphe

![image](https://github.com/user-attachments/assets/8d504389-7048-4d2c-9802-d70e610a0fd2)

![image](https://github.com/user-attachments/assets/f5e55afb-fab9-48a0-99f0-7a92114eb628)

fixes #1236 