### PR TITLE
Utilise le titre de l'article dans le composant entête

### DIFF
--- a/front/src/components/collaborative/CollaborativeEditor.jsx
+++ b/front/src/components/collaborative/CollaborativeEditor.jsx
@@ -4,7 +4,6 @@ import { useParams, useSearchParams } from 'react-router'
 import { executeQuery } from '../../helpers/graphQL.js'
 
 import ArticleStats from '../ArticleStats.jsx'
-import CollaborativeEditorArticleHeader from './CollaborativeEditorArticleHeader.jsx'
 import CollaborativeEditorMenu from './CollaborativeEditorMenu.jsx'
 import CollaborativeTextEditor from './CollaborativeTextEditor.jsx'
 
@@ -48,11 +47,7 @@ export default function CollaborativeEditor(props) {
 
   return (
     <section className={styles.container}>
-      <div className={styles.editorArea}>
-        <CollaborativeEditorArticleHeader
-          articleId={articleId}
-          versionId={versionId}
-        />
+      <div>
         <CollaborativeTextEditor
           mode={mode}
           articleId={articleId}

--- a/front/src/components/collaborative/CollaborativeEditorArticleHeader.jsx
+++ b/front/src/components/collaborative/CollaborativeEditorArticleHeader.jsx
@@ -16,30 +16,18 @@ import styles from './CollaborativeEditorArticleHeader.module.scss'
 
 /**
  * @param props
- * @param {string} props.articleId
+ * @param {string} props.articleTitle
  * @param {string?} props.versionId
  * @returns {import('react').ReactElementElement}
  */
 export default function CollaborativeEditorArticleHeader({
-  articleId,
+  articleTitle,
   versionId,
 }) {
   const { t } = useTranslation()
 
   const [searchParams, setSearchParams] = useSearchParams()
   const [mode, setMode] = useState('edit')
-
-  const { data, isLoading } = useFetchData(
-    { query: getArticleInfo, variables: { articleId } },
-    {
-      revalidateIfStale: false,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      fallbackData: {
-        article: {},
-      },
-    }
-  )
 
   useEffect(() => {
     if (mode === 'preview' && searchParams.get('mode') !== 'preview') {
@@ -49,13 +37,9 @@ export default function CollaborativeEditorArticleHeader({
     }
   }, [mode])
 
-  if (isLoading) {
-    return <Loading />
-  }
-
   return (
     <header className={styles.header}>
-      <h1 className={styles.title}>{data.article.title}</h1>
+      <h1 className={styles.title}>{articleTitle}</h1>
 
       <div className={styles.row}>
         <div

--- a/front/src/components/collaborative/CollaborativeTextEditor.jsx
+++ b/front/src/components/collaborative/CollaborativeTextEditor.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { MonacoBinding } from 'y-monaco'
 
+import { ack } from './actions'
 import { DiffEditor } from '@monaco-editor/react'
 import throttle from 'lodash.throttle'
 
@@ -13,11 +14,11 @@ import { useCollaboration } from '../../hooks/collaboration.js'
 import { useStyloExportPreview } from '../../hooks/stylo-export.js'
 import defaultEditorOptions from '../Write/providers/monaco/options.js'
 import { onDropIntoEditor } from '../Write/providers/monaco/support.js'
-import { ack } from './actions'
 
 import Alert from '../molecules/Alert.jsx'
 import Loading from '../molecules/Loading.jsx'
 import MonacoEditor from '../molecules/MonacoEditor.jsx'
+import CollaborativeEditorArticleHeader from './CollaborativeEditorArticleHeader.jsx'
 import CollaborativeEditorWebSocketStatus from './CollaborativeEditorWebSocketStatus.jsx'
 
 import styles from './CollaborativeTextEditor.module.scss'
@@ -115,7 +116,6 @@ export default function CollaborativeTextEditor({
       editor.onDropIntoEditor(onDropIntoEditor(editor))
 
       // Action commands
-      console.log({ ack })
       editor.addAction({ ...ack, label: t(ack.label) })
 
       const completionProvider = bibliographyCompletionProvider.register(monaco)
@@ -196,6 +196,11 @@ export default function CollaborativeTextEditor({
       <Helmet>
         <title>{article.title}</title>
       </Helmet>
+
+      <CollaborativeEditorArticleHeader
+        articleTitle={article.title}
+        versionId={versionId}
+      />
 
       <CollaborativeEditorWebSocketStatus
         className={styles.inlineStatus}


### PR DESCRIPTION
Evite de charger l'article dans l'entête en réutilisant le titre déjà présent dans l'éditeur.

resolves #1649