### PR TITLE
Suppression de la notion de `role` dans les workspace

### DIFF
--- a/front/src/components/workspace/Workspaces.graphql
+++ b/front/src/components/workspace/Workspaces.graphql
@@ -72,9 +72,9 @@ query getWorkspaceMembers($workspaceId: ID!) {
 
 ## mutations
 
-mutation inviteMember($workspaceId: ID!, $userId: ID!, $role: String) {
+mutation inviteMember($workspaceId: ID!, $userId: ID!) {
   workspace(workspaceId: $workspaceId) {
-    inviteMember(userId: $userId, role: $role) {
+    inviteMember(userId: $userId) {
       _id
       members {
         _id
@@ -103,52 +103,51 @@ mutation removeMember($workspaceId: ID!, $userId: ID!) {
 }
 
 mutation createWorkspace($createWorkspaceInput: CreateWorkspaceInput!) {
-    createWorkspace(createWorkspaceInput: $createWorkspaceInput) {
-        _id
-    }
+  createWorkspace(createWorkspaceInput: $createWorkspaceInput) {
+    _id
+  }
 }
 
 mutation create($data: CreateWorkspaceInput!) {
-    createWorkspace(createWorkspaceInput: $data) {
-        _id
-        name
-        description
-        color
-        bibliographyStyle
-        createdAt
-        updatedAt
-        stats {
-            membersCount
-            articlesCount
-        }
+  createWorkspace(createWorkspaceInput: $data) {
+    _id
+    name
+    description
+    color
+    bibliographyStyle
+    createdAt
+    updatedAt
+    stats {
+      membersCount
+      articlesCount
     }
+  }
 }
 
 mutation leave($workspaceId: ID!) {
-    workspace(workspaceId: $workspaceId) {
-        leave {
-            _id
-        }
+  workspace(workspaceId: $workspaceId) {
+    leave {
+      _id
     }
+  }
 }
 
 # Add/remove article
 
 mutation addArticle($workspaceId: ID!, $articleId: ID!) {
-    workspace(workspaceId: $workspaceId) {
-        addArticle(articleId: $articleId) {
-            _id
-        }
+  workspace(workspaceId: $workspaceId) {
+    addArticle(articleId: $articleId) {
+      _id
     }
+  }
 }
 
 mutation removeArticle($workspaceId: ID!, $articleId: ID!) {
-    workspace(workspaceId: $workspaceId) {
-        article(articleId: $articleId) {
-            remove {
-                _id
-            }
-        }
+  workspace(workspaceId: $workspaceId) {
+    article(articleId: $articleId) {
+      remove {
+        _id
+      }
     }
+  }
 }
-

--- a/front/src/hooks/workspace.js
+++ b/front/src/hooks/workspace.js
@@ -79,7 +79,7 @@ export function useWorkspaceMembersActions(workspaceId) {
     const { _id: userId } = user
     await executeQuery({
       query: inviteMemberMutation,
-      variables: { workspaceId, userId, role: '' },
+      variables: { workspaceId, userId },
       sessionToken,
       type: 'mutation',
     })

--- a/graphql/models/workspace.js
+++ b/graphql/models/workspace.js
@@ -8,7 +8,6 @@ const WorkspaceMemberSchema = new Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
   },
-  role: String,
 })
 
 const workspaceSchema = new Schema(

--- a/graphql/resolvers/articleResolver.test.js
+++ b/graphql/resolvers/articleResolver.test.js
@@ -27,15 +27,12 @@ describe('article resolver', () => {
       members: [
         {
           user: new ObjectId(),
-          role: 'editor',
         },
         {
           user: new ObjectId(),
-          role: 'translator',
         },
         {
           user: userId,
-          role: 'contributor',
         },
       ],
       articles: [article._id],
@@ -47,7 +44,6 @@ describe('article resolver', () => {
       members: [
         {
           user: new ObjectId(),
-          role: 'editor',
         },
       ],
       articles: [article._id],
@@ -59,7 +55,6 @@ describe('article resolver', () => {
       members: [
         {
           user: userId,
-          role: 'editor',
         },
       ],
       articles: [article._id],

--- a/graphql/resolvers/workspaceResolver.js
+++ b/graphql/resolvers/workspaceResolver.js
@@ -193,7 +193,7 @@ module.exports = {
       return workspace.save()
     },
 
-    async inviteMember(workspace, { userId, role }) {
+    async inviteMember(workspace, { userId }) {
       // question: should we check that the authenticated user "knows" the member?
       const memberAlreadyInvited = workspace.members.find(
         (id) => String(id) === userId
@@ -201,7 +201,7 @@ module.exports = {
       if (memberAlreadyInvited) {
         return workspace
       }
-      workspace.members.push({ user: userId, role })
+      workspace.members.push({ user: userId })
       return workspace.save()
     },
   },

--- a/graphql/resolvers/workspaceResolver.test.js
+++ b/graphql/resolvers/workspaceResolver.test.js
@@ -86,7 +86,7 @@ describe('workspace resolver', () => {
     const workspace = await Workspace.create({
       name: 'Workspace C',
       color: '#ff8c69',
-      members: [{ user: guillaume.id }, { user: thomas.id, role: 'editor' }],
+      members: [{ user: guillaume.id }, { user: thomas.id }],
       articles: [],
       creator: guillaume.id,
     })

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -257,7 +257,6 @@ type WorkspaceArticle {
 type WorkspaceMember {
   workspace: Workspace!
   user: User
-  role: String
 
   # mutation
   remove: Workspace!
@@ -288,7 +287,7 @@ type Workspace {
 
   # mutations
   leave: Workspace
-  inviteMember(userId: ID!, role: String): Workspace
+  inviteMember(userId: ID!): Workspace
   addArticle(articleId: ID!): Workspace
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -288,7 +288,7 @@ type Workspace {
   createdAt: DateTime
   creator: User!
   description: String
-  inviteMember(role: String, userId: ID!): Workspace
+  inviteMember(userId: ID!): Workspace
   leave: Workspace
   member(userId: ID!): WorkspaceMember
   members: [User!]!
@@ -305,7 +305,6 @@ type WorkspaceArticle {
 
 type WorkspaceMember {
   remove: Workspace!
-  role: String
   user: User
   workspace: Workspace!
 }


### PR DESCRIPTION
J'étais surpris de voir qu'il y avait une notion de `role` sur les workspace.

Est-ce que l'ajout d'un `enum` sur le rôle correspond à l'intention du champ ?

Je n'ai pas vu ce champ utilisé, à part dans les tests.