### PR TITLE
Ajoute une liste des personnes responsables  dans un fichier CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+*                 @stylo/dev @stylo/coordo
+front/            @stylo/dev
+graphql/          @stylo/dev
+infrastructure/   @stylo/dev @stylo/infra
+
+docs/             @stylo/coordo @stylo/docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
-*                     @stylo/dev @stylo/coordo
+*                     @EcrituresNumeriques/stylo-dev @EcrituresNumeriques/stylo-coordo
 
-front/                @stylo/dev
-graphql/              @stylo/dev
-infrastructure/       @stylo/dev @stylo/infra
+front/                @EcrituresNumeriques/stylo-dev
+graphql/              @EcrituresNumeriques/stylo-dev
+infrastructure/       @EcrituresNumeriques/stylo-dev @EcrituresNumeriques/infra
 
-docker-compose*.yaml  @stylo/dev @stylo/export
+docker-compose*.yaml  @EcrituresNumeriques/stylo-dev @EcrituresNumeriques/stylo-export
 
-docs/                 @stylo/coordo @stylo/docs
+docs/                 @EcrituresNumeriques/coordo @EcrituresNumeriques/stylo-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
-*                 @stylo/dev @stylo/coordo
-front/            @stylo/dev
-graphql/          @stylo/dev
-infrastructure/   @stylo/dev @stylo/infra
+*                     @stylo/dev @stylo/coordo
 
-docs/             @stylo/coordo @stylo/docs
+front/                @stylo/dev
+graphql/              @stylo/dev
+infrastructure/       @stylo/dev @stylo/infra
+
+docker-compose*.yaml  @stylo/dev @stylo/export
+
+docs/                 @stylo/coordo @stylo/docs


### PR DESCRIPTION
Il faudrait créer 4 équipes : 
- `@EcrituresNumeriques/stylo-dev` (avec @ggrossetie et @thom4parisot)
- `@EcrituresNumeriques/stylo-export` (avec @davidbgk)
- `@EcrituresNumeriques/infra` (avec @ggrossetie et @thom4parisot et des personnes d'Huma-Num peut-être).
- `@EcrituresNumeriques/stylo-docs` (avec Clara, @victorchaix, @giuliaferretti12 et @loup-brun)

Et actualiser `@EcrituresNumeriques/coordo` pour inclure @giuliaferretti12, @gromettoclara et @marviro.

Probablement nettoyer/ajuster `@EcrituresNumeriques/Developers` et `@EcrituresNumeriques/admin` parce qu'il y a 16 personnes avec des droits de commits et pas mal qui ne sont plus à la Chaire/actives.