### PR TITLE
Corrige la méthode permettant de nettoyer un objet avant de le convertir en YAML

### DIFF
--- a/front/src/components/Write/metadata/yaml.js
+++ b/front/src/components/Write/metadata/yaml.js
@@ -1,34 +1,57 @@
 import YAML from 'js-yaml'
 
-export function cleanOutput(object) {
-  let cleaning = structuredClone(object)
+/**
+ * Crée une copie de l'objet et supprime les valeurs vides/null/undefined.
+ * @param object
+ * @return {unknown|null} null si l'objet est vide, sinon l'objet sans les valeurs vides/null/undefined.
+ */
+function clean (object) {
+  const objectCloned = structuredClone(object)
 
-  if (ObjectIsEmpty(cleaning)) {
-    return ''
+  if (objectCloned === null || objectCloned === undefined) {
+    return null
   }
 
-  for (const propName in cleaning) {
+  if (objectIsEmpty(objectCloned)) {
+    return null
+  }
+
+  for (const propName in objectCloned) {
     if (
-      cleaning[propName] === null ||
-      cleaning[propName] === undefined ||
-      cleaning[propName] === ''
+      objectCloned[propName] === null ||
+      objectCloned[propName] === undefined ||
+      objectCloned[propName] === ''
     ) {
-      delete cleaning[propName]
+      delete objectCloned[propName]
     }
-    if (Array.isArray(cleaning[propName]) && cleaning[propName].length === 0) {
-      delete cleaning[propName]
+    if (Array.isArray(objectCloned[propName]) && objectCloned[propName].length === 0) {
+      delete objectCloned[propName]
     }
-    if (ObjectIsEmpty(cleaning[propName])) {
-      delete cleaning[propName]
+    if (objectIsEmpty(objectCloned[propName])) {
+      delete objectCloned[propName]
     }
   }
-  return cleaning
+  return objectCloned
 }
 
-export function ObjectIsEmpty(object) {
+/**
+ * Est-ce que l'objet est vide.
+ * @param object
+ * @return {boolean} vrai si l'objet est vide, sinon faux.
+ */
+function objectIsEmpty (object) {
   return typeof object === 'object' && Object.keys(object).length === 0
 }
 
-export function toYaml(formData) {
-  return '---\n' + YAML.dump(cleanOutput(formData), { sortKeys: true }) + '---'
+/**
+ * Transforme un objet en YAML.
+ * @param object
+ * @return {string} une chaine vide si l'objet est vide, sinon la représentation YAML de l'objet.
+ */
+export function toYaml (object) {
+  const output = clean(object)
+  if (output === null) {
+    return ''
+  }
+  return '---\n' + YAML.dump(output, { sortKeys: true }) + '---'
 }


### PR DESCRIPTION
Si l'objet est vide, on retourne maintenant "vide" au lieu de 
```
---
''
---
```


resolves #1506