### PR TITLE
Correctifs d'imports Zotero

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -27,7 +27,7 @@
         "copy-to-clipboard": "^3.3.3",
         "core-js": "^3.38",
         "diff-match-patch": "^1.0.5",
-        "downshift": "^6.1.12",
+        "downshift": "^9.0.9",
         "http-link-header": "^1.0.2",
         "i18next": "^22.4.15",
         "i18next-browser-languagedetector": "^7.0.1",
@@ -4220,9 +4220,10 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4562,24 +4563,26 @@
       }
     },
     "node_modules/downshift": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
-      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.0.9.tgz",
+      "integrity": "sha512-ygOT8blgiz5liDuEFAIaPeU4dDEa+w9p6PHVUisPIjrkF5wfR59a52HpGWAVVMoWnoFO8po2mZSScKZueihS7g==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^1.0.17",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2",
-        "tslib": "^2.3.0"
+        "@babel/runtime": "^7.24.5",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-is": "18.2.0",
+        "tslib": "^2.6.2"
       },
       "peerDependencies": {
         "react": ">=16.12.0"
       }
     },
     "node_modules/downshift/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,7 @@
     "copy-to-clipboard": "^3.3.3",
     "core-js": "^3.38",
     "diff-match-patch": "^1.0.5",
-    "downshift": "^6.1.12",
+    "downshift": "^9.0.9",
     "http-link-header": "^1.0.2",
     "i18next": "^22.4.15",
     "i18next-browser-languagedetector": "^7.0.1",

--- a/front/src/components/Article.graphql
+++ b/front/src/components/Article.graphql
@@ -17,9 +17,9 @@ query renameArticle($articleId: ID!, $title: String!) {
   }
 }
 
