### PR TITLE
Harmonise les tailles et hiérarchies de titres

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-react": "^7.25.7",
+        "@csstools/normalize.css": "^12.1.1",
         "@monaco-editor/react": "~4.7.0",
         "@rjsf/core": "^5.24.3",
         "@rjsf/validator-ajv8": "^5.24.3",
@@ -1749,6 +1750,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@csstools/normalize.css": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
+      "integrity": "sha512-YAYeJ+Xqh7fUou1d1j9XHl44BmsuThiTr4iNrgCQ3J27IbhXsxXDGZ1cXv8Qvs99d4rBbLiSKy3+WZiet32PcQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.49.0",

--- a/front/package.json
+++ b/front/package.json
@@ -29,6 +29,7 @@
     "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.25.7",
+    "@csstools/normalize.css": "^12.1.1",
     "@monaco-editor/react": "~4.7.0",
     "@rjsf/core": "^5.24.3",
     "@rjsf/validator-ajv8": "^5.24.3",

--- a/front/src/components/Article.jsx
+++ b/front/src/components/Article.jsx
@@ -175,6 +175,7 @@ export default function Article({
     <article
       className={styles.article}
       aria-labelledby={`article-${article._id}-title`}
+      role="listitem"
     >
       <Modal
         {...exportModal.bindings}
@@ -263,23 +264,26 @@ export default function Article({
       </Modal>
 
       {!renaming && (
-        <h1 className={styles.title} onClick={toggleExpansion}>
-          <span tabIndex={0} onKeyUp={toggleExpansion} className={styles.icon}>
-            {expanded ? <ChevronDown /> : <ChevronRight />}
-          </span>
+          <header className={styles.title} onClick={toggleExpansion}>
+            <span role="button" aria-expanded={expanded} aria-controls={`article-${article._id}-details`} tabIndex={0} onKeyUp={toggleExpansion} className={styles.icon}>
+              {expanded ? <ChevronDown /> : <ChevronRight />}
+            </span>
 
-          <span id={`article-${article._id}-title`}>{article.title}</span>
+            <h2 id={`article-${article._id}-title`}>
+              {article.title}
+            </h2>
 
-          <Button
-            icon={true}
-            className={styles.editTitleButton}
-            onClick={(evt) => evt.stopPropagation() || setRenaming(true)}
-          >
-            <Edit3 className="icon" aria-hidden />
-            <span className="sr-only">{t('article.editName.button')}</span>
-          </Button>
-        </h1>
+            <Button
+              icon={true}
+              className={styles.editTitleButton}
+              onClick={(evt) => evt.stopPropagation() || setRenaming(true)}
+            >
+              <Edit3 className="icon" aria-hidden />
+              <span className="sr-only">{t('article.editName.button')}</span>
+            </Button>
+        </header>
       )}
+
       {renaming && (
         <form
           className={clsx(styles.renamingForm, fieldStyles.inlineFields)}
@@ -313,70 +317,70 @@ export default function Article({
         </form>
       )}
 
-      <aside className={styles.actionButtons}>
+      <div role="menu" className={styles.actionButtons}>
         {isArticleOwner && !activeWorkspaceId && (
           <Button
-            title={t('article.delete.button')}
+            role="menuitem"
             icon={true}
             onClick={() => deleteModal.show()}
           >
-            <Trash />
+            <Trash aria-label={t('article.delete.button')} />
           </Button>
         )}
 
         <Button
-          title={t('article.duplicate.button')}
+          role="menuitem"
           icon={true}
           onClick={() => duplicate()}
         >
-          <Copy />
+          <Copy aria-label={t('article.duplicate.button')} />
         </Button>
 
         {
           <Button
-            title={t('article.sendCopy.button')}
+            role="menuitem"
             icon={true}
             onClick={() => sendCopyModal.show()}
           >
-            <Send />
+            <Send aria-label={t('article.sendCopy.button')} />
           </Button>
         }
 
         {
           <Button
-            title={t('article.share.button')}
+            role="menuitem"
             icon={true}
             onClick={() => sharingModal.show()}
           >
-            <UserPlus />
+            <UserPlus aria-label={t('article.share.button')} />
           </Button>
         }
 
         <Button
-          title={t('article.download.button')}
+          role="menuitem"
           icon={true}
           onClick={() => exportModal.show()}
         >
-          <Printer />
+          <Printer aria-label={t('article.download.button')} />
         </Button>
 
         <Link
-          title={t('article.editor.edit.title')}
+          role="menuitem"
           className={buttonStyles.primary}
           to={`/article/${article._id}`}
         >
-          <Pencil />
+          <Pencil aria-label={t('article.editor.edit.title')} />
         </Link>
 
         <Link
-          title={t('article.annotate.button')}
+          role="menuitem"
           target="_blank"
           className={buttonStyles.icon}
           to={`/article/${article._id}/annotate`}
         >
-          <MessageSquareShare />
+          <MessageSquareShare aria-label={t('article.annotate.button')} />
         </Link>
-      </aside>
+      </div>
 
       <section className={styles.metadata}>
         <p className={styles.metadataAuthoring}>
@@ -403,12 +407,12 @@ export default function Article({
         </p>
 
         {expanded && (
-          <div>
+          <div id={`article-${article._id}-details`}>
             <ArticleVersionLinks article={article} articleId={articleId} />
 
             {userTags.length > 0 && (
               <>
-                <h4>{t('article.tags.title')}</h4>
+                <h3>{t('article.tags.title')}</h3>
                 <div className={styles.editTags}>
                   <ArticleTags
                     articleId={article._id}
@@ -419,12 +423,12 @@ export default function Article({
               </>
             )}
 
-            <h4>{t('article.workspaces.title')}</h4>
+            <h3>{t('article.workspaces.title')}</h3>
             <ul className={styles.workspaces}>
               <WorkspaceSelectionItems articleId={articleId} />
             </ul>
 
-            <h4>{t('article.corpus.title')}</h4>
+            <h3>{t('article.corpus.title')}</h3>
             <ul className={styles.corpusList}>
               <CorpusSelectItems articleId={articleId} />
             </ul>

--- a/front/src/components/ArticleVersionLinks.jsx
+++ b/front/src/components/ArticleVersionLinks.jsx
@@ -50,7 +50,7 @@ export default function ArticleVersionLinks({ articleId, article }) {
     <>
       {versions && versions.length > 0 && (
         <>
-          <h4>{t('article.versions.title')}</h4>
+          <h3>{t('article.versions.title')}</h3>
           <ul className={styles.versions}>
             {versions.map((v) => (
               <li

--- a/front/src/components/Articles.jsx
+++ b/front/src/components/Articles.jsx
@@ -141,9 +141,8 @@ export default function Articles() {
   }
 
   return (
-    <section
+    <div
       className={styles.section}
-      aria-labelledby="articles-list-headline"
     >
       <Helmet>
         <title>
@@ -170,9 +169,9 @@ export default function Articles() {
           onChange={(e) => setFilter(etv(e))}
         />
 
-        <fieldset className={styles.filtersTags}>
+        <fieldset className={styles.filtersTags} aria-label={t('tag.list.title')}>
           <legend>
-            <h4>{t('tag.list.title')}</h4>
+            <h4 aria-level="2">{t('tag.list.title')}</h4>
           </legend>
 
           <TagsList action={TagEditForm} />
@@ -190,7 +189,7 @@ export default function Articles() {
         />
       </Modal>
 
-      <div aria-labelledby="articles-list-headline" role="list">
+      <section aria-labelledby="articles-list-headline" role="list">
         <div className={styles.articlesTableHeader}>
           <Button
             testId="create-article-button"
@@ -214,7 +213,7 @@ export default function Articles() {
             onArticleCreated={handleArticleCreated}
           />
         ))}
-      </div>
-    </section>
+      </section>
+    </div>
   )
 }

--- a/front/src/components/ContactSearch.module.scss
+++ b/front/src/components/ContactSearch.module.scss
@@ -18,5 +18,4 @@
 
 .contactEmail {
   display: block;
-  font-size: 0.9em;
 }

--- a/front/src/components/Header.jsx
+++ b/front/src/components/Header.jsx
@@ -42,12 +42,10 @@ export default function Header() {
   return (
     <header className={styles.header} role="banner">
       <div className={styles.container}>
-        <h1 className={styles.logo}>
-          <NavLink to="/" rel="home">
-            <img src={logoContent} alt="Stylo" aria-hidden />
-            <span className="sr-only">{t('header.home')}</span>
-          </NavLink>
-        </h1>
+        <NavLink to="/" rel="home"  className={styles.logo}>
+          <img src={logoContent} alt="Stylo" aria-hidden />
+          <span className="sr-only">{t('header.home')}</span>
+        </NavLink>
 
         {userId && (
           <nav

--- a/front/src/components/articleContributors.module.scss
+++ b/front/src/components/articleContributors.module.scss
@@ -3,7 +3,6 @@
 
 .acquintances {
   h1 {
-    font-size: 1.4rem;
     margin-bottom: 1rem;
   }
 

--- a/front/src/components/articleSendCopy.module.scss
+++ b/front/src/components/articleSendCopy.module.scss
@@ -3,7 +3,6 @@
 
 .acquintances {
   h1 {
-    font-size: 1.4rem;
     margin-bottom: 1rem;
   }
 

--- a/front/src/components/collaborative/CollaborativeEditorArticleHeader.module.scss
+++ b/front/src/components/collaborative/CollaborativeEditorArticleHeader.module.scss
@@ -3,12 +3,9 @@
 }
 
 .title {
-  font-size: 1.5em;
-  font-weight: 700;
   display: flex;
   align-items: center;
   justify-items: center;
-  margin-bottom: 0.25rem;
   gap: 0.5em;
   flex: 1;
 }

--- a/front/src/components/corpus/CorpusArticles.jsx
+++ b/front/src/components/corpus/CorpusArticles.jsx
@@ -39,7 +39,7 @@ export default function CorpusArticles({ corpusId }) {
 
   return (
     <>
-      <h5 className={styles.partsTitle}>{t('corpus.parts.label')}</h5>
+      <h3 className={styles.partsTitle}>{t('corpus.parts.label')}</h3>
       {isLoading && <Loading />}
       {!isLoading && corpusArticles.length > 0 && (
         <ul>

--- a/front/src/components/corpus/CorpusItem.jsx
+++ b/front/src/components/corpus/CorpusItem.jsx
@@ -85,19 +85,22 @@ export default function CorpusItem({ corpus }) {
   )
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} aria-labelledby={`corpus-${corpus._id}-title`}>
       <div className={styles.header}>
         <div className={styles.heading} onClick={toggleExpansion}>
-          <h4 className={styles.title}>
+          <h2 className={styles.title} id={`corpus-${corpus._id}-title`}>
             <span
               tabIndex={0}
+              role="button"
+              aria-expanded={expanded}
+              aria-controls={`corpus-${corpus._id}-chapters`}
               onKeyUp={toggleExpansion}
               className={styles.icon}
             >
               {expanded ? <ChevronDown /> : <ChevronRight />}
             </span>
             {corpus.name}
-          </h4>
+          </h2>
           <p className={styles.metadata}>
             <span className={styles.by}>{t('corpus.by.text')}</span>
             <span className={styles.creator}>
@@ -106,13 +109,14 @@ export default function CorpusItem({ corpus }) {
             <TimeAgo date={corpus.updatedAt} className={styles.updatedAt} />
           </p>
         </div>
-        <aside className={styles.actionButtons}>
+
+        <div role="menu" className={styles.actionButtons}>
           <Button
-            title={t('corpus.edit.buttonTitle')}
+            role="menuitem"
             icon={true}
             onClick={() => editCorpusModal.show()}
           >
-            <Settings />
+            <Settings aria-label={t('corpus.edit.buttonTitle')} />
           </Button>
 
           <CorpusMetadataModal
@@ -122,35 +126,35 @@ export default function CorpusItem({ corpus }) {
           />
 
           <Button
-            title={t('corpus.delete.buttonTitle')}
+            role="menuitem"
             icon={true}
             onClick={(event) => {
               event.preventDefault()
               deleteCorpusModal.show()
             }}
           >
-            <Trash />
+            <Trash aria-label={t('corpus.delete.buttonTitle')} />
           </Button>
           <Button
-            title={t('corpus.export.buttonTitle')}
+            role="menuitem"
             icon={true}
             onClick={() => exportCorpusModal.show()}
           >
-            <Printer />
+            <Printer aria-label={t('corpus.export.buttonTitle')} />
           </Button>
 
           <Link
-            title={t('article.annotate.button')}
+            role="menuitem"
             target="_blank"
             className={buttonStyles.icon}
             to={`/corpus/${corpus._id}/annotate`}
           >
-            <MessageSquareShare />
+            <MessageSquareShare aria-label={t('article.annotate.button')} />
           </Link>
-        </aside>
+        </div>
       </div>
       {expanded && (
-        <div className={styles.detail}>
+        <div id={`corpus-${corpus._id}-chapters`} className={styles.detail}>
           {corpus.description && <p>{corpus.description}</p>}
           <CorpusArticles corpusId={corpusId} />
         </div>

--- a/front/src/components/corpus/corpusItem.module.scss
+++ b/front/src/components/corpus/corpusItem.module.scss
@@ -20,11 +20,8 @@
 }
 
 .title {
-  font-size: 1.15em;
   display: inline-flex;
   align-items: center;
-  padding-bottom: 0.25em;
-  padding-top: 0.5em;
 }
 
 .icon {

--- a/front/src/components/export.module.scss
+++ b/front/src/components/export.module.scss
@@ -3,7 +3,6 @@
 
 .export {
   > h1 {
-    font-size: 1.4rem;
     margin-bottom: 1rem;
   }
 }

--- a/front/src/components/header.module.scss
+++ b/front/src/components/header.module.scss
@@ -18,7 +18,7 @@
     align-items: center;
     gap: 1em;
     justify-content: space-between;
-    padding: .5em;
+    padding: .75rem;
   }
 
   a, button {
@@ -37,6 +37,10 @@
 
 .logo {
   margin-right: auto;
+
+  img {
+    max-height: 2rem;
+  }
 }
 
 .skiplinks {
@@ -176,7 +180,7 @@
     left: auto;
     right: -1em;
   }
-  
+
   .toggleMenuList {
     padding: .5em;
 

--- a/front/src/components/modal.module.scss
+++ b/front/src/components/modal.module.scss
@@ -26,7 +26,6 @@ dialog::backdrop {
 }
 
 .title {
-  font-size: 1.5rem;
   display: flex;
   gap: 0.5rem;
   align-items: center;

--- a/front/src/components/workspace/WorkspaceItem.jsx
+++ b/front/src/components/workspace/WorkspaceItem.jsx
@@ -46,13 +46,15 @@ export default function WorkspaceItem({ workspace }) {
 
   const workspaceTitle = (
     <>
-      <h5 className={styles.title}>
+      <h2 className={styles.title}>
         <span
           className={styles.chip}
           style={{ backgroundColor: workspace.color }}
+          role="presentation"
         ></span>
+
         <span>{workspace.name}</span>
-      </h5>
+      </h2>
     </>
   )
 

--- a/front/src/components/workspace/workspaceItem.module.scss
+++ b/front/src/components/workspace/workspaceItem.module.scss
@@ -16,9 +16,8 @@
 }
 
 .title {
-  font-size: 1.35em;
   display: flex;
-  padding-bottom: 0.5em;
+  align-items: center;
 }
 
 .button {

--- a/front/src/styles/general.scss
+++ b/front/src/styles/general.scss
@@ -1,6 +1,8 @@
 @use './defaults' as *;
 @use './variables' as *;
 
+@import url('@csstools/normalize.css');
+
 @font-face {
   font-family: 'Inter';
   src: url('/fonts/Inter-VariableFont_slnt,wght.ttf') format('truetype');
@@ -10,10 +12,6 @@
 
 * {
   box-sizing: border-box;
-}
-
-[hidden]:not([hidden='false']) {
-  display: none;
 }
 
 .sr-only {
@@ -30,6 +28,43 @@
 
 html {
   scrollbar-gutter: stable;
+}
+
+/*
+ * https://typescale.com/
+ * 1.067 Minor Second
+ */
+
+h1 {
+  font-size: 1.476rem;
+}
+
+h2 {
+  font-size: 1.383rem;
+}
+
+h3 {
+  font-size: 1.296rem;
+}
+
+h4 {
+  font-size: 1.215rem;
+}
+
+h5 {
+  font-size: 1.138rem;
+}
+
+h6 {
+  font-size: 1.067rem;
+}
+
+p {
+  font-size: 1rem;
+}
+
+small {
+  font-size: 0.937rem;
 }
 
 @media screen {


### PR DESCRIPTION
Et utilise les bons niveaux de titres pour qu'il n'y ait pas d'interruption dans leur hiérarchie.

Aussi, le logo, dans la navigation principale, n'est plus un élément dans la hiérarchie de titres.

# Page d'accueil

<img width="1611" height="1249" alt="image" src="https://github.com/user-attachments/assets/5d5e4c0e-934e-496d-81b8-09a9588b00c3" />

# Liste d'articles

<img width="1611" height="1249" alt="image" src="https://github.com/user-attachments/assets/4e35f1be-d4c5-4ec1-9b30-d1984e2ed44e" />


# Liste de corpus

<img width="1611" height="1249" alt="image" src="https://github.com/user-attachments/assets/cd8929c9-7ad1-425f-aa9c-e89393b5216b" />


# Liste d'espaces de travail

<img width="1611" height="1249" alt="image" src="https://github.com/user-attachments/assets/4bce8d82-2233-49a5-8201-c6caa71ba9a3" />


# Modification d'article

<img width="1611" height="1249" alt="image" src="https://github.com/user-attachments/assets/c4677435-4a70-4d38-aea7-6c2230768cef" />


fixes #1656