### PR TITLE
Retourne vide si les métadonnées sont null, undefined, vide

### DIFF
--- a/front/src/components/Write/metadata/yaml.js
+++ b/front/src/components/Write/metadata/yaml.js
@@ -2,10 +2,14 @@ import YAML from 'js-yaml'
 
 /**
  * Crée une copie de l'objet et supprime les valeurs vides/null/undefined.
- * @param object
- * @return {unknown|null} null si l'objet est vide, sinon l'objet sans les valeurs vides/null/undefined.
+ * @param {any} object
+ * @returns {unknown|null} null si l'objet est vide, sinon l'objet sans les valeurs vides/null/undefined.
  */
-function clean (object) {
+function clean(object) {
+  if (typeof object === 'string' && object === '') {
+    return null
+  }
+
   const objectCloned = structuredClone(object)
 
   if (objectCloned === null || objectCloned === undefined) {
@@ -24,7 +28,10 @@ function clean (object) {
     ) {
       delete objectCloned[propName]
     }
-    if (Array.isArray(objectCloned[propName]) && objectCloned[propName].length === 0) {
+    if (
+      Array.isArray(objectCloned[propName]) &&
+      objectCloned[propName].length === 0
+    ) {
       delete objectCloned[propName]
     }
     if (objectIsEmpty(objectCloned[propName])) {
@@ -36,19 +43,19 @@ function clean (object) {
 
 /**
  * Est-ce que l'objet est vide.
- * @param object
- * @return {boolean} vrai si l'objet est vide, sinon faux.
+ * @param {any} object
+ * @returns {boolean} vrai si l'objet est vide, sinon faux.
  */
-function objectIsEmpty (object) {
+function objectIsEmpty(object) {
   return typeof object === 'object' && Object.keys(object).length === 0
 }
 
 /**
  * Transforme un objet en YAML.
- * @param object
- * @return {string} une chaine vide si l'objet est vide, sinon la représentation YAML de l'objet.
+ * @param {any} object
+ * @returns {string} une chaine vide si l'objet est vide, sinon la représentation YAML de l'objet.
  */
-export function toYaml (object) {
+export function toYaml(object) {
   const output = clean(object)
   if (output === null) {
     return ''

--- a/front/src/components/Write/metadata/yaml.test.js
+++ b/front/src/components/Write/metadata/yaml.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest'
+
+import { toYaml } from './yaml.js'
+
+describe('YAML', () => {
+  test('it should convert an empty object', () => {
+    const result = toYaml({})
+
+    expect(result).toEqual('')
+  })
+  test('it should convert an empty string', () => {
+    const result = toYaml('')
+
+    expect(result).toEqual('')
+  })
+  test('it should convert null', () => {
+    const result = toYaml(null)
+
+    expect(result).toEqual('')
+  })
+  test('it should convert undefined', () => {
+    const result = toYaml(undefined)
+
+    expect(result).toEqual('')
+  })
+  test('it should remove empty properties', () => {
+    const result = toYaml({
+      title: null,
+      description: undefined,
+      abstract: '',
+      authors: [],
+      version: '1.0.0',
+    })
+
+    expect(result).toEqual(`---
+version: 1.0.0
+---`)
+  })
+})

--- a/front/src/hooks/corpus.js
+++ b/front/src/hooks/corpus.js
@@ -36,7 +36,7 @@ export function useCorpusActions() {
           description,
           type,
           workspace: workspaceId,
-          metadata: '',
+          metadata: {},
         },
       },
     })
@@ -80,7 +80,7 @@ export function useCorpusActions() {
             ...c,
             ...(title && { title }),
             ...(description && { description }),
-            ...(metadata && { metadata }),
+            ...(metadata !== undefined && { metadata }),
             updatedAt: new Date(),
           }
         } else {

--- a/graphql/resolvers/corpusResolver.js
+++ b/graphql/resolvers/corpusResolver.js
@@ -268,11 +268,7 @@ module.exports = {
         corpus.description = description
       }
       const metadata = updateCorpusInput.metadata
-      if (
-        metadata &&
-        typeof metadata === 'object' &&
-        !Array.isArray(metadata)
-      ) {
+      if (metadata !== undefined) {
         corpus.metadata = metadata
       }
       return await corpus.save()

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -377,7 +377,7 @@ input CreateCorpusInput {
   name: String!
   type: CorpusType!
   description: String
-  metadata: String
+  metadata: JSON
   workspace: String
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -381,7 +381,7 @@ input CreateArticleInput {
 
 input CreateCorpusInput {
   description: String
-  metadata: String
+  metadata: JSON
   name: String!
   type: CorpusType!
   workspace: String


### PR DESCRIPTION
Met à jour les métadonnées sauf si elles sont undefined. Crée un corpus avec `{}` comme valeur par défaut plutôt que `''`.