### PR TITLE
Permet d'appliquer le style global sur les glyphes

### DIFF
--- a/front/src/components/Write/providers/monaco/BibtexEditor.jsx
+++ b/front/src/components/Write/providers/monaco/BibtexEditor.jsx
@@ -1,4 +1,5 @@
-import Editor, { loader } from '@monaco-editor/react'
+import { loader } from '@monaco-editor/react'
+import clsx from 'clsx'
 import * as monaco from 'monaco-editor'
 import React, { useCallback, useMemo } from 'react'
 import fieldStyles from '../../../field.module.scss'
@@ -6,8 +7,9 @@ import fieldStyles from '../../../field.module.scss'
 // Taken from https://github.com/koka-lang/madoko/blob/master/styles/lang/bibtex.json
 import languageDefinition from './lang/bibtex.json'
 import defaultEditorOptions from './options.js'
-import './BibtexEditor.module.scss'
 import MonacoEditor from '../../../molecules/MonacoEditor.jsx'
+
+import styles from './BibtexEditor.module.scss'
 
 loader.config({ monaco })
 
@@ -46,7 +48,7 @@ export default function MonacoBibtexEditor({
     <MonacoEditor
       height={height}
       defaultValue={text}
-      className={fieldStyles.textEditor}
+      className={clsx(fieldStyles.textEditor, styles.editor)}
       defaultLanguage="bibtex"
       onChange={onTextUpdate}
       options={options}

--- a/front/src/components/Write/providers/monaco/BibtexEditor.module.scss
+++ b/front/src/components/Write/providers/monaco/BibtexEditor.module.scss
@@ -1,11 +1,14 @@
 @use '../../../../styles/defaults' as *;
 @use '../../../../styles/variables' as *;
 
-:global {
-  .monaco-editor .glyph-margin-widgets .error {
-    background: $error-color;
-  }
-  .monaco-editor .glyph-margin-widgets .warning {
-    background: $warn-color;
+.editor {
+  :global {
+    .monaco-editor .glyph-margin-widgets .error {
+      background: $error-color;
+    }
+
+    .monaco-editor .glyph-margin-widgets .warning {
+      background: $warn-color;
+    }
   }
 }

--- a/front/src/locales/en/translation.json
+++ b/front/src/locales/en/translation.json
@@ -143,6 +143,7 @@
   "biblatexparser.error.missing_equal_sign": "Missing equal sign line {{line}}, found {{key}}",
   "biblatexparser.error.runaway_key": "Runaway key line {{line}}",
   "biblatexparser.error.token_mismatch": "Token mismatch line {{line}}, expected {{expected}} but found {{found}}",
+  "biblatexparser.error.unknown_uri": "URL of the field {{field_name}} is invalid on line {{line}}.",
   "biblatexparser.warning.unknown_type": "Unknown reference type '{{type_name}}' line {{line}}",
   "bibliography.addReference.button": "Add reference",
   "bibliography.addReference.title": "Add reference",

--- a/front/src/locales/fr/translation.json
+++ b/front/src/locales/fr/translation.json
@@ -143,6 +143,7 @@
   "biblatexparser.error.missing_equal_sign": "Signe égale (=) absent ligne {{line}}, trouvé {{key}}",
   "biblatexparser.error.runaway_key": "Clé incomplète ligne {{line}}",
   "biblatexparser.error.token_mismatch": "Jeton inattendu ligne {{line}}, attendu {{expected}} mais trouvé {{found}}",
+  "biblatexparser.error.unknown_uri": "L'URL du champ {{field_name}} est invalide en ligne {{line}}",
   "biblatexparser.warning.unknown_type": "Type de référence '{{type_name}}' non reconnu ligne {{line}}",
   "bibliography.addReference.button": "Ajouter une référence",
   "bibliography.addReference.title": "Ajouter une référence",


### PR DESCRIPTION
Actuellement le style `:global` n'est pas présent quand Vite applique du tree shaking et par conséquent l'indicateur est invisible:

![image](https://github.com/user-attachments/assets/34eb5c75-1eb1-47a9-afaf-db01035b238b)


resolves #1470

