### PR TITLE
Affiche des premiers éléments de syntaxe Markdown en clic droit

### DIFF
--- a/front/src/components/collaborative/CollaborativeTextEditor.jsx
+++ b/front/src/components/collaborative/CollaborativeTextEditor.jsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { MonacoBinding } from 'y-monaco'
 
-import { MetopesMenu, actions, registerActions, Separator } from './actions'
+import { MarkdownMenu, MetopesMenu, actions, registerActions, Separator } from './actions'
 import { DiffEditor } from '@monaco-editor/react'
 import throttle from 'lodash.throttle'
 import 'monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon.css'
@@ -135,6 +135,7 @@ export default function CollaborativeTextEditor({
             ...originalMenuActions,
             new Separator(),
             MetopesMenu({ editor, t }),
+            MarkdownMenu({ editor, t }),
           ]
       }
 

--- a/front/src/components/collaborative/CollaborativeTextEditor.jsx
+++ b/front/src/components/collaborative/CollaborativeTextEditor.jsx
@@ -140,7 +140,8 @@ export default function CollaborativeTextEditor({
       }
 
       // Command Palette commands
-      registerActions(editor, t, actions)
+      registerActions(editor, t, actions.metopes)
+      registerActions(editor, t, actions.md, { palette: false })
 
       const completionProvider = bibliographyCompletionProvider.register(monaco)
       editor.onDidDispose(() => completionProvider.dispose())

--- a/front/src/components/collaborative/actions/delimited-block.js
+++ b/front/src/components/collaborative/actions/delimited-block.js
@@ -29,7 +29,7 @@ export default function createDelimitedBlockCommand(
   id,
   {
     label = undefined,
-    contextMenuGroupId = '1_infratextual_markup',
+    contextMenuGroupId = '1_modification',
     delimiters = ':::',
     separator = '\n\n',
     keybindings = undefined,
@@ -92,16 +92,10 @@ export default function createDelimitedBlockCommand(
     id: `stylo--infratextual-markup--${id}`,
     label: label ?? `actions.infratextual-block.${id}`,
     contextMenuGroupId,
-    keybindings: keybindings
-      ? [
-          KeyMod.chord(
-            // common to 'infratextual markup'
-            KeyMod.CtrlCmd | KeyCode.KeyI,
-            // specific to this item within the 'infratextual-markup' group
-            keybindings
-          ),
-        ]
-      : null,
+    contextMenuOrder: 1,
+    keybindingContext: null,
+    enabled: true,
+    keybindings,
     run,
   }
 }

--- a/front/src/components/collaborative/actions/delimited-block.js
+++ b/front/src/components/collaborative/actions/delimited-block.js
@@ -17,6 +17,7 @@ import { blockAttributes } from './index.js'
  * @param {object} opts
  * @param {string?} opts.label
  * @param {string?} opts.contextMenuGroupId
+ * @param {string?} opts.delimiters
  * @param {number?} opts.keybindings
  * @param {string?} opts.className
  * @param {{[key: string]: string}?} opts.attrs
@@ -29,6 +30,8 @@ export default function createDelimitedBlockCommand(
   {
     label = undefined,
     contextMenuGroupId = '1_infratextual_markup',
+    delimiters = ':::',
+    separator = '\n\n',
     keybindings = undefined,
     className = undefined,
     attrs = {},
@@ -55,7 +58,7 @@ export default function createDelimitedBlockCommand(
     const attributes = blockAttributes({ classNames: [className ?? id], attrs })
     const bodyParts = [body_pre, originalText, body_post].filter((d) => d)
 
-    const text = `::: {${attributes}}\n${bodyParts.join('\n\n')}\n:::\n\n`
+    const text = `${delimiters}${attributes}\n${bodyParts.join(separator)}\n${delimiters}\n\n`
     const LINE_RETURN_COUNT = text.matchAll('\n').length
 
     const isTextSelected =

--- a/front/src/components/collaborative/actions/index.js
+++ b/front/src/components/collaborative/actions/index.js
@@ -47,6 +47,36 @@ export const actions = {
   sponsor: createDelimitedBlockCommand('sponsor'),
 }
 
+/** @type {object.<string,IActionDescriptor>} */
+export const md = {
+  italic: createInlineBlockCommand('italic', {
+    attrs: null,
+    body_pre: '__',
+    body_post: '__',
+  }),
+  bold: createInlineBlockCommand('bold', {
+    attrs: null,
+    body_pre: '**',
+    body_post: '**',
+  }),
+  footnoteRef: createInlineBlockCommand('footnote-ref', {
+    attrs: null,
+    body_pre: '',
+    body_post: '[^x]',
+  }),
+  footnoteContent: createDelimitedBlockCommand('footnote-content', {
+    attrs: null,
+    body_pre: '[^x]: ',
+    delimiters: '',
+    separator: ' '
+  }),
+  hyperlink: createInlineBlockCommand('hyperlink', {
+    attrs: null,
+    body_pre: '[',
+    body_post: '](https://example.com)',
+  }),
+}
+
 /**
  * @typedef {import('monaco-editor').editor.IActionDescriptor} IActionDescriptor
  * @typedef {import('monaco-editor').editor.ICodeEditor} ICodeEditor
@@ -89,17 +119,24 @@ export function registerActions (editor, t, actions) {
  * @see https://pandoc.org/MANUAL.html#extension-inline_code_attributes
  * @param {object} attributes
  * @param {Array.<string>} attributes.classNames
- * @param {{[key: string]: string}} attributes.attrs
+ * @param {{[key: string]: string}?} attributes.attrs
  * @returns {string}
  */
 export function blockAttributes({ classNames = [], attrs = {} } = {}) {
-  return [
+  if (attrs === null || attrs === undefined) {
+    return ''
+  }
+
+  const parts = [
     classNames.map((c) => `.${c}`),
     Object.entries(attrs).map(([key, value]) => `${key}="${value}"`),
   ]
     .flatMap((d) => d)
     .filter((d) => d)
-    .join(' ')
+
+  if (parts.length) {
+    return `{${parts.join(' ')}}`
+  }
 }
 
 /**
@@ -146,6 +183,22 @@ export function MetopesMenu({ editor, t }) {
         _bindAction(actions.smallcaps),
       ]),
       _bindAction(actions.figure),
+    ]
+  )
+}
+
+export function MarkdownMenu ({ editor, t }) {
+  const _bindAction = bindAction.bind(null, editor, t)
+
+  return new SubmenuAction(
+    'stylo--markdown--root',
+    t('stylo.markdown.rootMenu'),
+    [
+      _bindAction(md.italic),
+      _bindAction(md.bold),
+      _bindAction(md.hyperlink),
+      _bindAction(md.footnoteRef),
+      _bindAction(md.footnoteContent),
     ]
   )
 }

--- a/front/src/components/collaborative/actions/index.js
+++ b/front/src/components/collaborative/actions/index.js
@@ -1,80 +1,83 @@
 import createDelimitedBlockCommand from './delimited-block.js'
 import createInlineBlockCommand from './inline-block.js'
-import {
-  Separator,
-  SubmenuAction,
-  toAction,
-} from 'monaco-editor/esm/vs/base/common/actions'
+import { SubmenuAction } from 'monaco-editor/esm/vs/base/common/actions'
 export { Separator } from 'monaco-editor/esm/vs/base/common/actions'
-import { KeyCode, KeyMod } from 'monaco-editor/esm/vs/editor/editor.api'
+import { editor as _editor, KeyCode, KeyMod } from 'monaco-editor/esm/vs/editor/editor.api'
 
-/** @type {object.<string,IActionDescriptor>} */
+/** @type {object.<string,object.<string, IActionDescriptor>>} */
 export const actions = {
-  acknowledgement: createDelimitedBlockCommand('ack', {
-    keybindings: KeyMod.CtrlCmd | KeyCode.KeyA,
-  }),
-  dedication: createDelimitedBlockCommand('dedi'),
-  endnote: createDelimitedBlockCommand('endnote'),
-  epigraph: createDelimitedBlockCommand('epigraph', {
-    body_pre: '[@source]',
-  }),
-  figure: createDelimitedBlockCommand('figure', {
-    body_pre: '\n[titre]{.head}\n\n![caption](image.png)',
-    body_post: ':::{.credits}\n[]{.credits} [@source]\n:::',
-  }),
-  inlinequote: createInlineBlockCommand('inlinequote'),
-  notepreAuthor: createDelimitedBlockCommand('notepre.aut', {
-    attrs: { origin: 'aut' },
-    className: 'notepre',
-  }),
-  noteprePublisher: createDelimitedBlockCommand('notepre.pb', {
-    attrs: { origin: 'pb' },
-    className: 'notepre',
-  }),
-  notepreTranslator: createDelimitedBlockCommand('notepre.tr', {
-    attrs: { origin: 'tr' },
-    className: 'notepre',
-  }),
-  question: createDelimitedBlockCommand('question', {
-    body_pre: '[nom de personne]{.speaker}',
-  }),
-  quoteAlt: createDelimitedBlockCommand('quote-alt'),
-  reponse: createDelimitedBlockCommand('answ', {
-    body_pre: '[nom de personne]{.speaker}',
-  }),
-  signature: createDelimitedBlockCommand('sig'),
-  smallcaps: createInlineBlockCommand('smallcaps'),
-  sponsor: createDelimitedBlockCommand('sponsor'),
-}
-
-/** @type {object.<string,IActionDescriptor>} */
-export const md = {
-  italic: createInlineBlockCommand('italic', {
-    attrs: null,
-    body_pre: '__',
-    body_post: '__',
-  }),
-  bold: createInlineBlockCommand('bold', {
-    attrs: null,
-    body_pre: '**',
-    body_post: '**',
-  }),
-  footnoteRef: createInlineBlockCommand('footnote-ref', {
-    attrs: null,
-    body_pre: '',
-    body_post: '[^x]',
-  }),
-  footnoteContent: createDelimitedBlockCommand('footnote-content', {
-    attrs: null,
-    body_pre: '[^x]: ',
-    delimiters: '',
-    separator: ' '
-  }),
-  hyperlink: createInlineBlockCommand('hyperlink', {
-    attrs: null,
-    body_pre: '[',
-    body_post: '](https://example.com)',
-  }),
+  md: {
+    italic: createInlineBlockCommand('italic', {
+      attrs: null,
+      body_pre: '__',
+      body_post: '__',
+      keybindings: [KeyMod.CtrlCmd | KeyCode.KeyI]
+    }),
+    bold: createInlineBlockCommand('bold', {
+      attrs: null,
+      body_pre: '**',
+      body_post: '**',
+      keybindings: [KeyMod.CtrlCmd | KeyCode.KeyB],
+    }),
+    footnoteRef: createInlineBlockCommand('footnote-ref', {
+      attrs: null,
+      body_pre: '',
+      body_post: '[^x]',
+      keybindings: [KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyF]
+    }),
+    footnoteContent: createDelimitedBlockCommand('footnote-content', {
+      attrs: null,
+      body_pre: '[^x]: ',
+      delimiters: '',
+      keybindings: [[KeyMod.CtrlCmd | KeyMod.Alt | KeyMod.Shift | KeyCode.KeyF]],
+      separator: ' '
+    }),
+    hyperlink: createInlineBlockCommand('hyperlink', {
+      attrs: null,
+      body_pre: '[',
+      body_post: '](https://example.com)',
+      keybindings: [KeyMod.CtrlCmd | KeyCode.KeyK]
+    }),
+  },
+  metopes: {
+    acknowledgement: createDelimitedBlockCommand('ack', {
+      keybindings: [KeyMod.chord(KeyMod.CtrlCmd | KeyCode.KeyM, KeyMod.CtrlCmd | KeyCode.KeyA)],
+    }),
+    dedication: createDelimitedBlockCommand('dedi'),
+    endnote: createDelimitedBlockCommand('endnote', {
+      keybindings: [KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyD]
+    }),
+    epigraph: createDelimitedBlockCommand('epigraph', {
+      body_pre: '[@source]',
+    }),
+    figure: createDelimitedBlockCommand('figure', {
+      body_pre: '\n[titre]{.head}\n\n![caption](image.png)',
+      body_post: ':::{.credits}\n[]{.credits} [@source]\n:::',
+    }),
+    inlinequote: createInlineBlockCommand('inlinequote'),
+    notepreAuthor: createDelimitedBlockCommand('notepre.aut', {
+      attrs: { origin: 'aut' },
+      className: 'notepre',
+    }),
+    noteprePublisher: createDelimitedBlockCommand('notepre.pb', {
+      attrs: { origin: 'pb' },
+      className: 'notepre',
+    }),
+    notepreTranslator: createDelimitedBlockCommand('notepre.tr', {
+      attrs: { origin: 'tr' },
+      className: 'notepre',
+    }),
+    question: createDelimitedBlockCommand('question', {
+      body_pre: '[nom de personne]{.speaker}',
+    }),
+    quoteAlt: createDelimitedBlockCommand('quote-alt'),
+    reponse: createDelimitedBlockCommand('answ', {
+      body_pre: '[nom de personne]{.speaker}',
+    }),
+    signature: createDelimitedBlockCommand('sig'),
+    smallcaps: createInlineBlockCommand('smallcaps'),
+    sponsor: createDelimitedBlockCommand('sponsor'),
+  },
 }
 
 /**
@@ -94,11 +97,12 @@ export const md = {
  * @returns {IActionDescriptor} bound action
  */
 export function bindAction(editor, t, action) {
-  return toAction({
+  return {
     ...action,
+    enabled: true,
     label: t(action.label),
     run: action.run.bind(null, editor),
-  })
+  }
 }
 
 /**
@@ -106,11 +110,30 @@ export function bindAction(editor, t, action) {
  *
  * @param {ICodeEditor} editor
  * @param {TFunction} t
+ * @param {object?} options
+ * @param {boolean} options.palette
+ * @param {boolean} options.shortcuts
  * @param {object.<string, IActionDescriptor>} actions
  */
-export function registerActions (editor, t, actions) {
+export function registerActions (editor, t, actions, { palette = true, shortcuts = true } = {}) {
   for (const action of Object.values(actions)) {
-    editor.addAction(bindAction(editor, t, action))
+    // adding an entry in the command palette also registers its keybinding
+    if (palette) {
+      editor.addAction(bindAction(editor, t, action))
+    }
+    else {
+      _editor.addCommand(bindAction(editor, t, action))
+    }
+
+    // adding the keybinding for the context menu
+    if (shortcuts && action.keybindings?.at(0)) {
+      _editor.addKeybindingRule(
+        {
+          keybinding: action.keybindings.at(0),
+          command: palette ? `${editor.getId()}:${action.id}` : action.id
+        }
+      )
+    }
   }
 }
 
@@ -158,31 +181,37 @@ export function MetopesMenu({ editor, t }) {
         'stylo--metopes--liminaires',
         t('stylo.metopes.liminaires'),
         [
-          _bindAction(actions.acknowledgement),
-          _bindAction(actions.epigraph),
-          _bindAction(actions.notepreAuthor),
-          _bindAction(actions.noteprePublisher),
-          _bindAction(actions.notepreTranslator),
-          _bindAction(actions.endnote),
-          _bindAction(actions.dedication),
-          _bindAction(actions.sponsor),
+          _bindAction(actions.metopes.acknowledgement),
+          _bindAction(actions.metopes.epigraph),
+          _bindAction(actions.metopes.notepreAuthor),
+          _bindAction(actions.metopes.noteprePublisher),
+          _bindAction(actions.metopes.notepreTranslator),
+          _bindAction(actions.metopes.endnote),
+          _bindAction(actions.metopes.dedication),
+          _bindAction(actions.metopes.sponsor),
         ]
       ),
       new SubmenuAction(
         'stylo--metopes--citations',
         t('stylo.metopes.citations'),
-        [_bindAction(actions.inlinequote), _bindAction(actions.quoteAlt)]
+        [
+          _bindAction(actions.metopes.inlinequote),
+          _bindAction(actions.metopes.quoteAlt)
+        ]
       ),
       new SubmenuAction('stylo--metopes--texte', t('stylo.metopes.texte'), [
         new SubmenuAction(
           'stylo--metopes--entretien',
           t('stylo.metopes.entretien'),
-          [_bindAction(actions.question), _bindAction(actions.reponse)]
+          [
+            _bindAction(actions.metopes.question),
+            _bindAction(actions.metopes.reponse)
+          ]
         ),
-        _bindAction(actions.signature),
-        _bindAction(actions.smallcaps),
+        _bindAction(actions.metopes.signature),
+        _bindAction(actions.metopes.smallcaps),
       ]),
-      _bindAction(actions.figure),
+      _bindAction(actions.metopes.figure),
     ]
   )
 }
@@ -194,11 +223,11 @@ export function MarkdownMenu ({ editor, t }) {
     'stylo--markdown--root',
     t('stylo.markdown.rootMenu'),
     [
-      _bindAction(md.italic),
-      _bindAction(md.bold),
-      _bindAction(md.hyperlink),
-      _bindAction(md.footnoteRef),
-      _bindAction(md.footnoteContent),
+      _bindAction(actions.md.italic),
+      _bindAction(actions.md.bold),
+      _bindAction(actions.md.hyperlink),
+      _bindAction(actions.md.footnoteRef),
+      _bindAction(actions.md.footnoteContent),
     ]
   )
 }

--- a/front/src/components/collaborative/actions/index.test.js
+++ b/front/src/components/collaborative/actions/index.test.js
@@ -4,17 +4,24 @@ import { describe, expect, test } from 'vitest'
 
 describe('blockAttributes', () => {
   test('works with a single className', () => {
-    expect(blockAttributes({ classNames: ['ack']})).toEqual('.ack')
+    expect(blockAttributes({ classNames: ['ack']})).toEqual('{.ack}')
   })
 
   test('works with a single attribute', () => {
-    expect(blockAttributes({ attrs: {origine: 'valeur'}})).toEqual('origine="valeur"')
+    expect(blockAttributes({ attrs: {origine: 'valeur'}})).toEqual('{origine="valeur"}')
   })
 
   test('works with a combination of both', () => {
     expect(blockAttributes({
       classNames: ['ack', 'sponsor'],
       attrs: { origine: 'valeur', lang: 'fr'}
-    })).toEqual('.ack .sponsor origine="valeur" lang="fr"')
+    })).toEqual('{.ack .sponsor origine="valeur" lang="fr"}')
+  })
+
+  test('returns nothing if attrs empty', () => {
+    expect(blockAttributes({
+      classNames: ['ack', 'sponsor'],
+      attrs: null
+    })).toEqual('')
   })
 })

