### PR TITLE
Revert "chore(deps): update dependency ubuntu to v24"

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     # libcrypto.so.1.1 is missing in ubuntu-24.04
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Reverts EcrituresNumeriques/stylo#1242

```
Starting the MongoMemoryServer Instance failed, enable debug log for more information. Error:
 StdoutInstanceError: Instance failed to start because a library is missing or cannot be opened: "libcrypto.so.1.1"
```


Apparemment, MongoDB 4.4 utilise SSL 1.1 mais Ubuntu 24.04 utilise une version plus récente. Je pense qu'il faudrait plutôt mettre à jour MongoDB plutôt que de tenter d'installer des versions obsolètes de SSL sur Ubuntu 24.