### PR TITLE
Preview : corrige les styles de listes et paragraphes

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -62,7 +62,7 @@
     {{/if}}
   </head>
   <body>
-    <div id="root" style="height: 100%"></div>
+    <div id="root"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module" src="./src/index.jsx"></script>
   </body>

--- a/front/src/components/Page.module.scss
+++ b/front/src/components/Page.module.scss
@@ -16,7 +16,6 @@
 
 .container {
   position: relative;
-  height: 100%;
   display: flex;
   flex-direction: row;
   gap: 1em;

--- a/front/src/components/collaborative/CollaborativeTextEditor.module.scss
+++ b/front/src/components/collaborative/CollaborativeTextEditor.module.scss
@@ -71,46 +71,41 @@
       font-size: 1.2rem;
     }
 
-    p {
-      font-size: 1rem;
-    }
-
-    small {
-      font-size: 0.833rem;
-    }
-
     img, video, figure, iframe, audio, canvas, table {
       max-width: 100%;
     }
 
-    ul {
-      list-style: disc;
-      list-style-position: inside;
-      padding-left: 1em;
-    }
-
-    ol {
-      list-style: decimal;
-      list-style-position: inside;
-      padding-left: 1em;
-    }
 
     ul, ol, p, figure {
       font-size: 1rem;
       line-height: 1.6;
-      margin: .5em 0;
+      margin: 0 0 .75em;
+    }
+
+    ul {
+      list-style: disc;
+      padding-left: 2em;
+    }
+
+    ol {
+      list-style: decimal;
+      padding-left: 2em;
+    }
+
+    li, li > p {
+      margin: 0;
     }
 
     figure {
       margin: 1em 0;
     }
 
-    li {
-      margin-bottom: .25em;
+    p {
+      font-size: 1rem;
     }
 
-    :global(#footnotes > ol) {
-      list-style-position: outside;
+    small {
+      font-size: 0.833rem;
     }
   }
 }

--- a/front/src/components/collaborative/CollaborativeTextEditor.module.scss
+++ b/front/src/components/collaborative/CollaborativeTextEditor.module.scss
@@ -38,6 +38,10 @@
       color: #00f;
     }
 
+    a[href] {
+      word-break: break-word;
+    }
+
     h1, h2, h3, h4, h5, h6 {
       line-height: 1.15;
       margin: 2.25rem 0 1rem;

--- a/front/src/layout.module.scss
+++ b/front/src/layout.module.scss
@@ -61,7 +61,6 @@ $base-spacing: 2em;
 
   ul,
   ol {
-    list-style-position: inside;
     margin: 0 0 $base-spacing 0;
 
     li {

--- a/front/src/layouts/app.module.scss
+++ b/front/src/layouts/app.module.scss
@@ -1,4 +1,0 @@
-.viewportMaxHeight {
-  overflow-y: auto;
-  height: 100%;
-}

--- a/front/src/styles/general.scss
+++ b/front/src/styles/general.scss
@@ -50,11 +50,6 @@
     min-height: 8em;
   }
 
-  html,
-  body {
-    height: 100%;
-  }
-
   body {
     color: $main-color;
     font-family: 'Inter', serif;

--- a/graphql/data/defaultsData.js
+++ b/graphql/data/defaultsData.js
@@ -1,8 +1,7 @@
 module.exports = {
   article: {
     title: 'How to Stylo',
-    // https://www.zotero.org/groups/2464757/collections/PLXDF42M
-    zoteroLink: '2464757/collections/PLXDF42M',
+    zoteroLink: 'https://www.zotero.org/groups/2464757/collections/PLXDF42M',
     md: `## Introduction
 
 Stylo est un éditeur de texte scientifique. Pour faire vos premiers pas sur Stylo, commencez par éditer cet article.


### PR DESCRIPTION
# Liste avec retours à la ligne

![image](https://github.com/user-attachments/assets/f97fc5d8-f671-4ffc-8a5c-e10ad9b3431b)

# Liens trop longs

## Sous firefox

(pas constaté)

<img width="924" alt="image" src="https://github.com/user-attachments/assets/fa5e661a-a228-4008-a508-c0854be9e0c7" />

## Sous Chrome

Je n'avais constaté le problème que sur ce navigateur.

<img width="880" alt="image" src="https://github.com/user-attachments/assets/d301205f-b7c1-416a-aea9-fabc2ebff8b4" />




refs #1501
refs #1479
refs #1499 