### PR TITLE
chore: déplace le statut de l'édition collaborative au dessus de l'éditeur de texte

### DIFF
--- a/front/src/components/collaborative/CollaborativeEditor.module.scss
+++ b/front/src/components/collaborative/CollaborativeEditor.module.scss
@@ -6,6 +6,7 @@
   margin: auto;
   padding-left: 1em;
   padding-right: 1em;
+  position: relative;
 }
 
 .errorContainer {

--- a/front/src/components/collaborative/CollaborativeEditorStatus.jsx
+++ b/front/src/components/collaborative/CollaborativeEditorStatus.jsx
@@ -10,7 +10,6 @@ import Modal from '../Modal.jsx'
 import FormActions from '../molecules/FormActions.jsx'
 
 import styles from './CollaborativeEditorStatus.module.scss'
-import CollaborativeEditorWebSocketStatus from './CollaborativeEditorWebSocketStatus.jsx'
 import CollaborativeEditorWriters from './CollaborativeEditorWriters.jsx'
 
 import { stopCollaborativeSession } from './CollaborativeSession.graphql'
@@ -58,12 +57,6 @@ export default function CollaborativeEditorStatus({
       <div className={styles.row}>
         <div className={styles.writers}>
           <CollaborativeEditorWriters />
-        </div>
-        <div className={styles.status}>
-          <CollaborativeEditorWebSocketStatus
-            status={websocketStatus}
-            state={collaborativeSessionState}
-          />
         </div>
         {websocketStatus === 'connected' &&
           collaborativeSessionState === 'started' && (

--- a/front/src/components/collaborative/CollaborativeEditorWebSocketStatus.jsx
+++ b/front/src/components/collaborative/CollaborativeEditorWebSocketStatus.jsx
@@ -1,42 +1,39 @@
+import clsx from 'clsx'
 import React from 'react'
-import PropTypes from 'prop-types'
-import { Dot } from '@geist-ui/core'
 import { Loader } from 'react-feather'
 
 import styles from './CollaborativeEditorWebSocketStatus.module.scss'
 
+/**
+ * @param props
+ * @param {string} props.status
+ * @param {string} props.state
+ * @return {Element}
+ * @constructor
+ */
 export default function CollaborativeEditorWebSocketStatus({ status, state }) {
-  if (state !== 'started') {
+  if (status === 'connected') {
+    return <></>
+  }
+
+  if (state !== 'started' || status === 'connecting') {
     return (
-      <Dot type="warning" className={styles.dot}>
+      <div className={clsx(styles.status, styles.connecting)}>
+        <span className={clsx(styles.dot, styles.warning)}></span>
         Connecting
         <Loader className={styles.loadingIndicator} />
-      </Dot>
+      </div>
     )
   }
-  return (
-    <>
-      {status === 'connected' && (
-        <Dot type="success" className={styles.dot}>
-          Connected
-        </Dot>
-      )}
-      {status === 'disconnected' && (
-        <Dot type="error" className={styles.dot}>
-          Disconnected
-        </Dot>
-      )}
-      {status === 'connecting' && (
-        <Dot type="warning" className={styles.dot}>
-          Connecting
-          <Loader className={styles.loadingIndicator} />
-        </Dot>
-      )}
-    </>
-  )
-}
 
-CollaborativeEditorWebSocketStatus.propTypes = {
-  state: PropTypes.string.isRequired,
-  status: PropTypes.string.isRequired,
+  return (
+    <div className={clsx(styles.status, styles.disconnected)}>
+      {status === 'disconnected' && (
+        <>
+          <span className={clsx(styles.dot, styles.info)}></span>
+          Disconnected
+        </>
+      )}
+    </div>
+  )
 }

--- a/front/src/components/collaborative/CollaborativeEditorWebSocketStatus.module.scss
+++ b/front/src/components/collaborative/CollaborativeEditorWebSocketStatus.module.scss
@@ -1,12 +1,23 @@
 .dot {
-  font-size: 0.8rem !important;
-  
-  :global {
-    .label {
-      display: flex;
-      gap: 0.25rem;
-    }
-  }
+  border-radius: 50%;
+  height: 0.65em;
+  width: 0.65em;
+}
+
+.connecting {
+  background-color: hsl(11, 89%, 95%);
+}
+
+.warning {
+  background-color: hsl(11, 89%, 60%);
+}
+
+.disconnected {
+  background-color: hsl(0, 0%, 95%);
+}
+
+.info {
+  background-color: hsl(0, 0%, 30%);
 }
 
 .loadingIndicator {
@@ -16,6 +27,15 @@
   animation-iteration-count: infinite;
   animation-timing-function: linear;
   flex-shrink: 0;
+}
+
+.status {
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.9rem;
+  padding: 0.75rem;
+  display: flex;
+  justify-content: center;
 }
 
 @keyframes rotation {

--- a/front/src/components/collaborative/CollaborativeTextEditor.jsx
+++ b/front/src/components/collaborative/CollaborativeTextEditor.jsx
@@ -9,6 +9,7 @@ import Loading from '../molecules/Loading.jsx'
 import * as collaborating from './collaborating.js'
 import defaultEditorOptions from '../Write/providers/monaco/options.js'
 import CollaborativeEditorStatus from './CollaborativeEditorStatus.jsx'
+import CollaborativeEditorWebSocketStatus from './CollaborativeEditorWebSocketStatus.jsx'
 
 import styles from './CollaborativeTextEditor.module.scss'
 
@@ -66,7 +67,7 @@ export default function CollaborativeTextEditor({
     shallowEqual
   )
   const dispatch = useDispatch()
-  const editorRef = useRef()
+  const editorRef = useRef(null)
   const editorCursorPosition = useSelector(
     (state) => state.editorCursorPosition,
     shallowEqual
@@ -199,6 +200,12 @@ export default function CollaborativeTextEditor({
         websocketStatus={websocketStatus}
         collaborativeSessionCreatorId={collaborativeSessionCreatorId}
       />
+      <div className={styles.inlineStatus}>
+        <CollaborativeEditorWebSocketStatus
+          status={websocketStatus}
+          state={collaborativeSessionState}
+        />
+      </div>
       <Editor
         options={options}
         className={styles.editor}

--- a/front/src/components/collaborative/CollaborativeTextEditor.module.scss
+++ b/front/src/components/collaborative/CollaborativeTextEditor.module.scss
@@ -12,3 +12,9 @@
     }
   }
 }
+
+.inlineStatus {
+  position: absolute;
+  z-index: 999;
+  width: calc(100% - 2rem);
+}

--- a/front/src/stories/Story.jsx
+++ b/front/src/stories/Story.jsx
@@ -2,6 +2,7 @@ import { Tabs } from '@geist-ui/core'
 import React from 'react'
 import { Search } from 'react-feather'
 import buttonStyles from '../components/button.module.scss'
+import CollaborativeEditorWebSocketStatus from '../components/collaborative/CollaborativeEditorWebSocketStatus.jsx'
 import Field from '../components/Field.jsx'
 import Alert from '../components/molecules/Alert.jsx'
 import Loading from '../components/molecules/Loading.jsx'
@@ -23,7 +24,7 @@ export default function Story() {
           <h4>Heading 4</h4>
           <h5>Heading 5</h5>
 
-          <p>paragrap</p>
+          <p>paragraph</p>
 
           <p>
             regular <span>span</span> <small>small</small>
@@ -110,7 +111,6 @@ export default function Story() {
         <Tabs.Item label="form" value="3">
           <FormStory />
         </Tabs.Item>
-
         <Tabs.Item label="fields" value="4">
           <h2>Fields</h2>
           <h4>Search</h4>
@@ -130,6 +130,18 @@ export default function Story() {
         </Tabs.Item>
         <Tabs.Item label="sidebar" value="5">
           <SidebarStory />
+        </Tabs.Item>
+        <Tabs.Item label="Collaborative editor" value="6">
+          <h4>Status</h4>
+          <h5>Connected</h5>
+          <CollaborativeEditorWebSocketStatus status={'connected'} />
+          <h5>Connecting</h5>
+          <CollaborativeEditorWebSocketStatus status={'connecting'} />
+          <h5>Disconnected</h5>
+          <CollaborativeEditorWebSocketStatus
+            status={'disconnected'}
+            state={'started'}
+          />
         </Tabs.Item>
       </Tabs>
     </div>


### PR DESCRIPTION
### Interface d'écriture collaborative

![image](https://github.com/user-attachments/assets/2dc797ee-b028-4d22-9cdc-755423f56be0)

### Story
![image](https://github.com/user-attachments/assets/589fbce2-8150-4a2f-833d-34e9a98b3214)

Il faudra traduire les libellés pour le moment c'est uniquement en anglais.
Au passage, j'ai remplacé le composant Geist `<Dot>`