-query linkToZotero($articleId: ID!, $zotero: String!) {
+query updateZoteroLinkMutation($articleId: ID!, $url: String!) {
   article(article: $articleId) {
-    setZoteroLink(zotero: $zotero)
+    setZoteroLink(zotero: $url)
   }
 }
 

--- a/front/src/components/Footer.jsx
+++ b/front/src/components/Footer.jsx
@@ -1,20 +1,18 @@
-import React, { useCallback } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import React from 'react'
 import { Switch, Route, Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
+import { usePreferenceItem } from '../hooks/user.js'
+
 import styles from './header.module.scss'
 
-function Footer() {
-  const dispatch = useDispatch()
-  const userHasConsent = useSelector(
-    (state) => state.userPreferences.trackingConsent
-  )
-  const toggleConsent = useCallback(
-    () => dispatch({ type: 'USER_PREFERENCES_TOGGLE', key: 'trackingConsent' }),
-    []
-  )
+export default function Footer() {
   const { t } = useTranslation()
+
+  const { value: userHasConsent, toggleValue } = usePreferenceItem(
+    'trackingConsent',
+    'user'
+  )
 
   return (
     <Switch>
@@ -43,7 +41,7 @@ function Footer() {
                   <input
                     type="checkbox"
                     checked={userHasConsent}
-                    onChange={toggleConsent}
+                    onChange={toggleValue}
                     disabled={true}
                   />
                   {t('footer.navStats.checkbox')}
@@ -56,5 +54,3 @@ function Footer() {
     </Switch>
   )
 }
-
-export default Footer

--- a/front/src/components/Modal.jsx
+++ b/front/src/components/Modal.jsx
@@ -29,6 +29,7 @@ export default forwardRef(function Modal(
       ref={forwardedRef}
       onClose={cancel}
       aria-labelledby="modal-title"
+      aria-describedby={subtitle ? 'modal-description' : null}
     >
       {visible && (
         <div className={styles.content}>
@@ -46,7 +47,7 @@ export default forwardRef(function Modal(
             <h1 id="modal-title" className={styles.title}>
               {title}
             </h1>
-            {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
+            {subtitle && <div className={styles.subtitle} id="modal-description">{subtitle}</div>}
           </header>
 
           <div>{children}</div>

--- a/front/src/components/Sidebar.jsx
+++ b/front/src/components/Sidebar.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import clsx from 'clsx'
 import { PanelRightClose, PanelRightOpen } from 'lucide-react'
 
@@ -7,31 +8,36 @@ export default function Sidebar({
   className,
   opened,
   setOpened,
-  labelOpened,
-  labelClosed,
+  labelOpened = 'Close',
+  labelClosed = 'Open',
   children,
 }) {
-  const button = opened ? (
-    <PanelRightClose size={36} />
-  ) : (
-    <PanelRightOpen size={36} />
-  )
-
-  const label = opened ? (labelOpened ?? 'Close') : (labelClosed ?? 'Open')
+  const ButtonIcon = opened ? PanelRightClose : PanelRightOpen
+  const label = opened ? labelOpened : labelClosed
 
   return (
-    <div
+    <aside
+      aria-labelledby="editor-sidebar-label"
       className={clsx(
         styles.sidebar,
         opened ? styles.opened : styles.closed,
         className
       )}
     >
-      <div className={styles.action} onClick={() => setOpened(!opened)}>
-        <div className={styles.icon}>{button}</div>
-        <div className={styles.label}>{label}</div>
-      </div>
+      <button
+        className={styles.action}
+        onClick={setOpened}
+        aria-pressed={opened}
+      >
+        <div className={styles.icon}>
+          <ButtonIcon size={36} aria-hidden />
+        </div>
+        <div className={styles.label} id="editor-sidebar-label">
+          {label}
+        </div>
+      </button>
+
       {opened && <div className={styles.content}>{children}</div>}
-    </div>
+    </aside>
   )
 }

--- a/front/src/components/Write/ArticleMetadata.jsx
+++ b/front/src/components/Write/ArticleMetadata.jsx
@@ -3,11 +3,12 @@ import YAML from 'js-yaml'
 import React, { useCallback, useMemo, useState } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch, useSelector } from 'react-redux'
-import Alert from '../molecules/Alert.jsx'
-
+import { useSelector } from 'react-redux'
 import { toYaml } from './metadata/yaml.js'
-import MonacoYamlEditor from './providers/monaco/YamlEditor'
+import { usePreferenceItem } from '../../hooks/user.js'
+
+import Alert from '../molecules/Alert.jsx'
+import MonacoYamlEditor from './providers/monaco/YamlEditor.jsx'
 import ArticleEditorMetadataForm from './yamleditor/ArticleEditorMetadataForm.jsx'
 
 import styles from './articleEditorMetadata.module.scss'
@@ -27,22 +28,14 @@ export default function ArticleMetadata({ onChange, onBack, metadata }) {
     [articleWriters]
   )
   const { t } = useTranslation()
-  const dispatch = useDispatch()
-  const selector = useSelector(
-    (state) => state.articlePreferences.metadataFormMode
-  )
+
   const yaml = useMemo(() => toYaml(metadata), [metadata])
   const [rawYaml, setRawYaml] = useState(yaml)
   const [error, setError] = useState('')
 
-  const setSelector = useCallback(
-    (value) =>
-      dispatch({
-        type: 'ARTICLE_PREFERENCES_TOGGLE',
-        key: 'metadataFormMode',
-        value,
-      }),
-    []
+  const { value: selector, setValue: setSelector } = usePreferenceItem(
+    'metadataFormMode',
+    'article'
   )
 
   const handleFormUpdate = useCallback(

--- a/front/src/components/Write/metadata/isidoreAuthor.jsx
+++ b/front/src/components/Write/metadata/isidoreAuthor.jsx
@@ -30,7 +30,6 @@ export default function IsidoreAuthorAPIAutocompleteField(props) {
     isOpen,
     getMenuProps,
     getInputProps,
-    getComboboxProps,
     highlightedIndex,
     getItemProps,
     reset,
@@ -60,7 +59,7 @@ export default function IsidoreAuthorAPIAutocompleteField(props) {
   )
 
   return (
-    <div {...getComboboxProps()}>
+    <div>
       <Field
         {...getInputProps(
           {

--- a/front/src/components/Write/metadata/isidoreKeyword.jsx
+++ b/front/src/components/Write/metadata/isidoreKeyword.jsx
@@ -26,7 +26,6 @@ export default function IsidoreAPIAutocompleteField(props) {
     isOpen,
     getMenuProps,
     getInputProps,
-    getComboboxProps,
     highlightedIndex,
     getItemProps,
   } = useCombobox({
@@ -55,7 +54,7 @@ export default function IsidoreAPIAutocompleteField(props) {
   const isEmpty = ObjectIsEmpty(props.formData)
 
   return (
-    <div {...getComboboxProps()}>
+    <div>
       {!isEmpty && (
         <span className={styles.comboboxReadonlyField}>
           {props.formData.label}

--- a/front/src/components/bibliography/ArticleBibliography.jsx
+++ b/front/src/components/bibliography/ArticleBibliography.jsx
@@ -107,18 +107,14 @@ export default function ArticleBibliography({ articleId, versionId, onBack }) {
           <Button
             small={true}
             disabled={readOnly}
-            onClick={() => {
-              zoteroModal.show()
-            }}
+            onClick={() => zoteroModal.show()}
           >
             {t('bibliography.importZotero.button')}
           </Button>
           <Button
             small={true}
             disabled={readOnly}
-            onClick={() => {
-              addReferenceModal.show()
-            }}
+            onClick={() => addReferenceModal.show()}
           >
             {t('bibliography.addReference.button')}
           </Button>
@@ -144,8 +140,8 @@ export default function ArticleBibliography({ articleId, versionId, onBack }) {
         >
           <BibliographyZoteroImport
             articleId={articleId}
-            onChange={onChange}
             zoteroLink={article.zoteroLink}
+            onUpdated={zoteroModal.close}
           />
         </Modal>
 

--- a/front/src/components/button.module.scss
+++ b/front/src/components/button.module.scss
@@ -251,9 +251,7 @@ details.secondary {
   }
 
   &:disabled {
-    background: none;
-    cursor: not-allowed !important;
-    pointer-events: none;
+    @extend .isDisabled;
   }
 
   > svg {

--- a/front/src/components/collaborative/CollaborativeEditor.jsx
+++ b/front/src/components/collaborative/CollaborativeEditor.jsx
@@ -17,7 +17,7 @@ export default function CollaborativeEditor() {
   if (compareTo) {
     return (
       <section className={styles.container}>
-        <div className={styles.main} role="main">
+        <div className={styles.main}>
           <DiffEditor
             className={styles.diffEditor}
             width={'100%'}

--- a/front/src/components/collaborative/CollaborativeEditorMenu.module.scss
+++ b/front/src/components/collaborative/CollaborativeEditorMenu.module.scss
@@ -1,9 +1,5 @@
 @use '../../styles/variables' as *;
 
-.menu {
-  margin-right: 0.25rem;
-}
-
 .container {
   height: calc(100vh - 90px);
   max-width: initial;
@@ -28,7 +24,9 @@ a.external:after {
   flex: 1;
   width: 100%;
 
-  > a {
+  [role='menuitem'] :is(a, button) {
+    background: transparent;
+    border: none;
     user-select: none;
     cursor: pointer;
     font-size: 1.5rem;
@@ -36,8 +34,15 @@ a.external:after {
     display: flex;
     align-items: center;
     gap: 0.25rem;
+    padding: 0;
     text-decoration: none;
     color: $main-color;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+      text-decoration-color: currentColor;
+    }
   }
 }
 

--- a/front/src/components/field.module.scss
+++ b/front/src/components/field.module.scss
@@ -187,14 +187,10 @@
   position: absolute;
   width: 100%;
   z-index: 900;
-  max-height: 20rem;
+  max-height: min(30cqh, 20rem);
   overflow-y: auto;
 }
-.combobox > label:empty ~ .comboboxResults:not(:empty) {
-  margin-top: calc(
-    -0.5rem + 1px
-  ); /* (no label) same as .field margin-bottom + border-bottom-width */
-}
+
 .comboboxItem {
   cursor: pointer;
   padding: 0.5em 1em;

--- a/front/src/createReduxStore.js
+++ b/front/src/createReduxStore.js
@@ -17,10 +17,9 @@ export const initialState = {
   articlePreferences: localStorage.getItem('articlePreferences')
     ? JSON.parse(localStorage.getItem('articlePreferences'))
     : {
-        expandSidebarLeft: true,
-        expandSidebarRight: false,
+        expandSidebarRight: true,
+        activePanel: null,
         metadataFormMode: 'basic',
-        expandVersions: false,
       },
   articleFilters: {
     tagIds: [],
@@ -105,6 +104,7 @@ function createRootReducer(state) {
     SET_EXPORT_PREFERENCES: setExportPreferences,
 
     ARTICLE_PREFERENCES_TOGGLE: toggleArticlePreferences,
+    SET_ARTICLE_PREFERENCES: setArticlePreferences,
 
     UPDATE_EDITOR_CURSOR_POSITION: updateEditorCursorPosition,
 
@@ -117,6 +117,7 @@ function createRootReducer(state) {
 function persistStateIntoLocalStorage({ getState }) {
   const actionStateMap = new Map([
     ['ARTICLE_PREFERENCES_TOGGLE', 'articlePreferences'],
+    ['SET_ARTICLE_PREFERENCES', 'articlePreferences'],
     ['USER_PREFERENCES_TOGGLE', 'userPreferences'],
     ['SET_EXPORT_PREFERENCES', 'exportPreferences'],
   ])
@@ -275,6 +276,7 @@ function setPreferences(storeKey) {
 }
 
 const toggleArticlePreferences = togglePreferences('articlePreferences')
+const setArticlePreferences = setPreferences('articlePreferences')
 const toggleUserPreferences = togglePreferences('userPreferences')
 const setExportPreferences = setPreferences('exportPreferences')
 

--- a/front/src/helpers/zotero.js
+++ b/front/src/helpers/zotero.js
@@ -5,11 +5,36 @@ const baseApiUrl = 'https://api.zotero.org/'
 const baseWebUrl = 'https://www.zotero.org/'
 
 /**
+ *
+ * @param {URL|string} url
+ * @param {RequestInit?} fetchOptions
+ * @param {number?} retries
+ * @returns {Promise<Response>}
+ */
+async function retryFetch(url, fetchOptions = {}, retries = 3) {
+  const initialRetries = retries
+
+  while (retries--) {
+    const response = await fetch(url?.toString(), fetchOptions)
+
+    if (response.ok) {
+      return response
+    } else {
+      await new Promise((resolve) =>
+        setTimeout(resolve, (initialRetries / retries) * 200)
+      )
+    }
+  }
+
+  throw new Error('Maximum attempts reached')
+}
+
+/**
  * @typedef ZoteroCollection
  * @property {ZoteroCollectionData} data
  * @property {string} key
  * @property {ZoteroLibrary} library
- * @property {Object.<string, HTMLLink>} links
+ * @property {{[key: string]: HTMLLink}} links
  * @property {ZoteroMeta} meta
  * @property {number} version
  */
@@ -25,7 +50,7 @@ const baseWebUrl = 'https://www.zotero.org/'
 /**
  * @typedef ZoteroLibrary
  * @property {number} id
- * @property {Object.<string, HTMLLink>} links
+ * @property {{[key: string]: HTMLLink}} links
  * @property {string} name Name of the library
  * @property {string} type Enum of 'user' or 'group' (whom it belongs)
  */
@@ -51,6 +76,24 @@ const baseWebUrl = 'https://www.zotero.org/'
  */
 
 /**
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isApiUrl(url) {
+  return /^https:\/\/api.zotero.org\/(users|groups)\/\d+\//i.test(url)
+}
+
+/**
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isWebUrl(url) {
+  return url.startsWith(baseWebUrl)
+}
+
+/**
  * Get the next link from headers.
  * @param headers HTTP headers (from a response)
  * @returns {URL|null}
@@ -68,121 +111,83 @@ function getNextLink(headers) {
 
 /**
  *
- * @param {URL} url
- * @param {string} key Zotero API key
- * @param {object[]} agg
- * @returns {Promise<string[]>} a list of JSON responses
+ * @param {URL} from
+ * @param {URL} to
+ * @returns {URL}
  */
-async function fetchAllJSON(url, key, agg = []) {
-  if (key) {
-    url.searchParams.set('key', key)
-  }
-  const response = await fetch(url.toString(), {
-    method: 'GET',
-    credentials: 'same-origin',
-    'Zotero-API-Version': '3',
+function copySearchParams(from, to) {
+  from.searchParams.forEach((value, key) => {
+    if (!to.searchParams.has(key)) {
+      to.searchParams.set(key, value)
+    }
   })
 
-  const { headers } = response
-  const json = await response.json()
-
-  if (json) {
-    agg.push(json)
-  }
-
-  const nextLink = getNextLink(headers)
-
-  if (nextLink) {
-    await fetchAllJSON(nextLink, key, agg)
-  }
-
-  return agg
+  return to
 }
 
 /**
- * @param {URL} url
- * @param {string} key Zotero API key
- * @param {string[]=} agg
- * @returns {Promise<string[]>} - a list of bibliographical references (as BibTeX)
+ *
+ * @param {URL} initialUrl
+ * @param {'json' | 'text'} resolveAs
+ * @returns {Generator<string[]|Object[]>} a list of aggregated responses
  */
-async function fetchAllBibTeX(url, key, agg = []) {
-  if (key) {
-    url.searchParams.set('key', key)
-  }
-
-  url.searchParams.set('format', 'bibtex')
-  const response = await fetch(url.toString(), {
+async function fetchAll(initialUrl, resolveAs = 'json') {
+  const agg = []
+  let url = initialUrl
+  const options = {
     method: 'GET',
     credentials: 'same-origin',
     'Zotero-API-Version': '3',
-  })
-
-  if (!response.ok) {
-    const error = new Error(response.statusText)
-    error.statusCode = response.status
-    error.response = response
-
-    throw error
   }
 
-  const { headers } = response
-  const bib = await response.text()
+  while (url) {
+    copySearchParams(initialUrl, url)
+    const response = await retryFetch(url, options)
 
-  if (bib && bib.trim().length > 0) {
-    agg.push(filter(bib))
+    if (response.ok) {
+      const data = await response[resolveAs]()
+      agg.push(data)
+
+      url = getNextLink(response.headers)
+    }
   }
 
-  const nextLink = getNextLink(headers)
-
-  if (nextLink) {
-    await fetchAllBibTeX(nextLink, key, agg)
-  }
-
-  return agg
+  return agg.flat()
 }
 
 /**
  * @param {string} token Zotero API token
  * @returns {Promise<ZoteroKeyResponse>} - a JSON response (contains userID and key)
  */
-function fetchUserFromToken(token) {
-  return fetch(`https://api.zotero.org/keys/${token}`).then((response) =>
-    response.json()
-  )
+async function fetchUserFromToken(token) {
+  const response = await retryFetch(`https://api.zotero.org/keys/${token}`)
+
+  return response.json()
 }
 
 /**
- * @param {object} options
- * @param {string} options.userID
- * @param {string} options.key Zotero API key
- * @returns {Promise<ZoteroCollection[]>} - a list of Zotero collections
+ * @param {string} token
+ * @returns {Promise<ZoteroCollection[]>} - a list of user related collections
  */
-async function fetchAllCollections({ userID, key }) {
-  // let collections = []
-  const url = new URL(`https://api.zotero.org/users/${userID}/groups`)
-  const groups = (await fetchAllJSON(url, key)).flat()
+export async function fetchUserCollections(token) {
+  const { userID, key } = await fetchUserFromToken(token)
+
+  const [allGroups, userCollections] = await Promise.all([
+    fetchUserGroups({ userID, key }),
+    fetchUserLibraryCollections({ userID, key }),
+  ])
 
   const groupCollections = await Promise.all(
-    groups.map((group) => {
-      return fetchAllJSON(new URL(`${group.links.self.href}/collections`), key)
+    allGroups.map((group) => {
+      const url = new URL(`${group.links.self.href}/collections`)
+      url.searchParams.set('key', key)
+      url.searchParams.set('format', 'json')
+      return fetchAll(url)
     })
   ).then((groups) => [].concat(...groups.flat()))
   // concat dissolves empty arrays (groups without collections)
 
-  const userCollections = await fetchUserCollections({ userID, key })
-
   return userCollections.concat(groupCollections)
-}
-
-/**
- * @param {object} options
- * @param {string} options.token
- * @returns {Promise<ZoteroCollection[]>}
- */
-export async function fetchAllCollectionsPerLibrary({ token }) {
-  const { userID, key } = await fetchUserFromToken(token)
-
-  return fetchAllCollections({ userID, key })
 }
 
 /**
@@ -192,11 +197,27 @@ export async function fetchAllCollectionsPerLibrary({ token }) {
  * @param {string} token.key
  * @returns {Promise<ZoteroCollection[]>}
  */
-export async function fetchUserCollections({ userID, key }) {
-  return fetchAllJSON(
-    new URL(`https://api.zotero.org/users/${userID}/collections`),
-    key
-  ).then((all) => all.flat())
+export async function fetchUserLibraryCollections({ userID, key }) {
+  const url = new URL(`https://api.zotero.org/users/${userID}/collections`)
+  url.searchParams.set('key', key)
+  url.searchParams.set('format', 'json')
+
+  return fetchAll(url)
+}
+
+/**
+ *
+ * @param {object} token
+ * @param {string} token.userID
+ * @param {string} token.key
+ * @returns {Promise<ZoteroCollection[]>}
+ */
+export async function fetchUserGroups({ userID, key }) {
+  const url = new URL(`https://api.zotero.org/users/${userID}/groups`)
+  url.searchParams.set('key', key)
+  url.searchParams.set('format', 'json')
+
+  return fetchAll(url)
 }
 
 /**
@@ -209,7 +230,19 @@ export async function fetchBibliographyFromCollectionHref({
   collectionHref,
   token: key = null,
 }) {
-  return (await fetchAllBibTeX(new URL(collectionHref), key)).join('\n')
+  const url = new URL(collectionHref)
+  url.searchParams.set('format', 'bibtex')
+
+  if (key) {
+    url.searchParams.set('key', key)
+  }
+
+  return fetchAll(url, 'text').then((responses) =>
+    responses
+      .map((bib) => filter(bib))
+      .filter((d) => d)
+      .join('\n')
+  )
 }
 
 /**
@@ -221,6 +254,8 @@ export async function fetchBibliographyFromCollectionHref({
  * @returns {Promise<string>} Zotero API URL
  */
 export async function toApiUrl(plainUrl, token) {
+  let strategy = null
+
   // https://www.zotero.org/{username}
   // https://www.zotero.org/{username}/library
   // https://www.zotero.org/{username}/collections/{collectionId}
@@ -231,28 +266,45 @@ export async function toApiUrl(plainUrl, token) {
   const GROUP_RE =
     /zotero.org\/(groups\/(?<groupId>\d+)(\/[^/]+)?|(?<username>[^/]+))(\/collections\/(?<collectionId>[A-Z0-9]+))?(\/items\/(?<itemId>[A-Z0-9]+))?(\/tags\/(?<tag>[^/]+))?(\/(?<action>collection|library|item-list|trash))?$/
 
-  if (/https:\/\/api.zotero.org\/(users|groups)\/\d+\//i.test(plainUrl)) {
-    return plainUrl
-  }
+  // https://api.zotero.org/users/{userId}[/items]?
+  // https://api.zotero.org/users/{userId}/collections/{collectionId}[/items]?
+  // https://api.zotero.org/groups/{groupId}[/items]?
+  const API_RE =
+    /api.zotero.org\/(users\/(?<userId>\d+)|groups\/(?<groupId>\d+))(\/collections\/(?<collectionId>[A-Z0-9]+))?(\/(?<action>items\/top|items\/trash|items))?$/
 
-  if (!plainUrl.startsWith(baseWebUrl)) {
+  if (isApiUrl(plainUrl)) {
+    strategy = 'API'
+  } else if (isWebUrl(plainUrl)) {
+    strategy = 'WEB'
+  } else {
     throw new Error('This is not a Zotero URL')
   }
 
-  if (!plainUrl.startsWith('https://www.zotero.org/groups/') && !token) {
+  if (
+    strategy === 'WEB' &&
+    !plainUrl.startsWith('https://www.zotero.org/groups/') &&
+    !token
+  ) {
     throw new Error('A token is required to fetch personal items.')
   }
 
-  const result = plainUrl.match(GROUP_RE)
+  const result = plainUrl.match(strategy === 'WEB' ? GROUP_RE : API_RE)
 
-  let userId = null
-  const { username, groupId, collectionId, itemId, tag, action } = result.groups
+  let {
+    username,
+    userId,
+    groupId,
+    collectionId,
+    itemId,
+    tag,
+    action = 'items',
+  } = result.groups
 
   if (tag) {
     throw new Error('Cannot fetch items associated to a tag.')
   }
 
-  if (username) {
+  if (strategy === 'WEB' && username) {
     const user = await fetchUserFromToken()
 
     if (user.username !== username) {
@@ -262,12 +314,19 @@ export async function toApiUrl(plainUrl, token) {
     userId = user.userID
   }
 
+  if (strategy === 'WEB' && ['library', 'collection', 'items-list'].includes(action)) {
+    action = 'items'
+  }
+
   const path = [
+    // either one of them
     userId && `users/${userId}`,
     groupId && `groups/${groupId}`,
-    collectionId || itemId ? '' : 'items',
-    collectionId && !itemId && `collections/${collectionId}/items`,
+    // either a collection or an item
+    collectionId && !itemId && `collections/${collectionId}`,
     itemId && `items/${itemId}`,
+    // if it's not an item, it might have an action associated to it
+    !itemId && `${action}`,
   ]
     .filter(Boolean)
     .join('/')

--- a/front/src/helpers/zotero.js
+++ b/front/src/helpers/zotero.js
@@ -109,12 +109,21 @@ async function fetchAllBibTeX(url, key, agg = []) {
   if (key) {
     url.searchParams.set('key', key)
   }
+
   url.searchParams.set('format', 'bibtex')
   const response = await fetch(url.toString(), {
     method: 'GET',
     credentials: 'same-origin',
     'Zotero-API-Version': '3',
   })
+
+  if (!response.ok) {
+    const error = new Error(response.statusText)
+    error.statusCode = response.status
+    error.response = response
+
+    throw error
+  }
 
   const { headers } = response
   const bib = await response.text()

--- a/front/src/hooks/article.js
+++ b/front/src/hooks/article.js
@@ -17,6 +17,7 @@ import {
   getArticleWorkingCopy,
   getEditableArticle,
   updateWorkingVersion,
+  updateZoteroLinkMutation,
 } from '../components/Article.graphql'
 import {
   createVersion,
@@ -162,7 +163,7 @@ export function useArticleWorkingCopy({ articleId }) {
       async (data) => {
         return {
           article: {
-            ...data,
+            ...data.article,
             workingVersion: {
               ...data.workingVersion,
               metadata: metadata,
@@ -220,23 +221,46 @@ export function useEditableArticle({ articleId, versionId }) {
         if (hasVersion) {
           return {
             article: {
-              ...data,
+              ...data.article,
               version: {
                 ...data.version,
-                bib: bib,
+                bib,
               },
             },
           }
         } else {
           return {
             article: {
-              ...data,
+              ...data.article,
               workingVersion: {
                 ...data.workingVersion,
-                bib: bib,
+                bib,
               },
             },
           }
+        }
+      },
+      { revalidate: false }
+    )
+  }
+
+  const updateZoteroLink = async (url) => {
+    await executeQuery({
+      sessionToken,
+      query: updateZoteroLinkMutation,
+      variables: {
+        articleId: articleId,
+        url,
+      },
+      type: 'mutate',
+    })
+    await mutate(
+      async (data) => {
+        return {
+          article: {
+            ...data.article,
+            zoteroLink: url,
+          },
         }
       },
       { revalidate: false }
@@ -252,6 +276,7 @@ export function useEditableArticle({ articleId, versionId }) {
   return {
     article: data?.article,
     updateBibliography,
+    updateZoteroLink,
     bibliography: {
       bibtext,
       entries,

--- a/front/src/hooks/user.js
+++ b/front/src/hooks/user.js
@@ -16,6 +16,36 @@ export function useActiveUserId() {
 }
 
 /**
+ * @typedef {import('redux').Dispatch} Dispatch
+ */
+
+/**
+ *
+ * @param {string} key
+ * @param {'article' | 'user' | 'export'} namespace
+ * @returns {{ value: string|boolean|number, setValue: Dispatch, toggleValue: Dispatch }}
+ */
+export function usePreferenceItem(key, namespace = 'article') {
+  const dispatch = useDispatch()
+  const value = useSelector((state) => state[`${namespace}Preferences`]?.[key])
+
+  const ns = namespace.toUpperCase()
+
+  return {
+    value,
+    /**
+     * @param {boolean | undefined} value
+     */
+    setValue(value) {
+      dispatch({ type: `SET_${ns}_PREFERENCES`, key, value })
+    },
+    toggleValue() {
+      dispatch({ type: `${ns}_PREFERENCES_TOGGLE`, key })
+    },
+  }
+}
+
+/**
  *
  * @param {'humanid' | 'hypothesis' | 'zotero' } service
  * @returns {{ link: React.EffectCallback, token: string | undefined, id: string | undefined, isLinked: boolean, error: string, unlink: React.EffectCallback }}

--- a/front/src/locales/en/translation.json
+++ b/front/src/locales/en/translation.json
@@ -159,6 +159,10 @@
   "bibliography.errors_one": "Thereʼs a syntax error in your BibTeX. <1>Unable to save.</1>",
   "bibliography.errors_other": "There are {{count}} syntax errors in your BibTeX. <1>Unable to save.</1>",
   "bibliography.importZotero.button": "Import via Zotero",
+  "bibliography.importZotero.collections": {
+    "leaf": "{{ name }} ({{ count }} items)",
+    "section": "{{ name }} ({{ type }})"
+  },
   "bibliography.importZotero.title": "Import via Zotero",
   "bibliography.readonly": "The bibliography is editable only when you are the only one working on the article.",
   "bibliography.readonly.references_one": "Thereʼs one reference in your BibTeX.",

--- a/front/src/locales/es/translation.json
+++ b/front/src/locales/es/translation.json
@@ -158,6 +158,10 @@
   "bibliography.errors_one": "Thereʼs a syntax error in your BibTeX. <1>Unable to save.</1>",
   "bibliography.errors_other": "There are {{count}} syntax errors in your BibTeX. <1>Unable to save.</1>",
   "bibliography.importZotero.button": "Import via Zotero",
+  "bibliography.importZotero.collections": {
+    "leaf": "{{ name }} ({{ count }} elementos)",
+    "section": "{{ name }} ({{ type }})"
+  },
   "bibliography.importZotero.title": "Import via Zotero",
   "bibliography.readonly": "The bibliography is editable only when you are the only one working on the article.",
   "bibliography.readonly.references_one": "Thereʼs one reference in your BibTeX.",

--- a/front/src/locales/fr/translation.json
+++ b/front/src/locales/fr/translation.json
@@ -159,6 +159,19 @@
   "bibliography.errors_one": "Il y a une erreur de syntaxe dans le BibTeX. <1>Impossible d'enregistrer.</1>",
   "bibliography.errors_other": "Il y a {{count}} erreurs de syntaxes dans le BibTeX. <1>Impossible d'enregistrer.</1>",
   "bibliography.importZotero.button": "Importer via Zotero",
+  "bibliography.importZotero.collections": {
+    "leaf": "{{ name }} ({{ count }} références)",
+    "section": "{{ name }} ({{ type }})"
+  },
+  "bibliography.importZotero.error": {
+    "e400": "Stylo n'a pas correctement interrogé le service Zotero. Nous allons investiguer le problème.",
+    "e403": "Impossible d'importer cette collection privée. Est-elle partagée avec votre compte Zotero ?",
+    "e404": "Cette collection n'existe pas ou n'est pas publique.",
+    "e500": "Il y a un problème avec le service Zotero. Veuillez réessayer plus tard.",
+    "e503": "Il y a un problème avec le service Zotero. Veuillez réessayer plus tard.",
+    "generic": "Nous n'avons pas pu importer la collection Zotero. Nous allons investiguer le problème."
+  },
+  "bibliography.importZotero.success": "Import terminé avec succès.",
   "bibliography.importZotero.title": "Importer via Zotero",
   "bibliography.readonly": "La bibliographie est éditable uniquement quand vous êtes seul·e sur l'article.",
   "bibliography.readonly.references_one": "Il y a une référence dans le BibTeX.",


### PR DESCRIPTION
- affiche une erreur en cas de statut HTTP non-`2xx`
- détecte le statut http d'une requête (avant, même une 500 résolvait la promesse et enregistrait un résultat vide dans la biblio)


En bonus, accessibilise et mémorise l'état d'ouverture de la barre latérale ainsi que le menu sélectionné (comment ça j'étais soulé de faire 2 clics pour tester à chaque fois ?).

refs #1332 
refs #1414
refs #1385 
refs #1383 