--- a/front/src/components/collaborative/actions/inline-block.js
+++ b/front/src/components/collaborative/actions/inline-block.js
@@ -32,8 +32,8 @@ export default function createInlineBlockCommand(
     keybindings = undefined,
     className = undefined,
     attrs = {},
-    body_pre = '',
-    body_post = '',
+    body_pre = '[',
+    body_post = ']',
   } = {}
 ) {
   /**
@@ -51,11 +51,11 @@ export default function createInlineBlockCommand(
     )
 
     const originalText = editor.getModel().getValueInRange(range) || ''
-
     const attributes = blockAttributes({ classNames: [className ?? id], attrs })
+    console.log({ attributes, originalText })
     const bodyParts = [body_pre, originalText, body_post].filter((d) => d)
 
-    const text = `[${bodyParts.join(' ').trim()}]{${attributes}}`
+    const text = `${bodyParts.join('').trim()}${attributes}`
     const LINE_RETURN_COUNT = text.matchAll('\n').length
 
     const isTextSelected =
@@ -63,7 +63,7 @@ export default function createInlineBlockCommand(
     const newStartLineNumber = isTextSelected
       ? endLineNumber + LINE_RETURN_COUNT
       : startLineNumber + 1
-    const newColumn = 0
+    const newColumn = body_pre.length + 1
 
     editor.executeEdits(
       id,

--- a/front/src/locales/en/editor.json
+++ b/front/src/locales/en/editor.json
@@ -7,6 +7,7 @@
       "endnote": "$t(types.block) end note",
       "epigraph": "$t(types.block) epigraph",
       "figure": "$t(types.block) figure",
+      "footnote-content": "Footnote (text)",
       "notepre.aut": "$t(types.block) preliminary note from author",
       "notepre.pb": "$t(types.block) preliminary note from publisher",
       "notepre.tr": "$t(types.block) preliminary note from translator",
@@ -16,11 +17,18 @@
       "sponsor": "$t(types.block) sponsor"
     },
     "infratextual-inline": {
+      "bold": "Bold",
+      "footnote-ref": "Footnote (reference)",
+      "hyperlink": "Hyperlink",
       "inlinequote": "$t(types.inline) citation",
+      "italic": "Italic",
       "smallcaps": "$t(types.inline) small caps"
     }
   },
   "stylo": {
+    "markdown": {
+      "rootMenu": "Lightweight markup language"
+    },
     "metopes": {
       "citations": "Citations",
       "entretien": "Interviews",

--- a/front/src/locales/es/editor.json
+++ b/front/src/locales/es/editor.json
@@ -7,6 +7,7 @@
       "endnote": "$t(types.block) nota final",
       "epigraph": "$t(types.block) epígrafe",
       "figure": "$t(types.block) figura",
+      "footnote-content": "Nota al pie (texto)",
       "notepre.aut": "$t(types.block) nota preliminar del autor",
       "notepre.pb": "$t(types.block) nota preliminar del editor",
       "notepre.tr": "$t(types.block) nota preliminar del traductor",
@@ -16,11 +17,18 @@
       "sponsor": "$t(types.block) patrocinador"
     },
     "infratextual-inline": {
+      "bold": "Negrita",
+      "footnote-ref": "Nota al pie (referencia)",
+      "hyperlink": "Hipervínculo",
       "inlinequote": "$t(types.inline) cita",
+      "italic": "Cursiva",
       "smallcaps": "$t(types.inline) versalitas"
     }
   },
   "stylo": {
+    "markdown": {
+      "rootMenu": "Lenguaje de marcado ligero"
+    },
     "metopes": {
       "citations": "Citas",
       "entretien": "Entrevistas",

--- a/front/src/locales/fr/editor.json
+++ b/front/src/locales/fr/editor.json
@@ -7,6 +7,7 @@
       "endnote": "$t(types.block) note de fin",
       "epigraph": "$t(types.block) épigraphe",
       "figure": "$t(types.block) figure",
+      "footnote-content": "Pied de page (texte)",
       "notepre.aut": "$t(types.block) note préliminaire d'auteur·ice",
       "notepre.pb": "$t(types.block) note préliminaire d'éditeur·ice",
       "notepre.tr": "$t(types.block) note préliminaire de traducteur·ice",
@@ -16,11 +17,18 @@
       "sponsor": "$t(types.block) sponsor"
     },
     "infratextual-inline": {
+      "bold": "Gras",
+      "footnote-ref": "Pied de page (référence)",
+      "hyperlink": "Hyperlien",
       "inlinequote": "$t(types.inline) citation",
+      "italic": "Italique",
       "smallcaps": "$t(types.inline) petites capitales"
     }
   },
   "stylo": {
+    "markdown": {
+      "rootMenu": "Balisage léger"
+    },
     "metopes": {
       "citations": "Citations",
       "entretien": "Entretien",


### PR DESCRIPTION
<img width="761" height="308" alt="image" src="https://github.com/user-attachments/assets/f3f0747f-fae7-4d3f-a714-749d93aee3fd" />

Reste à faire : 

- [x] traduire les libellés
- [x] ajouter des raccourcis clavier

fixes #1682 
