### PR TITLE
Règle la featureCompatibility mongodb à `4.4`

### DIFF
--- a/graphql/migrations/20250305092400-mongo44.js
+++ b/graphql/migrations/20250305092400-mongo44.js
@@ -1,0 +1,9 @@
+exports.up = async function (db) {
+  return db._run('executeDbAdminCommand', {
+    setFeatureCompatibilityVersion: '4.4',
+  })
+}
+
+exports.down = function () {
+  return null
+}


### PR DESCRIPTION
Ça prépare les migrations suivantes.

(aujourd'hui elle est positionnée implicitement à `4.2`, ce qui empêche une migration vers la version 5.

refs #1317