### PR TITLE
Permet de forcer la mise à jour des propriétés const

### DIFF
--- a/front/src/components/Write/yamleditor/ArticleEditorMetadataForm.jsx
+++ b/front/src/components/Write/yamleditor/ArticleEditorMetadataForm.jsx
@@ -1,36 +1,13 @@
-import { merge } from 'allof-merge'
 import React, { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import blogPostSchema from '../../../schemas/article-blog-post-metadata.schema.json'
-import blogPostUiSchema from '../../../schemas/article-blog-post-ui-schema.json'
-import meetingNotesSchema from '../../../schemas/article-meeting-notes-metadata.schema.json'
-import meetingNotesUiSchema from '../../../schemas/article-meeting-notes-ui-schema.json'
-import defaultSchema from '../../../schemas/article-metadata.schema.json'
-import defaultUiSchema from '../../../schemas/article-ui-schema.json'
 import Form from '../../Form'
+
+import { ArticleSchemas } from '../../../schemas/schemas.js'
 
 import Select from '../../Select.jsx'
 
 import styles from './ArticleEditorMetadataForm.module.scss'
-
-const FormTypeDefaultOptions = [
-  {
-    name: 'default',
-    data: defaultSchema,
-    ui: defaultUiSchema,
-  },
-  {
-    name: 'blog-post',
-    data: blogPostSchema,
-    ui: blogPostUiSchema,
-  },
-  {
-    name: 'meeting-notes',
-    data: meetingNotesSchema,
-    ui: meetingNotesUiSchema,
-  },
-]
 
 /**
  * @param {object} props properties
@@ -52,31 +29,29 @@ export default function ArticleEditorMetadataForm({
 }) {
   const [type, setType] = useState(metadataFormType)
   const schemaMerged = useMemo(() => {
-    const defaultOption = FormTypeDefaultOptions.find((o) => o.name === type)
-    if (defaultOption === undefined) {
+    const schema = ArticleSchemas.find((o) => o.name === type)
+    if (schema === undefined) {
       const option = metadataFormTypeOptions.find((o) => o.name === type)
       if (option) {
-        return merge(option.data)
+        return option.data
       }
       // QUESTION: what should we do, if we can't find the form?
-      return merge(
-        FormTypeDefaultOptions.find((o) => o.name === 'default').data
-      )
+      return ArticleSchemas.find((o) => o.name === 'default').data
     } else {
-      return merge(defaultOption.data)
+      return schema.data
     }
   }, [metadataFormTypeOptions, type])
   const uiSchema = useMemo(() => {
-    const defaultOption = FormTypeDefaultOptions.find((o) => o.name === type)
-    if (defaultOption === undefined) {
+    const schema = ArticleSchemas.find((o) => o.name === type)
+    if (schema === undefined) {
       const option = metadataFormTypeOptions.find((o) => o.name === type)
       if (option) {
         return option.ui
       }
       // QUESTION: what should we do, if we can't find the form?
-      return FormTypeDefaultOptions.find((o) => o.name === 'default').ui
+      return ArticleSchemas.find((o) => o.name === 'default').ui
     } else {
-      return defaultOption.ui
+      return schema.ui
     }
   }, [metadataFormTypeOptions, type])
 
@@ -88,6 +63,13 @@ export default function ArticleEditorMetadataForm({
   const handleTypeChange = useCallback(
     (type) => {
       setType(type)
+      const schema = ArticleSchemas.find((o) => o.name === type)
+      if (schema && schema.const !== undefined) {
+        handleChange({
+          ...metadata,
+          ...schema.const,
+        })
+      }
       onTypeChange(type)
     },
     [setType, onTypeChange]

--- a/front/src/hooks/article.js
+++ b/front/src/hooks/article.js
@@ -1,3 +1,4 @@
+import { merge } from 'allof-merge'
 import { useSelector } from 'react-redux'
 
 import { toYaml } from '../components/Write/metadata/yaml.js'
@@ -223,7 +224,7 @@ export function useArticleMetadata({ articleId, versionId }) {
     ?.filter((w) => w.formMetadata.data !== null)
     .map((w) => {
       try {
-        const data = JSON.parse(w.formMetadata.data)
+        const data = merge(JSON.parse(w.formMetadata.data))
         const ui =
           w.formMetadata.ui !== null ? JSON.parse(w.formMetadata.ui) : {}
         return {

--- a/front/src/schemas/schemas.js
+++ b/front/src/schemas/schemas.js
@@ -1,0 +1,43 @@
+import { merge } from 'allof-merge'
+
+import blogPostSchema from './article-blog-post-metadata.schema.json'
+import blogPostUiSchema from './article-blog-post-ui-schema.json'
+import meetingNotesSchema from './article-meeting-notes-metadata.schema.json'
+import meetingNotesUiSchema from './article-meeting-notes-ui-schema.json'
+import defaultSchema from './article-metadata.schema.json'
+import defaultUiSchema from './article-ui-schema.json'
+
+const defaultSchemaMerged = merge(defaultSchema)
+const blogPostSchemaMerged = merge(blogPostSchema)
+const meetingNotesSchemaMerged = merge(meetingNotesSchema)
+
+export const ArticleSchemas = [
+  {
+    name: 'default',
+    data: defaultSchemaMerged,
+    const: getConstMetadata(defaultSchemaMerged),
+    ui: defaultUiSchema,
+  },
+  {
+    name: 'blog-post',
+    data: blogPostSchemaMerged,
+    const: getConstMetadata(blogPostSchemaMerged),
+    ui: blogPostUiSchema,
+  },
+  {
+    name: 'meeting-notes',
+    data: meetingNotesSchemaMerged,
+    const: getConstMetadata(meetingNotesSchemaMerged),
+    ui: meetingNotesUiSchema,
+  },
+]
+
+function getConstMetadata(schema) {
+  const props = schema.properties
+  return Object.entries(props)
+    .filter(([, value]) => value.const !== undefined)
+    .reduce(function (map, [key, val]) {
+      map[key] = val.const
+      return map
+    }, {})
+}

--- a/front/src/schemas/schemas.test.js
+++ b/front/src/schemas/schemas.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest'
+
+import { ArticleSchemas } from './schemas.js'
+
+describe('schemas', () => {
+  test('it has const metadata properties', () => {
+    const schema = ArticleSchemas.find((s) => s.name === 'default')
+    expect(schema.const).to.deep.equal({
+      type: 'article',
+      '@version': '1.0',
+    })
+  })
+})


### PR DESCRIPTION
- Déplace la logique dans un fichier schemas.js
- Ajout d'un test afin de vérifier la logique permettant d'extraire les constantes du JSON schéma
- Renseigne les constantes quand on change de type d'article

ref #1619