### PR TITLE
mongoose ne permet plus de populate un path qui n'existe pas

### DIFF
--- a/graphql/app.js
+++ b/graphql/app.js
@@ -154,7 +154,7 @@ passport.use(localAuth.strategy)
 // mandatory for passport-login/logout
 passport.serializeUser((user, next) => next(null, user.id))
 passport.deserializeUser(async (id, next) => {
-  const user = await User.findById(id).populate({ path: 'permissions' })
+  const user = await User.findById(id)
   next(null, user)
 })
 


### PR DESCRIPTION
On avait un `populate` sur `permissions` mais `permissions` n'existe pas. La nouvelle version de mongoose est plus stricte et déclenche une exception.

resolves #1831