### PR TITLE
Corrige le système de retour de login

### DIFF
--- a/front/src/components/Login.jsx
+++ b/front/src/components/Login.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState, useEffect } from 'react'
-import { Link, useLocation, useNavigate, useRouteLoaderData } from 'react-router'
+import { Link, useLocation, useNavigate, useRevalidator, useRouteLoaderData } from 'react-router'
 import { useDispatch } from 'react-redux'
 import { Helmet } from 'react-helmet'
 import { useToasts } from '@geist-ui/core'
@@ -24,9 +24,23 @@ export default function Login() {
   const navigate = useNavigate()
   const { user } = useRouteLoaderData('app')
   const location = useLocation()
+  const revalidator = useRevalidator()
 
   const { backendEndpoint } = applicationConfig
 
+  // Scenario: auth callback return
+  useEffect(() => {
+    const token = new URLSearchParams(location.hash).get('#auth-token')
+
+    if (token) {
+      // will trigger a store subscription and profile to be loaded there (hooks mainly)
+      dispatch({ type: 'UPDATE_SESSION_TOKEN', token })
+      // will trigger AppLoader to reload data (PrivateRoute etc.)
+      revalidator.revalidate()
+    }
+  }, [location.hash])
+
+  // Scenario: user is logged in and lands on this page
   useEffect(() => {
     if (user?._id) {
       navigate(location?.state?.returnTo ?? '/articles', { replace: true })

--- a/front/src/hooks/corpus.test.jsx
+++ b/front/src/hooks/corpus.test.jsx
@@ -28,7 +28,6 @@ describe('Corpus', () => {
     fetch.mockResolvedValueOnce({
       ok: true,
       json: () => {
-        console.log('resolve data')
         return new Promise((resolve) =>
           resolve({
             data: {

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -76,21 +76,19 @@ const Annotate = lazy(() => import('./components/Annotate.jsx'))
 const Privacy = lazy(() => import('./components/Privacy.jsx'))
 const Story = lazy(() => import('./stories/Story.jsx'))
 
-let sessionToken = new URLSearchParams(location.hash).get('#auth-token')
 const store = createStore({
-  ...(sessionToken ? { sessionToken } : {}),
   activeWorkspaceId: matchPath('/workspaces/:workspaceId', location.pathname)
     ?.params?.workspaceId,
 })
 
 // refresh session profile whenever something happens to the session token
 // maybe there is a better way to do this
+let previousValue = ''
 store.subscribe(() => {
-  const previousValue = sessionToken
-  const { sessionToken: currentValue } = store.getState()
+  const { sessionToken } = store.getState()
 
-  if (currentValue !== previousValue) {
-    sessionToken = currentValue
+  if (sessionToken !== previousValue) {
+    previousValue = sessionToken
     getUserProfile({ sessionToken }).then((response) =>
       store.dispatch({ type: 'PROFILE', ...response })
     )

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -298,11 +298,6 @@ module.exports = {
      * @returns
      */
     async article (_root, args, context) {
-      console.log({
-        _root,
-        args,
-        context
-      })
       return await getArticleByContext(args.article, context)
     },
 


### PR DESCRIPTION
@ggrossetie c'est une régression induite par la combinaison de #1517 et #1531 : les données du loader `AppLoader` se retrouvaient en désynchro avec celles du store, et… plus aucun composant n'attrapait le paramètre `auth-token`. C'était chargé dans le store mais le reste de l'appli ne suivait pas.

J'ai appris l'existence de `useRevalidate()` pour relancer le chargement des loaders et pense qu'à terme, on ne devrait gérer le profil qu'à un seul endroit (le `AppLoader`). Le jeton lui reste dans le store / `localStorage`.

fixes #1584 
fixes #1580 
fixes #1581