### PR TITLE
Capture les erreurs et avertissements silencieux

### DIFF
--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -42,6 +42,7 @@ if (SENTRY_DSN) {
       Sentry.reactRouterV5BrowserTracingIntegration({ history }),
       Sentry.replayIntegration(),
       Sentry.replayCanvasIntegration(),
+      Sentry.captureConsoleIntegration({ levels: ['warn', 'error', 'assert'] }),
     ],
     tracesSampleRate: 1.0,
     replaysSessionSampleRate: 0.1,


### PR DESCRIPTION
Comme ça les `catch()` qui finissent en `console.{warn,error}()` atterriront dans Sentry.

📖 [Documentation](https://docs.sentry.io/platforms/javascript/configuration/integrations/captureconsole/).