### PR TITLE
Prend en compte une bibliographie fraiche lors de l'export

### DIFF
--- a/front/src/components/Write/WorkingVersion.jsx
+++ b/front/src/components/Write/WorkingVersion.jsx
@@ -11,6 +11,7 @@ import {
   Printer,
 } from 'react-feather'
 import { useTranslation } from 'react-i18next'
+import { toBibtex } from '../../helpers/bibtex.js'
 import TimeAgo from '../TimeAgo.jsx'
 
 import styles from './workingVersion.module.scss'
@@ -139,7 +140,7 @@ export default function WorkingVersion({
             <Export
               articleVersionId={selectedVersion}
               articleId={articleInfos._id}
-              bib={live.bibPreview}
+              bib={toBibtex(workingArticle.bibliography.entries.slice(0, 3))}
               name={articleInfos.title}
             />
           </Modal>

--- a/front/src/helpers/bibtex.js
+++ b/front/src/helpers/bibtex.js
@@ -13,7 +13,7 @@ export async function parse(bibtex) {
 }
 
 export function toBibtex(entries) {
-  return entries.map((e) => e.raw_text).join('\n\n')
+  return entries.map((e) => e?.entry?.raw_text ?? e.raw_text).join('\n\n')
 }
 
 /**


### PR DESCRIPTION
Le problème vient du fait qu'on a des données en doublon et désynchronisées dans : 
- `live`
- `articleInfos`
- dans le store, `workingArticle`

La mise à jour de la bibiliographie n'était pas reflétée dans la valeur `live.bibPreview`.


fixes #996 