### PR TITLE
Une taille de police plus lisible

### DIFF
--- a/front/src/components/Write/ArticleMetadata.jsx
+++ b/front/src/components/Write/ArticleMetadata.jsx
@@ -133,8 +133,7 @@ export default function ArticleMetadata({ onBack, articleId, versionId }) {
           {error !== '' && <p className={styles.error}>{error}</p>}
           <MonacoYamlEditor
             readOnly={readOnly}
-            height="100%"
-            fontSize="14"
+            height="400px"
             text={metadataYaml}
             onTextUpdate={handleYamlChange}
           />

--- a/front/src/components/Write/providers/monaco/YamlEditor.jsx
+++ b/front/src/components/Write/providers/monaco/YamlEditor.jsx
@@ -21,6 +21,7 @@ export default function MonacoYamlEditor({
   const options = useMemo(
     () => ({
       ...defaultEditorOptions,
+      height,
       readOnly,
       fontSize,
       lineNumbers: false,

--- a/front/src/components/Write/providers/monaco/options.js
+++ b/front/src/components/Write/providers/monaco/options.js
@@ -5,7 +5,10 @@ export default {
    * Shown with Ctrl+Enter for example
    */
   contextmenu: false,
+  fontSize: 16,
   hideCursorInOverviewRuler: true,
+  insertSpaces: false,
+  lineHeight: 1.5,
   lineNumbers: true,
   minimap: {
     enabled: false,
@@ -18,6 +21,8 @@ export default {
   suggest: {
     showWords: false,
   },
+  // do not trap focus in the editor
+  tabFocusMode: true,
   wordWrap: 'on',
   wrappingIndent: 'none',
 }


### PR DESCRIPTION
Juste en spécifiant une taille de police.

On peut envisager de rendre la taille de police dynamique via des [boutons d'ajustement dans l'interface](https://app.studyraid.com/en/read/15534/540321/adjusting-monaco-font-settings-and-sizing) (genre "taille plus grande", "taille plus petite").

## Avant
<img width="1262" height="1258" alt="Screenshot 2025-11-27 at 18-05-10 Négentripie - Stylo" src="https://github.com/user-attachments/assets/d6efded8-60bd-417e-a0e5-82325b44aeb4" />

## Après
<img width="1262" height="1258" alt="Screenshot 2025-11-27 at 18-05-36 Négentripie - Stylo" src="https://github.com/user-attachments/assets/25d27a45-3450-4715-889a-e32189eb2e4d" />

refs #808

