### PR TITLE
Ajuste le composant permettant de rechercher des auteurs.rices et des mots clés avec Isidore

### DIFF
--- a/front/src/components/SelectCombobox.jsx
+++ b/front/src/components/SelectCombobox.jsx
@@ -1,12 +1,14 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import styles from './field.module.scss'
-import buttonStyles from './button.module.scss'
+import clsx from 'clsx'
 import { useCombobox } from 'downshift'
 import { ChevronDown, X } from 'lucide-react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { groupItems } from './SelectCombobox.js'
 
 import Field from './Field.jsx'
-import clsx from 'clsx'
-import { groupItems } from './SelectCombobox.js'
+
+import buttonStyles from './button.module.scss'
+import styles from './field.module.scss'
 
 /**
  * @typedef {object} ComboboxItem
@@ -45,37 +47,47 @@ export default function Combobox({
     }
   }, [items])
 
-  const stateReducer = useCallback(function reducer(state, { changes, type }) {
-    switch (type) {
-      case useCombobox.stateChangeTypes.InputKeyDownEnter:
-      case useCombobox.stateChangeTypes.ItemClick:
-        onChange(changes.selectedItem.key)
+  const stateReducer = useCallback(
+    function reducer(state, { changes, type }) {
+      switch (type) {
+        case useCombobox.stateChangeTypes.InputKeyDownEnter:
+        case useCombobox.stateChangeTypes.ItemClick:
+          onChange(changes.selectedItem.key)
 
-        return {
-          ...changes,
-          highlightedIndex: items.findIndex(({ key }) => key === changes.selectedItem.key)
-        }
+          return {
+            ...changes,
+            highlightedIndex: items.findIndex(
+              ({ key }) => key === changes.selectedItem.key
+            ),
+          }
 
-      case useCombobox.stateChangeTypes.InputChange:
-      case useCombobox.stateChangeTypes.FunctionReset:
-        if (type === useCombobox.stateChangeTypes.FunctionReset || changes.inputValue === '') {
-          onChange('')
-        }
+        case useCombobox.stateChangeTypes.InputChange:
+        case useCombobox.stateChangeTypes.FunctionReset:
+          if (
+            type === useCombobox.stateChangeTypes.FunctionReset ||
+            changes.inputValue === ''
+          ) {
+            onChange('')
+          }
 
-        setInputItems(
-          !changes.inputValue
-            ? items
-            : items.filter((item) => {
-                return item.name.toLowerCase().includes(changes.inputValue.toLowerCase())
-              })
-        )
+          setInputItems(
+            !changes.inputValue
+              ? items
+              : items.filter((item) => {
+                  return item.name
+                    .toLowerCase()
+                    .includes(changes.inputValue.toLowerCase())
+                })
+          )
 
-        return changes
+          return changes
 
-      default:
-        return changes
-    }
-  }, [items])
+        default:
+          return changes
+      }
+    },
+    [items]
+  )
 
   const {
     isOpen,
@@ -89,15 +101,15 @@ export default function Combobox({
     inputValue,
     setInputValue,
     setHighlightedIndex,
-    reset
+    reset,
   } = useCombobox({
     items,
     selectedItem,
     stateReducer,
-    itemToString (item) {
+    itemToString(item) {
       return item?.name
     },
-    itemToKey (item) {
+    itemToKey(item) {
       return item?.key
     },
   })

--- a/front/src/components/Write/metadata/isidoreAuthor.jsx
+++ b/front/src/components/Write/metadata/isidoreAuthor.jsx
@@ -1,11 +1,14 @@
-import React, { useCallback, useState } from 'react'
-import throttle from 'lodash.throttle'
-import { searchAuthor as isidoreAuthorSearch } from '../../../helpers/isidore'
+import clsx from 'clsx'
 import { useCombobox } from 'downshift'
-import Field from '../../Field'
-
-import styles from '../../form.module.scss'
 import { Search } from 'lucide-react'
+import React, { useCallback, useState } from 'react'
+
+import { searchAuthor as isidoreAuthorSearch } from '../../../helpers/isidore'
+import Field from '../../Field'
+import throttle from 'lodash.throttle'
+
+import fieldStyles from '../../field.module.scss'
+import styles from '../../form.module.scss'
 
 function toValueFn(el) {
   const firstname = el.option.find((opt) => opt['@key'] === 'firstname')?.[
@@ -16,8 +19,9 @@ function toValueFn(el) {
   ]
   const orcid = el.option.find((opt) => opt['@key'] === 'orcid')?.['@value']
   const isni = el.option.find((opt) => opt['@key'] === 'isni')?.['@value']
+
   return {
-    forname: firstname,
+    forename: firstname,
     surname: lastname,
     orcid,
     isni,
@@ -71,19 +75,23 @@ export default function IsidoreAuthorAPIAutocompleteField(props) {
           { suppressRefError: true }
         )}
       />
-      <ul {...getMenuProps()}>
+      <ul {...getMenuProps()} className={fieldStyles.comboboxResults}>
         {isOpen &&
-          inputItems.map((item, index) => (
-            <li
-              style={
-                highlightedIndex === index ? { backgroundColor: '#bde4ff' } : {}
-              }
-              key={`${item.option['@value']}${index}`}
-              {...getItemProps({ item, index })}
-            >
-              {item['@label']}
-            </li>
-          ))}
+          inputItems.map((item, index) => {
+            return (
+              <li
+                className={clsx(
+                  fieldStyles.comboboxItem,
+                  highlightedIndex === index &&
+                    fieldStyles.comboboxHighlightedItem
+                )}
+                key={`${item.option['@value']}${index}`}
+                {...getItemProps({ item, index })}
+              >
+                {item['@label']}
+              </li>
+            )
+          })}
       </ul>
     </div>
   )

--- a/front/src/components/Write/metadata/isidoreKeyword.jsx
+++ b/front/src/components/Write/metadata/isidoreKeyword.jsx
@@ -1,9 +1,12 @@
-import React, { useCallback, useState } from 'react'
-import throttle from 'lodash.throttle'
-import { searchKeyword as isidoreKeywordSearch } from '../../../helpers/isidore'
+import clsx from 'clsx'
 import { useCombobox } from 'downshift'
-import Field from '../../Field'
+import React, { useCallback, useState } from 'react'
 
+import { searchKeyword as isidoreKeywordSearch } from '../../../helpers/isidore'
+import Field from '../../Field'
+import throttle from 'lodash.throttle'
+
+import fieldStyles from '../../field.module.scss'
 import styles from '../../form.module.scss'
 
 const toValueFn = (el) => ({
@@ -68,13 +71,15 @@ export default function IsidoreAPIAutocompleteField(props) {
           )}
         />
       )}
-      <ul {...getMenuProps()}>
+      <ul {...getMenuProps()} className={fieldStyles.comboboxResults}>
         {isOpen &&
           inputItems.map((item, index) => (
             <li
-              style={
-                highlightedIndex === index ? { backgroundColor: '#bde4ff' } : {}
-              }
+              className={clsx(
+                fieldStyles.comboboxItem,
+                highlightedIndex === index &&
+                  fieldStyles.comboboxHighlightedItem
+              )}
               key={`${item.option['@value']}${index}`}
               {...getItemProps({ item, index })}
             >

--- a/front/src/components/field.module.scss
+++ b/front/src/components/field.module.scss
@@ -209,6 +209,7 @@
   cursor: pointer;
   padding: 0.5em 1em;
 }
+
 .comboboxHighlightedItem {
   background-color: rgba(0, 0, 0, 0.2);
 }

--- a/front/src/components/form.module.scss
+++ b/front/src/components/form.module.scss
@@ -110,6 +110,7 @@
         flex-direction: column;
         flex: 1;
         gap: 0.5rem;
+        position: relative;
 
         > * {
           width: 100%;


### PR DESCRIPTION
- Corrige le remplissage automatique du prénom suite à la correction de la type `forname` -> `forename`.
- Applique les styles manquants
- Corrige la mise en surbrillance de l'élément survolé  


### Avant
![before](https://github.com/user-attachments/assets/290dd186-8000-4a38-a0c8-8f2c7f303d0a)



### Après

![now](https://github.com/user-attachments/assets/f5ac49e3-2c6c-4079-8755-63893b2edf29)
