### PR TITLE
chore: simplifie la gestion de l'état des corpus

### DIFF
--- a/front/src/components/corpus/Corpus.jsx
+++ b/front/src/components/corpus/Corpus.jsx
@@ -1,82 +1,31 @@
-import {
-  Button,
-  Modal as GeistModal,
-  useModal,
-  useToasts,
-} from '@geist-ui/core'
-import React, { useState, useEffect, useCallback } from 'react'
+import { Button, Modal as GeistModal, useModal } from '@geist-ui/core'
+import React, { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { shallowEqual, useSelector } from 'react-redux'
 import { Helmet } from 'react-helmet'
 
-import { useGraphQLClient } from '../../helpers/graphQL'
+import { useCorpus } from '../../hooks/corpus.js'
 import { useActiveWorkspace } from '../../hooks/workspace.js'
 import styles from './corpus.module.scss'
 import CorpusCreate from './CorpusCreate.jsx'
 
 import Loading from '../Loading'
-import { useActiveUserId } from '../../hooks/user'
 import WorkspaceLabel from '../workspace/WorkspaceLabel.jsx'
 
-import { getCorpus } from './Corpus.graphql'
 import CorpusItem from './CorpusItem.jsx'
 
 export default function Corpus() {
   const { t } = useTranslation()
-  const { setToast } = useToasts()
-  const currentUser = useSelector((state) => state.activeUser, shallowEqual)
-  const latestCorpusCreated = useSelector(
-    (state) => state.latestCorpusCreated,
-    shallowEqual
-  )
-  const latestCorpusDeleted = useSelector(
-    (state) => state.latestCorpusDeleted,
-    shallowEqual
-  )
-  const latestCorpusUpdated = useSelector(
-    (state) => state.latestCorpusUpdated,
-    shallowEqual
-  )
-  const [isLoading, setIsLoading] = useState(true)
-  const [corpus, setCorpus] = useState([])
-  const activeUserId = useActiveUserId()
+  const { corpus, isLoading } = useCorpus()
   const activeWorkspace = useActiveWorkspace()
-  const activeWorkspaceId = activeWorkspace?._id
   const {
     visible: createCorpusVisible,
     setVisible: setCreateCorpusVisible,
     bindings: createCorpusModalBinding,
   } = useModal()
 
-  const { query } = useGraphQLClient()
-
   const handleCreateNewCorpus = useCallback(() => {
     setCreateCorpusVisible(false)
   }, [])
-
-  useEffect(() => {
-    ;(async () => {
-      try {
-        const variables = activeWorkspaceId
-          ? { filter: { workspaceId: activeWorkspaceId } }
-          : {}
-        const data = await query({ query: getCorpus, variables })
-        setCorpus(data.corpus)
-        setIsLoading(false)
-      } catch (err) {
-        setToast({
-          type: 'error',
-          text: t('corpus.load.toastFailure', { errorMessage: err.toString() }),
-        })
-      }
-    })()
-  }, [
-    activeUserId,
-    activeWorkspaceId,
-    latestCorpusCreated,
-    latestCorpusDeleted,
-    latestCorpusUpdated,
-  ])
 
   return (
     <section className={styles.section}>
@@ -114,7 +63,7 @@ export default function Corpus() {
       >
         <h2>{t('corpus.createModal.title')}</h2>
         <GeistModal.Content>
-          <CorpusCreate onSubmit={handleCreateNewCorpus} />
+          <CorpusCreate onSubmit={() => setCreateCorpusVisible(false)} />
         </GeistModal.Content>
         <GeistModal.Action
           passive

--- a/front/src/components/corpus/CorpusCreate.jsx
+++ b/front/src/components/corpus/CorpusCreate.jsx
@@ -1,29 +1,19 @@
 import { Button, Textarea, useInput, useToasts } from '@geist-ui/core'
-import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch } from 'react-redux'
-import { useGraphQLClient } from '../../helpers/graphQL.js'
-import { useActiveWorkspace } from '../../hooks/workspace.js'
 
 import Field from '../Field.jsx'
+import { useCorpusActions } from '../../hooks/corpus.js'
 
 import styles from './corpusCreate.module.scss'
-
-import { createCorpus } from './Corpus.graphql'
 
 export default function CorpusCreate({ onSubmit }) {
   const { t } = useTranslation()
   const { setToast } = useToasts()
-  const dispatch = useDispatch()
   const { state: title, bindings: titleBindings } = useInput('')
   const { state: description, bindings: descriptionBindings } = useInput('')
-  const titleInputRef = useRef()
-  const { query } = useGraphQLClient()
-  const activeWorkspace = useActiveWorkspace()
-  const activeWorkspaceId = useMemo(
-    () => activeWorkspace?._id,
-    [activeWorkspace]
-  )
+  const titleInputRef = useRef(null)
+  const { createCorpus } = useCorpusActions()
 
   useEffect(() => {
     if (titleInputRef.current !== undefined) {
@@ -35,21 +25,7 @@ export default function CorpusCreate({ onSubmit }) {
     async (event) => {
       try {
         event.preventDefault()
-        const response = await query({
-          query: createCorpus,
-          variables: {
-            createCorpusInput: {
-              name: title,
-              description,
-              workspace: activeWorkspaceId,
-              metadata: '',
-            },
-          },
-        })
-        dispatch({
-          type: 'SET_LATEST_CORPUS_CREATED',
-          data: { corpusId: response.createCorpus._id },
-        })
+        await createCorpus({ title, description })
         onSubmit()
         setToast({
           text: t('corpus.create.toastSuccess'),

--- a/front/src/components/corpus/CorpusUpdate.jsx
+++ b/front/src/components/corpus/CorpusUpdate.jsx
@@ -1,11 +1,9 @@
 import { Button, Textarea, useInput, useToasts } from '@geist-ui/core'
 import React, { useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useGraphQLClient } from '../../helpers/graphQL.js'
+import { useCorpusActions } from '../../hooks/corpus.js'
 
 import Field from '../Field.jsx'
-
-import { updateCorpus } from './Corpus.graphql'
 
 import styles from './corpusUpdate.module.scss'
 
@@ -16,8 +14,8 @@ export default function CorpusUpdate({ corpus, onSubmit }) {
   const { state: description, bindings: descriptionBindings } = useInput(
     corpus.description
   )
-  const titleInputRef = useRef()
-  const { query } = useGraphQLClient()
+  const titleInputRef = useRef(null)
+  const { updateCorpus } = useCorpusActions()
 
   useEffect(() => {
     if (titleInputRef.current !== undefined) {
@@ -29,15 +27,10 @@ export default function CorpusUpdate({ corpus, onSubmit }) {
     async (event) => {
       try {
         event.preventDefault()
-        await query({
-          query: updateCorpus,
-          variables: {
-            corpusId: corpus._id,
-            updateCorpusInput: {
-              name: title,
-              description,
-            },
-          },
+        await updateCorpus({
+          corpusId: corpus._id,
+          title,
+          description,
         })
         onSubmit()
         setToast({

--- a/front/src/createReduxStore.js
+++ b/front/src/createReduxStore.js
@@ -60,8 +60,6 @@ export const initialState = {
     workspaces: [],
     activeWorkspaceId: null,
   },
-  latestCorpusCreated: null,
-  latestCorpusDeleted: null,
   userPreferences: localStorage.getItem('userPreferences')
     ? JSON.parse(localStorage.getItem('userPreferences'))
     : {
@@ -119,10 +117,6 @@ function createRootReducer(state) {
     SET_ACTIVE_WORKSPACE: setActiveWorkspace,
 
     UPDATE_SELECTED_TAG: updateSelectedTag,
-
-    SET_LATEST_CORPUS_DELETED: setLatestCorpusDeleted,
-    SET_LATEST_CORPUS_CREATED: setLatestCorpusCreated,
-    SET_LATEST_CORPUS_UPDATED: setLatestCorpusUpdated,
   })
 }
 
@@ -510,27 +504,6 @@ function updateSelectedTag(state, { tagId }) {
         ? selectedTagIds.filter((selectedTagId) => selectedTagId !== tagId)
         : [...selectedTagIds, tagId],
     },
-  }
-}
-
-function setLatestCorpusDeleted(state, { data }) {
-  return {
-    ...state,
-    latestCorpusDeleted: data,
-  }
-}
-
-function setLatestCorpusCreated(state, { data }) {
-  return {
-    ...state,
-    latestCorpusCreated: data,
-  }
-}
-
-function setLatestCorpusUpdated(state, { data }) {
-  return {
-    ...state,
-    latestCorpusUpdated: data,
   }
 }
 

--- a/front/src/hooks/corpus.js
+++ b/front/src/hooks/corpus.js
@@ -1,0 +1,100 @@
+import { useSelector } from 'react-redux'
+import { useSWRConfig } from 'swr'
+import {
+  createCorpus as createCorpusQuery,
+  deleteCorpus as deleteCorpusQuery,
+  getCorpus as getCorpusQuery,
+  updateCorpus as updateCorpusQuery,
+} from '../components/corpus/Corpus.graphql'
+import { executeQuery } from '../helpers/graphQL.js'
+import useGraphQL, { useSWRKey } from './graphql.js'
+import { useActiveWorkspace } from './workspace.js'
+
+export function useCorpusActions() {
+  const activeWorkspace = useActiveWorkspace()
+  const { mutate } = useSWRConfig()
+  const workspaceId = activeWorkspace?._id
+  const variables = workspaceId ? { filter: { workspaceId } } : {}
+  const key = useSWRKey()({ query: getCorpusQuery, variables })
+  const sessionToken = useSelector((state) => state.sessionToken)
+  const createCorpus = async ({ title, description }) => {
+    const response = await executeQuery({
+      sessionToken,
+      query: createCorpusQuery,
+      variables: {
+        createCorpusInput: {
+          name: title,
+          description,
+          workspace: activeWorkspace?._id,
+          metadata: '',
+        },
+      },
+    })
+    await mutate(key, async (data) => ({
+      article: [...data.corpus, response.createCorpus],
+    }))
+  }
+  const deleteCorpus = async (corpusId) => {
+    await executeQuery({
+      sessionToken,
+      query: deleteCorpusQuery,
+      variables: {
+        corpusId,
+      },
+    })
+    await mutate(key, async (data) => ({
+      corpus: data.corpus.filter((c) => c._id !== corpusId),
+    }))
+  }
+  const updateCorpus = async ({ corpusId, title, description }) => {
+    await executeQuery({
+      sessionToken,
+      query: updateCorpusQuery,
+      variables: {
+        corpusId,
+        updateCorpusInput: {
+          name: title,
+          description,
+        },
+      },
+    })
+    await mutate(key, async (data) => ({
+      article: data.corpus.map((c) => {
+        if (c._id === corpusId) {
+          return {
+            ...c,
+            title,
+            description,
+            updatedAt: new Date(),
+          }
+        } else {
+          return c
+        }
+      }),
+    }))
+  }
+
+  return {
+    createCorpus,
+    deleteCorpus,
+    updateCorpus,
+  }
+}
+
+export function useCorpus() {
+  const activeWorkspace = useActiveWorkspace()
+  const workspaceId = activeWorkspace?._id
+  const variables = workspaceId ? { filter: { workspaceId } } : {}
+  const { data, error, isLoading } = useGraphQL(
+    { query: getCorpusQuery, variables },
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  )
+  return {
+    error,
+    isLoading,
+    corpus: data?.corpus ?? [],
+  }
+}


### PR DESCRIPTION
- Utilise `swr` afin de gérer l'état des corpus
- Ajout d'un hook permettant de réaliser des actions sur les corpus (ajout, modification et suprpession) avec mise à jour du cache
- Supprime le dispatch d’événements (`SET_LATEST_CORPUS_DELETED`, `SET_LATEST_CORPUS_CREATED` et `SET_LATEST_CORPUS_UPDATED`) dans le store Redux afin de rafraichir la liste des corpus (via un `useEffect`) 