### PR TITLE
feat: permet de basculer le formulaire des métadonnées en lecture seule

### DIFF
--- a/front/src/components/Form.jsx
+++ b/front/src/components/Form.jsx
@@ -24,6 +24,7 @@ const {
 
 /**
  * @param {BaseInputTemplate} properties
+ * @returns {Element}
  */
 function BaseInputTemplate(properties) {
   const { placeholder } = properties
@@ -41,6 +42,7 @@ function BaseInputTemplate(properties) {
 
 /**
  * @param {SelectWidget} properties
+ * @returns {Element}
  */
 function CustomSelectWidget(properties) {
   const { options, title, placeholder } = properties
@@ -76,6 +78,7 @@ function CustomSelectWidget(properties) {
 
 /**
  * @param {WidgetProps} properties
+ * @returns {Element}
  */
 function CustomCheckboxesWidget(properties) {
   const { options, title } = properties
@@ -108,6 +111,7 @@ function CustomCheckboxesWidget(properties) {
 
 /**
  * @param {ArrayFieldTemplateProps} properties
+ * @returns {Element}
  */
 function ArrayFieldTemplate(properties) {
   const addItemTitle =
@@ -130,6 +134,7 @@ function ArrayFieldTemplate(properties) {
       )}
       {properties.canAdd && (
         <Button
+          disabled={properties.disabled || properties.readonly}
           type="button"
           className={styles.addButton}
           tabIndex={-1}
@@ -210,6 +215,7 @@ function FieldTemplate(properties) {
 
 /**
  * @param {ObjectFieldTemplateProps} properties
+ * @returns {Element}
  */
 function ObjectFieldTemplate(properties) {
   if (properties.uiSchema['ui:groups']) {
@@ -286,16 +292,17 @@ const customFields = {
 }
 
 /**
- *
- * @param initialFormData
- * @param schema
- * @param uiSchema
- * @param {(any) => void} onChange
- * @return {Element}
- * @constructor
+ * @param {object} props properties
+ * @param {any} props.formData
+ * @param {boolean} props.readOnly
+ * @param {any} props.schema
+ * @param {any} props.uiSchema
+ * @param {(any) => void} props.onChange
+ * @returns {Element}
  */
 export default function SchemaForm({
   formData: initialFormData,
+  readOnly,
   schema,
   uiSchema,
   onChange = () => {},
@@ -340,6 +347,7 @@ export default function SchemaForm({
   // noinspection JSValidateTypes
   return (
     <Form
+      readonly={readOnly}
       className={styles.form}
       formContext={formContext}
       schema={schema}

--- a/front/src/components/Write/ArticleEditorMetadata.jsx
+++ b/front/src/components/Write/ArticleEditorMetadata.jsx
@@ -1,7 +1,6 @@
 import { Toggle } from '@geist-ui/core'
 import React, { useCallback, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import PropTypes from 'prop-types'
 import { useTranslation } from 'react-i18next'
 import YAML from 'js-yaml'
 import { Sidebar } from 'react-feather'
@@ -12,6 +11,13 @@ import MonacoYamlEditor from './providers/monaco/YamlEditor'
 
 import styles from './articleEditorMetadata.module.scss'
 
+/**
+ * @param {object} props properties
+ * @param {any} props.metadata
+ * @param {boolean} props.readOnly
+ * @param {(any) => void} props.onChange
+ * @returns {Element}
+ */
 export default function ArticleEditorMetadata({
   onChange,
   readOnly,
@@ -97,7 +103,6 @@ export default function ArticleEditorMetadata({
                 checked={selector === 'raw'}
                 title={'Activer le mode YAML'}
                 onChange={(e) => {
-                  console.log(e)
                   setSelector(e.target.checked ? 'raw' : 'basic')
                 }}
               />
@@ -132,6 +137,7 @@ export default function ArticleEditorMetadata({
           )}
           {selector !== 'raw' && (
             <ArticleEditorMetadataForm
+              readOnly={readOnly}
               metadata={metadata}
               error={(reason) => {
                 setError(reason)
@@ -146,10 +152,4 @@ export default function ArticleEditorMetadata({
       )}
     </nav>
   )
-}
-
-ArticleEditorMetadata.propTypes = {
-  onChange: PropTypes.func,
-  readOnly: PropTypes.bool,
-  metadata: PropTypes.object,
 }

--- a/front/src/components/Write/ArticleEditorMetadata.jsx
+++ b/front/src/components/Write/ArticleEditorMetadata.jsx
@@ -109,25 +109,11 @@ export default function ArticleEditorMetadata({
               <label htmlFor="raw-mode">YAML</label>
             </div>
           </header>
-
-          {/*<NavTag*/}
-          {/*  defaultValue={selector}*/}
-          {/*  onChange={setSelector}*/}
-          {/*  items={[*/}
-          {/*    {*/}
-          {/*      value: 'basic',*/}
-          {/*      name: t('write.basicMode.metadataButton'),*/}
-          {/*    },*/}
-          {/*    {*/}
-          {/*      value: 'raw',*/}
-          {/*      name: t('write.rawMode.metadataButton'),*/}
-          {/*    },*/}
-          {/*  ]}*/}
-          {/*/>*/}
           {selector === 'raw' && (
             <>
               {error !== '' && <p className={styles.error}>{error}</p>}
               <MonacoYamlEditor
+                readOnly={readOnly}
                 height="calc(100vh - 280px)"
                 fontSize="14"
                 text={rawYaml}

--- a/front/src/components/Write/metadata/isidoreAuthor.jsx
+++ b/front/src/components/Write/metadata/isidoreAuthor.jsx
@@ -67,6 +67,7 @@ export default function IsidoreAuthorAPIAutocompleteField(props) {
             className: styles.autocompleteField,
             autoComplete: 'disabled',
             icon: Search,
+            readOnly: props.readonly,
           },
           { suppressRefError: true }
         )}

--- a/front/src/components/Write/providers/monaco/YamlEditor.jsx
+++ b/front/src/components/Write/providers/monaco/YamlEditor.jsx
@@ -5,6 +5,7 @@ import Editor, { loader } from '@monaco-editor/react'
 import defaultEditorOptions from './options.js'
 
 import styles from './YamlEditor.module.scss'
+
 loader.config({ monaco })
 
 export default function MonacoYamlEditor({
@@ -12,16 +13,18 @@ export default function MonacoYamlEditor({
   height,
   onTextUpdate,
   fontSize = 16,
+  readOnly = false,
 }) {
   const options = useMemo(
     () => ({
       ...defaultEditorOptions,
+      readOnly,
       fontSize,
       lineNumbers: false,
       wordWrap: 'off',
       wrappingIndent: 'same',
     }),
-    []
+    [readOnly]
   )
 
   return (

--- a/front/src/components/Write/yamleditor/ArticleEditorMetadataForm.jsx
+++ b/front/src/components/Write/yamleditor/ArticleEditorMetadataForm.jsx
@@ -1,12 +1,19 @@
 import React, { useCallback, useMemo } from 'react'
 import { merge } from 'allof-merge'
-import PropTypes from 'prop-types'
 import Form from '../../Form'
 import uiSchema from '../../../schemas/article-ui-schema.json'
 import schema from '../../../schemas/article-metadata.schema.json'
 
+/**
+ * @param {object} props properties
+ * @param {any} props.metadata
+ * @param {boolean} props.readOnly
+ * @param {(any) => void} props.onChange
+ * @returns {Element}
+ */
 export default function ArticleEditorMetadataForm({
   metadata,
+  readOnly = false,
   onChange = () => {},
 }) {
   const schemaMerged = useMemo(() => merge(schema), [schema])
@@ -16,16 +23,11 @@ export default function ArticleEditorMetadataForm({
   )
   return (
     <Form
+      readOnly={readOnly}
       formData={metadata}
       schema={schemaMerged}
       uiSchema={uiSchema}
       onChange={handleChange}
     />
   )
-}
-
-ArticleEditorMetadataForm.propTypes = {
-  metadata: PropTypes.object,
-  basicMode: PropTypes.bool,
-  onChange: PropTypes.func,
 }

--- a/front/src/components/button.module.scss
+++ b/front/src/components/button.module.scss
@@ -80,6 +80,10 @@
   }
 }
 
+.button:disabled {
+  cursor: default;
+}
+
 a.button:not(.primary),
 a.icon:not(.primary) {
   color: currentColor;

--- a/front/src/components/form.module.scss
+++ b/front/src/components/form.module.scss
@@ -146,6 +146,12 @@
       .checkboxes {
         padding-left: 10%;
 
+        .checkbox.disabled {
+          label {
+            cursor: default;
+          }
+        }
+
         .checkbox {
           padding: 0.5rem 0;
 

--- a/front/src/components/metadata/MetadataForm.jsx
+++ b/front/src/components/metadata/MetadataForm.jsx
@@ -4,16 +4,24 @@ import PropTypes from 'prop-types'
 import Form from '../Form.jsx'
 
 /**
- * @param data Values in JSON format
- * @param schema Data schema
- * @param uiSchema UI schema
- * @param onChange Function that return the values in JSON format
+ * @param {object} props properties
+ * @param {any} props.data Values in JSON format
+ * @param {boolean} props.readOnly Values in JSON format
+ * @param {any} props.schema Data schema
+ * @param {any} props.uiSchema UI schema
+ * @param {(any) => void} props.onChange Function that return the values in JSON format
  * @returns {Element}
- * @constructor
  */
-export default function MetadataForm({ data, schema, uiSchema, onChange }) {
+export default function MetadataForm({
+  data,
+  readOnly = false,
+  schema,
+  uiSchema,
+  onChange,
+}) {
   return (
     <Form
+      readOnly={readOnly}
       formData={data}
       schema={schema}
       uiSchema={uiSchema}

--- a/front/src/components/metadata/MetadataForm.jsx
+++ b/front/src/components/metadata/MetadataForm.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 import Form from '../Form.jsx'
 
@@ -28,12 +27,4 @@ export default function MetadataForm({
       onChange={onChange}
     />
   )
-}
-
-MetadataForm.propTypes = {
-  data: PropTypes.object,
-  schema: PropTypes.object,
-  uiSchema: PropTypes.object,
-  templates: PropTypes.array,
-  onChange: PropTypes.func,
 }

--- a/front/src/styles/general.scss
+++ b/front/src/styles/general.scss
@@ -33,7 +33,7 @@
     resize: vertical;
     font-size: 0.9em;
     font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono,
-      DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
+    DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
   }
 
   textarea:not([rows]) {
@@ -86,17 +86,29 @@ input[type='search']::-ms-clear {
   width: 0;
   height: 0;
 }
+
 input[type='search']::-ms-reveal {
   display: none;
   width: 0;
   height: 0;
 }
+
 /* clears the ‘X’ from Chrome */
 input[type='search']::-webkit-search-decoration,
 input[type='search']::-webkit-search-cancel-button,
 input[type='search']::-webkit-search-results-button,
 input[type='search']::-webkit-search-results-decoration {
   display: none;
+}
+
+input:read-only,
+textarea:read-only,
+select:read-only,
+select:disabled {
+  border: 0 !important;
+  box-shadow: none !important;
+  color: $main-color !important;
+  background-color: $muted-background-color !important;
 }
 
 .yRemoteSelectionHead {

--- a/front/src/styles/variables.scss
+++ b/front/src/styles/variables.scss
@@ -7,6 +7,7 @@ $main-background-color: #f8f9fa;
 $main-color: #202020;
 $main-lighter-color: #505050;
 $muted-color: #818181;
+$muted-background-color: #ececec;
 $alternate-row-color: #f0f0f0;
 $extra-color: #000000;
 $main-color-links: #1565c0;


### PR DESCRIPTION
Quand on sélectionne une version, les métadonnées doivent être en lecture seule.

Prépare aussi le terrain pour le regroupement des interfaces d'écriture (mode collaboratif activé par défaut) où les métadonnées ne seront pas modifiables (dans un premier temps) quand plusieurs personnes sont connectés.


https://github.com/user-attachments/assets/bd78906f-d5f1-479d-8e2e-888f3c4b0b2b

