### PR TITLE
Ajout de l'utilisateur stylo dans le groupe syslog

### DIFF
--- a/infrastructure/playbook.yml
+++ b/infrastructure/playbook.yml
@@ -107,6 +107,13 @@
         mode: "0775"
       when: site == "stylo.huma-num.fr"
 
+    - name: Add the user 'stylo' to the group 'syslog'
+      ansible.builtin.user:
+        name: stylo
+        shell: /bin/bash
+        groups: syslog
+        append: yes
+
     - name: Create a backup job (cron) that runs at midnight
       ansible.builtin.cron:
         name: "Backup data"


### PR DESCRIPTION
Le script de sauvegarde de la base de données lancé par l'utilisateur Stylo stocke des logs dans /var/log.

resolves #1693