### PR TITLE
Ne rend pas le workspaceId obligatoire

### DIFF
--- a/front/src/components/Articles.graphql
+++ b/front/src/components/Articles.graphql
@@ -55,7 +55,7 @@
 #   }
 # }
 
-query getWorkspaceArticles($workspaceId: ID = "default", $isPersonalWorkspace: Boolean!, $filter: FilterCorpusInput) {
+query getWorkspaceArticles($workspaceId: ID, $isPersonalWorkspace: Boolean!, $filter: FilterCorpusInput) {
   tags {
     _id
     owner

--- a/front/src/components/corpus/Corpus.graphql
+++ b/front/src/components/corpus/Corpus.graphql
@@ -1,7 +1,7 @@
 query getCorpus(
   $filter: FilterCorpusInput
   $isPersonalWorkspace: Boolean = false,
-  $workspaceId: ID!,
+  $workspaceId: ID,
   $includeArticles: Boolean = false
   $includeWorkingVersion: Boolean = false
 ) {

--- a/front/src/components/corpus/Corpus.jsx
+++ b/front/src/components/corpus/Corpus.jsx
@@ -38,8 +38,8 @@ export default function Corpus() {
           color={workspace.color}
           name={workspace.name}
         />
-
       </header>
+
       <p className={styles.introduction}>{t('corpus.page.description')}</p>
 
       <Button primary onClick={() => createCorpusModal.show()}>

--- a/front/src/components/corpus/CorpusForm.jsx
+++ b/front/src/components/corpus/CorpusForm.jsx
@@ -35,7 +35,7 @@ export default function CorpusForm({ corpus, onSubmit = () => {}, onCancel }) {
     if (titleInputRef.current !== undefined) {
       titleInputRef.current.focus()
     }
-  }, [titleInputRef])
+  }, [])
 
   const handleSubmit = useCallback(async (event) => {
     event.preventDefault()

--- a/graphql/resolvers/workspaceResolver.js
+++ b/graphql/resolvers/workspaceResolver.js
@@ -5,6 +5,10 @@ const Article = require('../models/article')
 const Corpus = require('../models/corpus')
 
 async function workspace(_, { workspaceId }, { user, token }) {
+  if (!workspaceId) {
+    return null
+  }
+
   if (token?.admin) {
     const workspace = await Workspace.findById(workspaceId)
     if (!workspace) {
@@ -15,9 +19,11 @@ async function workspace(_, { workspaceId }, { user, token }) {
     }
     return workspace
   }
+
   const workspace = await Workspace.findOne({
     $and: [{ _id: workspaceId }, { 'members.user': user?._id }],
   })
+
   if (!workspace) {
     throw new ApiError(
       'NOT_FOUND',

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -378,7 +378,7 @@ type Query {
   stats: InstanceUsageStats
 
   "Get a given workspace"
-  workspace(workspaceId: ID!): Workspace
+  workspace(workspaceId: ID): Workspace
 
   "Get a list of workspaces for the authenticated user"
   workspaces: [Workspace!]

--- a/schema.graphql
+++ b/schema.graphql
@@ -189,7 +189,7 @@ type Query {
   "Fetch version info"
   version(version: ID!): Version
   "Get a given workspace"
-  workspace(workspaceId: ID!): Workspace
+  workspace(workspaceId: ID): Workspace
   "Get a list of workspaces for the authenticated user"
   workspaces: [Workspace!]
 }


### PR DESCRIPTION
Dans certaines requêtes avec des `@skip` ça rend les choses compliquées.

On peut surement mieux faire en terme de requêtes GraphQL.

fixes #1576 
fixes #1575 