### PR TITLE
Revert "chore(deps): update dependency ubuntu to v24"

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     # libcrypto.so.1.1 is missing in ubuntu-24.04
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Reverts EcrituresNumeriques/stylo#1302

Toujours pas 😬 
Il faut passer à MongoDB 6 et pour le moment on est sur la version 5.