### PR TITLE
Permet d'accéder à /register/:service

### DIFF
--- a/front/src/components/Register.jsx
+++ b/front/src/components/Register.jsx
@@ -1,32 +1,27 @@
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
+import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
-import { useToasts } from '@geist-ui/core'
-import { useGraphQLClient } from '../helpers/graphQL'
-import * as queries from './Credentials.graphql'
-import { useActiveUserId } from '../hooks/user.js'
 
-import styles from './login.module.scss'
-import formStyles from './form.module.scss'
-import Field from './Field'
+import { useGraphQLClient } from '../helpers/graphQL'
 import Button from './Button'
+import Field from './Field'
+import { useToasts } from '@geist-ui/core'
+
 import { fromFormData, validateSameFieldValue } from '../helpers/forms.js'
-import { Helmet } from 'react-helmet'
+
+import * as queries from './Credentials.graphql'
+
+import formStyles from './form.module.scss'
+import styles from './login.module.scss'
 
 export default function Register() {
   const { t } = useTranslation()
   const { setToast } = useToasts()
-  const userId = useActiveUserId()
-  const passwordRef = useRef()
-  const passwordConfirmationRef = useRef()
+  const passwordRef = useRef(null)
+  const passwordConfirmationRef = useRef(null)
   const navigate = useNavigate()
   const { query } = useGraphQLClient()
-
-  useEffect(() => {
-    if (userId) {
-      navigate('/articles')
-    }
-  }, [userId])
 
   const handleFormSubmit = useCallback(async (event) => {
     event.preventDefault()

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -119,9 +119,13 @@ const router = createBrowserRouter(
           <Route index element={<Login />} />
         </Route>
         <Route path="logout" element={<Logout />} />
-        <Route path="register" element={<Register />}>
-          <Route path=":service" element={<RegisterWithAuthProvider />} />
+        <Route path="register" element={<RedirectIfAuth />}>
+          <Route index element={<Register />} />
         </Route>
+        <Route
+          path="register/:service"
+          element={<RegisterWithAuthProvider />}
+        />
 
         {/* Articles */}
         <Route path="articles" element={<RequireAuth />}>


### PR DESCRIPTION
ref #1613

Au passage, j'ai supprimer le `useEffet` + `navigate` par le composant parent `RedirectIfAuth` qui va rediriger si on est authentifié (ce qui permet d'éviter de polluer la navigation).

Je suppose que `/register/:service` doit rester accessible quand on est authentifié ? Auparavant, comme la route était en enfant de `<Register>` je pense que ça pouvait poser problème.