### PR TITLE
Charge les espaces de travail avec SWR

### DIFF
--- a/front/src/components/field.module.scss
+++ b/front/src/components/field.module.scss
@@ -62,6 +62,10 @@
     height: auto;
   }
 
+  input[type='color'] {
+    height: 2.5em;
+  }
+
   :global {
     .control {
       align-self: center;

--- a/front/src/components/tag/tagsList.module.scss
+++ b/front/src/components/tag/tagsList.module.scss
@@ -11,6 +11,7 @@
   padding: 0.25em 1.25em;
   line-height: inherit;
   color: $main-lighter-color;
+  min-height: 2.5em;
 }
 
 .filterByTags {
@@ -28,7 +29,4 @@
 
   margin-top: 0.25rem;
   margin-bottom: 0.5rem;
-}
-
-.createTagButton {
 }

--- a/front/src/createReduxStore.js
+++ b/front/src/createReduxStore.js
@@ -36,7 +36,6 @@ export const initialState = {
     authTypes: [],
     authProviders: {},
     selectedTagIds: [],
-    workspaces: [],
   },
   userPreferences: localStorage.getItem('userPreferences')
     ? JSON.parse(localStorage.getItem('userPreferences'))

--- a/front/src/hooks/user.js
+++ b/front/src/hooks/user.js
@@ -3,7 +3,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 
 import { applicationConfig } from '../config.js'
 import { useGraphQLClient } from '../helpers/graphQL.js'
-import { useMutateData } from './graphql.js'
+import useFetchData, { useMutateData } from './graphql.js'
 
 import {
   logoutMutation,
@@ -147,6 +147,20 @@ export function useUserTagActions() {
 
   return {
     create,
+  }
+}
+
+export function useUserTags() {
+  const { data, error, isLoading } = useFetchData({
+    query: getTags,
+    variables: {},
+  })
+
+  const tags = data?.user?.tags || []
+  return {
+    tags,
+    error,
+    isLoading,
   }
 }
 

--- a/front/src/hooks/workspace.js
+++ b/front/src/hooks/workspace.js
@@ -1,5 +1,9 @@
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router'
+
+import { executeQuery } from '../helpers/graphQL.js'
+import useFetchData, { useMutateData } from './graphql.js'
+
 import {
   create as createMutation,
   getWorkspaceMembers,
@@ -8,24 +12,6 @@ import {
   leave as leaveMutation,
   removeMember as removeMemberMutation,
 } from '../components/workspace/Workspaces.graphql'
-import { executeQuery } from '../helpers/graphQL.js'
-import useFetchData, { useMutateData } from './graphql.js'
-
-export function useActiveWorkspace() {
-  const workspaceId = useActiveWorkspaceId()
-
-  return useSelector((state) => {
-    const { activeUser } = state
-
-    if (!workspaceId || !activeUser) {
-      return undefined
-    }
-
-    return activeUser.workspaces?.find(
-      (workspace) => workspace._id === workspaceId
-    )
-  })
-}
 
 export function useActiveWorkspaceId() {
   const { workspaceId } = useParams()


### PR DESCRIPTION
ref #1631

Corrige le fait que créer un espace de travail n'était pas reflèté sur la modale de création d'un article : 

1. Créer un espace de travail
2. Retourner sur la page articles
3. Cliquer sur créer un article 

On constate que l'espace de travail que l'on vient de créer n'est pas présent dans la liste. Il faut recharger la page pour que l'espace de travail nouvellement crée apparaisse.

J'utilise aussi SWR pour charger la liste des étiquettes, plutôt qu'une requête GraphQL dans un `useEffect`. 

Au passage, j'ai ajusté le style CSS des `input[type=color]` car on ne voyait plus la couleur : 


<img width="774" alt="Capture d’écran 2025-06-24 à 00 03 19" src="https://github.com/user-attachments/assets/d3dc00d1-b02f-402f-bb4e-b2a532998115" />

