### PR TITLE
feat: déplace la barre de défilement dans le contenu de la page corpus et articles

### DIFF
--- a/front/src/components/Articles.jsx
+++ b/front/src/components/Articles.jsx
@@ -191,8 +191,8 @@ export default function Articles() {
         />
       </Modal>
 
-      <div aria-labelledby="articles-list-headline" role="list">
-        <div  className={styles.articlesTableHeader}>
+      <div aria-labelledby="article-actions" role="menubar">
+        <div className={styles.articlesTableHeader}>
           <Button primary onClick={() => createArticleModal.show()}>
             {t('article.createAction.buttonText')}
           </Button>
@@ -201,7 +201,8 @@ export default function Articles() {
             {t('article.count', { count: keepArticles.length })}
           </span>
         </div>
-
+      </div>
+      <div className={styles.articlesList} aria-labelledby="articles-list" role="list">
         {keepArticles.map((article) => (
           <Article
             key={`article-${article._id}`}

--- a/front/src/components/articles.module.scss
+++ b/front/src/components/articles.module.scss
@@ -15,6 +15,9 @@
   padding: 1rem;
   border: 1px solid $main-border-color;
   background-color: $extra-background-color;
+  height: calc(100vh - 7rem);
+  display: grid;
+  grid-auto-rows: min-content min-content min-content 1fr;
 
   > h1 {
     margin-bottom: 1rem;
@@ -75,4 +78,10 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 0.5em;
+}
+
+.articlesList {
+  overflow-y: auto;
+  scroll-margin-inline-end: 1rem;
+  scrollbar-gutter: stable;
 }

--- a/front/src/components/corpus/Corpus.jsx
+++ b/front/src/components/corpus/Corpus.jsx
@@ -42,7 +42,7 @@ export default function Corpus() {
 
       <p className={styles.introduction}>{t('corpus.page.description')}</p>
 
-      <Button primary onClick={() => createCorpusModal.show()}>
+      <Button className={styles.createButton} primary onClick={() => createCorpusModal.show()}>
         {t('corpus.createAction.buttonText')}
       </Button>
 

--- a/front/src/components/corpus/corpus.module.scss
+++ b/front/src/components/corpus/corpus.module.scss
@@ -6,6 +6,9 @@
   padding: 1rem;
   border: 1px solid $main-border-color;
   background-color: $extra-background-color;
+  height: calc(100vh - 7rem);
+  display: grid;
+  grid-auto-rows: min-content min-content min-content 1fr;
 
   > h1 {
     margin-bottom: 1rem;
@@ -31,6 +34,13 @@
   padding-bottom: 0.75em;
 }
 
+.createButton {
+  max-width: fit-content;
+}
+
 .corpusList {
   margin-top: 0.5em;
+  overflow-y: auto;
+  scroll-margin-inline-end: 1rem;
+  scrollbar-gutter: stable;
 }


### PR DESCRIPTION
### Proposition
![fix-height](https://github.com/user-attachments/assets/44466dbc-7393-4fbe-b972-c231c0b68a88)

### Actuellement
![no-fixed-height](https://github.com/user-attachments/assets/8d2a4d6b-8d75-4d33-b5c1-183e0e151028)


### TODO

- [ ]  Faire la même chose sur la liste des espaces de travail ?
- [ ] Faire la même chose sur le profile utilisateur ?
