### PR TITLE
Désactive la traduction par des outils tiers

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="./favicon.ico" />

--- a/front/src/i18n.js
+++ b/front/src/i18n.js
@@ -19,4 +19,6 @@ i18n
     },
   })
 
+i18n.on('languageChanged', (lng) => (document.documentElement.lang = lng))
+
 export default i18n


### PR DESCRIPTION
On peut s'en passer maintenant que l'interface est traduite en au moins 3 langues.

C'est relié aux issues Sentry `NotFoundError`.

Sources : [facebook/react#11538](https://github.com/facebook/react/issues/11538) et [Everything about Google Translate crashing React (and other web apps)](https://martijnhols.nl/blog/everything-about-google-translate-crashing-react).