### PR TITLE
Configure react-i18n pour ne pas utiliser Suspense dans le composant ErrorBoundary

### DIFF
--- a/front/src/components/Error.module.scss
+++ b/front/src/components/Error.module.scss
@@ -6,3 +6,7 @@
   @extend .simplePage;
   color: $error-color;
 }
+
+.stacktrace {
+  overflow-x: auto;
+}


### PR DESCRIPTION
- Améliore le style de la page d'erreur
- Corrige l'affiche de la stacktrace



|Avant|Après|
|---|---|
|![image](https://github.com/user-attachments/assets/a89e0eab-f73c-466f-bb63-657fa39307bd)|![image](https://github.com/user-attachments/assets/e750dd77-2970-40a5-bfc0-e98d1f1848b3)|



resolves #1585