### PR TITLE
From `translator` to `translators` in metadata

### DIFF
--- a/graphql/helpers/metadata.js
+++ b/graphql/helpers/metadata.js
@@ -243,7 +243,7 @@ function reformat(yaml, { id, originalUrl, replaceBibliography = false }) {
  *   translatedTitle: [],
  *   translationOf: [],
  *   translations: [],
- *   translator: [],
+ *   translators: [],
  *   typeArticle: string[],
  * }}
  */
@@ -345,7 +345,7 @@ function toLegacyFormat(metadata) {
     translationOf: [translationOf],
     articleslies: senspublic?.linkedArticles,
     translations: senspublic?.translations,
-    translator: translators?.map((p) => toLegacyPerson(p)),
+    translators: translators?.map((p) => toLegacyPerson(p)),
     typeArticle: senspublic?.categories,
   }
 }


### PR DESCRIPTION
To be consistent with other lists like `transcribers`.

We already use `translators` on the export templates side.

⚠️ There are probably other places to edit!