### PR TITLE
chore: déplace les actions exporter et annoter dans le menu

### DIFF
--- a/front/src/components/Export.jsx
+++ b/front/src/components/Export.jsx
@@ -6,13 +6,13 @@ import slugify from 'slugify'
 import { applicationConfig } from '../config.js'
 import useStyloExport from '../hooks/stylo-export.js'
 import Button from './Button.jsx'
-
-import Select from './Select'
-import Combobox from './SelectCombobox.jsx'
-import Loading from './molecules/Loading.jsx'
 import buttonStyles from './button.module.scss'
 import styles from './export.module.scss'
 import formStyles from './form.module.scss'
+import Loading from './molecules/Loading.jsx'
+
+import Select from './Select'
+import Combobox from './SelectCombobox.jsx'
 
 /**
  * @param {object} props
@@ -24,18 +24,16 @@ import formStyles from './form.module.scss'
  * @param {() => {}} props.onCancel
  * @returns {React.ReactElement}
  */
-export default function Export(props) {
+export default function Export({
+  bookId,
+  articleVersionId = '',
+  articleId,
+  bib,
+  name,
+  onCancel,
+}) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
-
-  const {
-    bookId,
-    articleVersionId = '',
-    articleId,
-    bib,
-    name,
-    onCancel = () => {},
-  } = props
   const { pandocExportHost, pandocExportEndpoint } = applicationConfig
 
   const {
@@ -181,13 +179,15 @@ export default function Export(props) {
         </form>
       </section>
       <footer className={styles.actions}>
-        <Button
-          aria-label={t('modal.cancelButton.label')}
-          secondary={true}
-          onClick={() => onCancel()}
-        >
-          {t('modal.cancelButton.text')}
-        </Button>
+        {onCancel && (
+          <Button
+            aria-label={t('modal.cancelButton.label')}
+            secondary={true}
+            onClick={() => onCancel()}
+          >
+            {t('modal.cancelButton.text')}
+          </Button>
+        )}
         <a
           className={clsx(buttonStyles.button, buttonStyles.primary)}
           href={exportUrl}

--- a/front/src/components/Write/ArticleMetadata.jsx
+++ b/front/src/components/Write/ArticleMetadata.jsx
@@ -5,11 +5,11 @@ import { ArrowLeft } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
-import styles from './articleEditorMetadata.module.scss'
-
 import { toYaml } from './metadata/yaml.js'
 import MonacoYamlEditor from './providers/monaco/YamlEditor'
 import ArticleEditorMetadataForm from './yamleditor/ArticleEditorMetadataForm.jsx'
+
+import styles from './articleEditorMetadata.module.scss'
 
 /**
  * @param {object} props

--- a/front/src/components/collaborative/CollaborativeEditorArticleHeader.jsx
+++ b/front/src/components/collaborative/CollaborativeEditorArticleHeader.jsx
@@ -1,18 +1,11 @@
 import React from 'react'
-import { Eye, Printer } from 'lucide-react'
-import { Link } from 'react-router-dom'
 
 import useFetchData from '../../hooks/graphql.js'
-import { useModal } from '../../hooks/modal.js'
+
+import Loading from '../molecules/Loading.jsx'
 
 import { getArticleInfo } from '../Article.graphql'
 
-import Button from '../Button.jsx'
-
-import buttonStyles from '../button.module.scss'
-import Export from '../Export.jsx'
-import Modal from '../Modal.jsx'
-import Loading from '../molecules/Loading.jsx'
 import styles from './CollaborativeEditorArticleHeader.module.scss'
 
 /**
@@ -29,8 +22,6 @@ export default function CollaborativeEditorArticleHeader({ articleId }) {
       revalidateOnReconnect: false,
     }
   )
-  const exportModal = useModal()
-
   if (isLoading) {
     return <Loading />
   }
@@ -38,40 +29,6 @@ export default function CollaborativeEditorArticleHeader({ articleId }) {
   return (
     <header className={styles.header}>
       <h1 className={styles.title}>{data?.article?.title}</h1>
-      <div>
-        <Button
-          icon
-          title="Download a printable version"
-          onClick={() => exportModal.show()}
-        >
-          <Printer />
-        </Button>
-        <Link
-          to={`/article/${articleId}/preview`}
-          title="Preview (open a new window)"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={buttonStyles.icon}
-        >
-          <Eye />
-        </Link>
-      </div>
-
-      <Modal
-        {...exportModal.bindings}
-        title={
-          <>
-            <Printer /> Export
-          </>
-        }
-      >
-        <Export
-          articleId={articleId}
-          name={data?.article?.title}
-          bib={data?.article?.workingVersion?.bibPreview}
-          onCancel={() => exportModal.close()}
-        />
-      </Modal>
     </header>
   )
 }

--- a/front/src/components/collaborative/CollaborativeEditorMenu.jsx
+++ b/front/src/components/collaborative/CollaborativeEditorMenu.jsx
@@ -1,8 +1,16 @@
 import clsx from 'clsx'
+import { ChevronRight, ExternalLink, Printer } from 'lucide-react'
 import React, { useState } from 'react'
-import { ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useHistory } from 'react-router-dom'
 import { useArticleWorkingCopy } from '../../hooks/article.js'
+import useFetchData from '../../hooks/graphql.js'
+import { useModal } from '../../hooks/modal.js'
+
+import { getArticleInfo } from '../Article.graphql'
+import Export from '../Export.jsx'
+import Modal from '../Modal.jsx'
+import Loading from '../molecules/Loading.jsx'
 import Sidebar from '../Sidebar.jsx'
 import ArticleMetadata from '../Write/ArticleMetadata.jsx'
 import ArticleTableOfContents from './ArticleTableOfContents.jsx'
@@ -13,8 +21,21 @@ export default function CollaborativeEditorMenu({ articleId }) {
   const { t } = useTranslation()
   const [opened, setOpened] = useState(false)
   const [activeMenu, setActiveMenu] = useState('')
-
+  const exportModal = useModal()
   const { article } = useArticleWorkingCopy({ articleId })
+  const history = useHistory()
+  const { data, isLoading } = useFetchData(
+    { query: getArticleInfo, variables: { articleId } },
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  )
+
+  if (isLoading) {
+    return <Loading />
+  }
 
   const metadata = article?.workingVersion?.metadata
 
@@ -29,24 +50,42 @@ export default function CollaborativeEditorMenu({ articleId }) {
       >
         <section>
           {activeMenu === '' && (
-            <ul className={styles.entries}>
-              <li onClick={() => setActiveMenu('toc')}>
+            <div className={styles.entries}>
+              <a href="#" onClick={() => setActiveMenu('toc')}>
                 {t('toc.title')}
                 <ChevronRight
                   style={{ strokeWidth: 3 }}
                   height={32}
                   width={32}
                 />
-              </li>
-              <li onClick={() => setActiveMenu('metadata')}>
+              </a>
+              <a href="#" onClick={() => setActiveMenu('metadata')}>
                 {t('metadata.title')}
                 <ChevronRight
                   style={{ strokeWidth: 3 }}
                   height={32}
                   width={32}
                 />
-              </li>
-            </ul>
+              </a>
+
+              <a
+                href="#"
+                onClick={() => exportModal.show()}
+                title="Download a printable version"
+              >
+                {t('export.title')}
+              </a>
+
+              <a
+                href={`/article/${articleId}/preview`}
+                title="Preview (open a new window)"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.external}
+              >
+                {t('annotate.title')}
+              </a>
+            </div>
           )}
           <div className={styles.content}>
             {activeMenu === 'metadata' && (
@@ -62,6 +101,21 @@ export default function CollaborativeEditorMenu({ articleId }) {
           </div>
         </section>
       </Sidebar>
+      <Modal
+        {...exportModal.bindings}
+        title={
+          <>
+            <Printer /> Export
+          </>
+        }
+      >
+        <Export
+          articleId={articleId}
+          name={data?.article?.title}
+          bib={data?.article?.workingVersion?.bibPreview}
+          onCancel={() => exportModal.close()}
+        />
+      </Modal>
     </div>
   )
 }

--- a/front/src/components/collaborative/CollaborativeEditorMenu.jsx
+++ b/front/src/components/collaborative/CollaborativeEditorMenu.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { ChevronRight, ExternalLink, Printer } from 'lucide-react'
+import { ArrowLeft, ChevronRight, ExternalLink, Printer } from 'lucide-react'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
@@ -70,10 +70,15 @@ export default function CollaborativeEditorMenu({ articleId }) {
 
               <a
                 href="#"
-                onClick={() => exportModal.show()}
+                onClick={() => setActiveMenu('export')}
                 title="Download a printable version"
               >
                 {t('export.title')}
+                <ChevronRight
+                  style={{ strokeWidth: 3 }}
+                  height={32}
+                  width={32}
+                />
               </a>
 
               <a
@@ -98,24 +103,28 @@ export default function CollaborativeEditorMenu({ articleId }) {
             {activeMenu === 'toc' && (
               <ArticleTableOfContents onBack={() => setActiveMenu('')} />
             )}
+            {activeMenu === 'export' && (
+              <>
+                <h2
+                  className={styles.title}
+                  onClick={() => setActiveMenu('')}
+                  style={{ cursor: 'pointer', userSelect: 'none' }}
+                >
+                  <span style={{ display: 'flex' }}>
+                    <ArrowLeft style={{ strokeWidth: 3 }} />
+                  </span>
+                  <span>{t('export.title')}</span>
+                </h2>
+                <Export
+                  articleId={articleId}
+                  name={data?.article?.title}
+                  bib={data?.article?.workingVersion?.bibPreview}
+                />
+              </>
+            )}
           </div>
         </section>
       </Sidebar>
-      <Modal
-        {...exportModal.bindings}
-        title={
-          <>
-            <Printer /> Export
-          </>
-        }
-      >
-        <Export
-          articleId={articleId}
-          name={data?.article?.title}
-          bib={data?.article?.workingVersion?.bibPreview}
-          onCancel={() => exportModal.close()}
-        />
-      </Modal>
     </div>
   )
 }

--- a/front/src/components/collaborative/CollaborativeEditorMenu.module.scss
+++ b/front/src/components/collaborative/CollaborativeEditorMenu.module.scss
@@ -42,3 +42,10 @@
   width: 100%;
   min-width: 375px;
 }
+
+.title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}

--- a/front/src/components/collaborative/CollaborativeEditorMenu.module.scss
+++ b/front/src/components/collaborative/CollaborativeEditorMenu.module.scss
@@ -20,7 +20,8 @@
   flex-direction: column;
   flex: 1;
   width: 100%;
-  > li {
+
+  > a {
     user-select: none;
     cursor: pointer;
     font-size: 1.5rem;
@@ -28,19 +29,13 @@
     display: flex;
     align-items: center;
     gap: 0.25rem;
-
-    > a {
-      display: flex;
-      gap: 0.25rem;
-      text-decoration: none;
-      color: $main-color;
-
-    }
+    text-decoration: none;
+    color: $main-color;
   }
 }
 
 .external::after {
-    content: "↗";
+  content: "↗";
 }
 
 .content {

--- a/front/src/locales/en/translation.json
+++ b/front/src/locales/en/translation.json
@@ -384,5 +384,7 @@
   "metadata.showYaml": "Enable YAML mode",
   "toc.title": "Table Of Contents",
   "editorMenu.open.label": "Close", 
-  "editorMenu.close.label": "Menu"
+  "editorMenu.close.label": "Menu",
+  "export.title": "Export",
+  "annotate.title": "Annotate"
 }

--- a/front/src/locales/es/translation.json
+++ b/front/src/locales/es/translation.json
@@ -359,5 +359,7 @@
   "metadata.showYaml": "Activar el modo YAML",
   "toc.title": "Tabla de contenido",
   "editorMenu.open.label": "Cerrar",
-  "editorMenu.close.label": "Menú"
+  "editorMenu.close.label": "Menú",
+  "export.title": "Exportar",
+  "annotate.title": "Anotar"
 }

--- a/front/src/locales/fr/translation.json
+++ b/front/src/locales/fr/translation.json
@@ -381,5 +381,7 @@
   "metadata.showYaml": "Activer le mode YAML",
   "toc.title": "Tables des matières",
   "editorMenu.open.label": "Fermer",
-  "editorMenu.close.label": "Menu"
+  "editorMenu.close.label": "Menu",
+  "export.title": "Exporter",
+  "annotate.title": "Annoter"
 }


### PR DESCRIPTION
Je pense qu'on devrait afficher les options d'export dans le menu au lieu d'ouvrir une popup, sinon on a 3 fonctionnements distincts : 

- Lien externe (ouvre une nouvelle fenêtre avec la prévisualisation pour annoter le texte)
- Navigation dans le menu pour la table des matières et les métadonnées
- Navigation qui ouvre une popup pour l'export

![menu](https://github.com/user-attachments/assets/8b6f34d5-8733-4423-bdcd-e3a687e1719c)


@thom4parisot @maiwann des avis ?