### PR TITLE
Calcule les métadonnées au format YAML dans le hook

### DIFF
--- a/front/src/components/corpus/CorpusMetadataModal.jsx
+++ b/front/src/components/corpus/CorpusMetadataModal.jsx
@@ -34,7 +34,7 @@ export default function CorpusMetadataModal({
   const { setToast } = useToasts()
 
   const [metadata, setMetadata] = useState(initialValue)
-  const [yaml, setYaml] = useState(toYaml(metadata))
+  const yaml = useMemo(() => toYaml(metadata), [metadata])
   const [error, setError] = useState('')
   const { value: selector, setValue: setSelector } = usePreferenceItem(
     'metadataFormMode',
@@ -66,11 +66,9 @@ export default function CorpusMetadataModal({
         setMetadata(metadata)
       } catch (err) {
         setError(err.message)
-      } finally {
-        setYaml(yaml)
       }
     },
-    [setYaml, setMetadata]
+    [setMetadata]
   )
   const handleUpdateMetadata = useCallback(async () => {
     try {
@@ -90,15 +88,13 @@ export default function CorpusMetadataModal({
   const handleMetadataUpdated = useCallback(
     (metadata) => {
       setMetadata(metadata)
-      setYaml(toYaml(metadata))
     },
-    [setMetadata, setYaml]
+    [setMetadata]
   )
   const handleCancel = useCallback(() => {
     setMetadata(initialValue)
-    setYaml(toYaml(initialValue))
     modal.close()
-  }, [setMetadata, setYaml, initialValue, modal])
+  }, [setMetadata, initialValue, modal])
 
   return (
     <>

--- a/front/src/hooks/article.js
+++ b/front/src/hooks/article.js
@@ -1,4 +1,13 @@
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
+
+import { toYaml } from '../components/Write/metadata/yaml.js'
+import { toEntries } from '../helpers/bibtex.js'
+import { executeQuery } from '../helpers/graphQL.js'
+import useFetchData, {
+  useConditionalFetchData,
+  useMutateData,
+} from './graphql.js'
 
 import {
   addTags,
@@ -12,13 +21,14 @@ import {
   updateWorkingVersion,
   updateZoteroLinkMutation,
 } from '../components/Article.graphql'
+import {
+  createVersion,
+  getArticleVersion,
+  getArticleVersions,
+  renameVersion,
+} from './Versions.graphql'
 
-import { toEntries } from '../helpers/bibtex.js'
-import { executeQuery } from '../helpers/graphQL.js'
-import useFetchData, { useConditionalFetchData, useMutateData, } from './graphql.js'
-import { createVersion, getArticleVersion, getArticleVersions, renameVersion, } from './Versions.graphql'
-
-export function useArticleTagActions ({ articleId }) {
+export function useArticleTagActions({ articleId }) {
   const sessionToken = useSelector((state) => state.sessionToken)
   const { data, mutate, error, isLoading } = useFetchData(
     { query: getArticleTags, variables: { articleId } },
@@ -79,7 +89,7 @@ export function useArticleTagActions ({ articleId }) {
   }
 }
 
-export function useArticleActions ({ articleId }) {
+export function useArticleActions({ articleId }) {
   const sessionToken = useSelector((state) => state.sessionToken)
   const activeUser = useSelector((state) => state.activeUser)
   const copy = async (toUserId) => {
@@ -131,12 +141,15 @@ export function useArticleActions ({ articleId }) {
   }
 }
 
-export function useArticleMetadata ({ articleId, versionId }) {
+export function useArticleMetadata({ articleId, versionId }) {
   const sessionToken = useSelector((state) => state.sessionToken)
   const activeUser = useSelector((state) => state.activeUser)
   const hasVersion = typeof versionId === 'string'
   const { data, error, mutate, isLoading } = useFetchData(
-    { query: getArticleMetadata, variables: { articleId, versionId: versionId ?? '', hasVersion } },
+    {
+      query: getArticleMetadata,
+      variables: { articleId, versionId: versionId ?? '', hasVersion },
+    },
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
@@ -179,13 +192,14 @@ export function useArticleMetadata ({ articleId, versionId }) {
 
   return {
     metadata,
+    metadataYaml: toYaml(metadata),
     updateMetadata,
     isLoading,
     error,
   }
 }
 
-export function useEditableArticle ({ articleId, versionId }) {
+export function useEditableArticle({ articleId, versionId }) {
   const sessionToken = useSelector((state) => state.sessionToken)
   const activeUser = useSelector((state) => state.activeUser)
   const hasVersion = typeof versionId === 'string'
@@ -280,7 +294,7 @@ export function useEditableArticle ({ articleId, versionId }) {
   }
 }
 
-export function useArticleVersions ({ articleId }) {
+export function useArticleVersions({ articleId }) {
   const { data, error, isLoading } = useFetchData(
     { query: getArticleVersions, variables: { article: articleId } },
     {
@@ -296,15 +310,15 @@ export function useArticleVersions ({ articleId }) {
   }
 }
 
-export function useArticleVersion ({ versionId }) {
+export function useArticleVersion({ versionId }) {
   const { data, error, isLoading } = useConditionalFetchData(
     versionId ? { query: getArticleVersion, variables: { versionId } } : null,
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       fallbackData: {
-        version: {}
-      }
+        version: {},
+      },
     }
   )
 
@@ -315,7 +329,7 @@ export function useArticleVersion ({ versionId }) {
   }
 }
 
-export function useArticleVersionActions ({ articleId }) {
+export function useArticleVersionActions({ articleId }) {
   const sessionToken = useSelector((state) => state.sessionToken)
   const activeUser = useSelector((state) => state.activeUser)
   const { mutate } = useMutateData({


### PR DESCRIPTION
Sinon, on pouvait se retrouver dans un état où le state rawYaml était calculé avant que les métadonnées soient récupérées par le hook.

### TODO

- [x] Problème similaire vu sur les métadonnées du corpus. Il faut gérer l'état à un seul endroit.