### PR TITLE
Met à jour uniquement les corpus et les espaces de travail associés à l'article supprimé

### DIFF
--- a/graphql/models/article.test.js
+++ b/graphql/models/article.test.js
@@ -1,0 +1,79 @@
+const Article = require('./article.js')
+const Corpus = require('./corpus.js')
+const User = require('./user.js')
+const Version = require('./version.js')
+const Workspace = require('./workspace.js')
+
+describe('remove', () => {
+  test('remove article', async () => {
+    // given
+    const user = await User.create({
+      email: 'a@example.com',
+    })
+    const chapter1 = await Article.create({
+      title: 'Chapter 1',
+      owner: user.id,
+      contributors: [],
+      versions: [],
+      tags: [],
+    })
+    const chapter1VersionId = await chapter1.createNewVersion({
+      mode: 'MAJOR',
+      user: user,
+    })
+    const chapter2 = await Article.create({
+      title: 'Chapter 2',
+      owner: user.id,
+      contributors: [],
+      versions: [],
+      tags: [],
+    })
+    const chapter2VersionId = await chapter2.createNewVersion({
+      mode: 'MAJOR',
+      user: user,
+    })
+    const corpus = await Corpus.create({
+      name: 'Thesis',
+      articles: [
+        {
+          article: chapter1.id,
+          order: 1,
+        },
+        {
+          article: chapter2.id,
+          order: 1,
+        },
+      ],
+      creator: user.id,
+    })
+    const workspace = await Workspace.create({
+      name: 'Workspace',
+      color: '#bb69ff',
+      members: [{ user: user.id }],
+      articles: [chapter1.id, chapter2.id],
+      creator: user.id,
+    })
+
+    // when
+    await chapter1.remove()
+
+    // then...
+    // chapter 1 must be removed from workspace
+    const w = await Workspace.findOne({ _id: workspace.id })
+    expect(w.articles).toHaveLength(1)
+    expect(w.articles[0].toString()).toStrictEqual(chapter2.id) // chapter 2 _must not_ be removed
+
+    // chapter 1 must be removed from corpus
+    const c = await Corpus.findOne({ _id: corpus.id })
+    expect(c.articles).toHaveLength(1)
+    expect(c.articles[0].article.toString()).toStrictEqual(chapter2.id) // chapter 2 _must not_ be removed
+
+    // chapter 1 version must be removed
+    const chapter1Version = await Version.findById(chapter1VersionId)
+    expect(chapter1Version).toBeNull()
+
+    // chapter 2 version _must not_ be removed
+    const chapter2Version = await Version.findById(chapter2VersionId)
+    expect(chapter2Version).not.toBeNull()
+  })
+})

--- a/graphql/models/corpus.js
+++ b/graphql/models/corpus.js
@@ -50,10 +50,31 @@ const corpusSchema = new Schema(
  * @param {import('./workspace')} [params.workspace]
  * @returns {mongoose.Collection<import('./corpus')>} corpuses
  */
-corpusSchema.statics.findByUser = function findCorpusByUser({ user, workspace = null }) {
-  return this
-    .find({ creator: user._id, workspace })
-    .sort([['updatedAt', -1]])
+corpusSchema.statics.findByUser = function findCorpusByUser({
+  user,
+  workspace = null,
+}) {
+  return this.find({ creator: user._id, workspace }).sort([['updatedAt', -1]])
+}
+
+/**
+ * Removes an article from all corpuses where it appears.
+ *
+ * @param articleId article unique identifier
+ * @returns {Promise<import('mongodb').UpdateResult<import('./corpus')>>}
+ */
+corpusSchema.statics.removeArticle = function removeArticle(articleId) {
+  return this.updateMany(
+    { 'articles.article': articleId },
+    {
+      $pull: {
+        articles: {
+          article: articleId,
+        },
+      },
+    },
+    { timestamps: true }
+  )
 }
 
 module.exports = mongoose.model('Corpus', corpusSchema)

--- a/graphql/models/tag.js
+++ b/graphql/models/tag.js
@@ -38,11 +38,7 @@ const tagSchema = new Schema(
  * @returns {mongoose.Collection} tags
  */
 tagSchema.statics.findByUser = function findTagByUser(user) {
-  return this
-    .find({ 'owner': user?._id })
-    .sort([
-      ['updatedAt', -1],
-    ])
+  return this.find({ owner: user?._id }).sort([['updatedAt', -1]])
 }
 
 // TODO: middleware name will change in future version of Mongoose

--- a/graphql/models/user.js
+++ b/graphql/models/user.js
@@ -71,13 +71,14 @@ const userSchema = new Schema(
       type: String,
       default: null,
       required: false,
-      set: (password) => password ? bcrypt.hashSync(password.trim(), 10) : null,
+      set: (password) =>
+        password ? bcrypt.hashSync(password.trim(), 10) : null,
     },
     firstName: String,
     lastName: String,
     institution: String,
     connectedAt: Date,
-    deletedAt: Date
+    deletedAt: Date,
   },
   { timestamps: true }
 )
@@ -137,7 +138,7 @@ userSchema.virtual('authTypes').get(function authTypes() {
   return Array.from(types)
 })
 
-userSchema.methods.softDelete =  async function softDeleteUser() {
+userSchema.methods.softDelete = async function softDeleteUser() {
   // generate a random/unguessable email because email is a unique index
   const email = `deleted-user-${randomUUID({ disableEntropyCache: true })}@example.com`
 

--- a/graphql/models/user.test.js
+++ b/graphql/models/user.test.js
@@ -57,21 +57,21 @@ describe('softDelete', () => {
 
     const ta1 = await Tag.create({
       name: 'User A tag #1',
-      owner: userA
+      owner: userA,
     })
     const ta2 = await Tag.create({
       name: 'User A tag #2',
-      owner: userA
+      owner: userA,
     })
     const tb1 = await Tag.create({
       name: 'User B tag',
-      owner: userB
+      owner: userB,
     })
 
     const articleA = await Article.create({
       title: 'User A article #1',
       owner: userA,
-      tags: [ta1, ta2]
+      tags: [ta1, ta2],
     })
 
     await articleA.createNewVersion({
@@ -111,22 +111,28 @@ describe('softDelete', () => {
       color: '#C00',
       creator: userB.id,
       articles: [articleA, articleB],
-      members: [{ user: userA }]
+      members: [{ user: userA }],
     })
 
     await Corpus.create({
       name: 'User B Corpus #1',
       description: 'because it is part of workspace which will be removed',
       creator: userB.id,
-      articles: [{ article: articleA.id, order: 1 }, { article: articleB.id, order: 2 }],
-      workspace: w1
+      articles: [
+        { article: articleA.id, order: 1 },
+        { article: articleB.id, order: 2 },
+      ],
+      workspace: w1,
     })
 
     await Corpus.create({
       name: 'User B Corpus #2',
       color: '#C00',
       creator: userB.id,
-      articles: [{ article: articleA.id, order: 1 }, { article: articleB.id, order: 2 }],
+      articles: [
+        { article: articleA.id, order: 1 },
+        { article: articleB.id, order: 2 },
+      ],
     })
 
     await userA.softDelete()
@@ -137,11 +143,13 @@ describe('softDelete', () => {
 
     expect(user).toHaveProperty('deletedAt', expect.any(Date))
     expect(user).toHaveProperty('password', null)
-    expect(user).toHaveProperty('email', expect.stringMatching(/^deleted-user-[a-f0-9-]+@example.com$/))
+    expect(user).toHaveProperty(
+      'email',
+      expect.stringMatching(/^deleted-user-[a-f0-9-]+@example.com$/)
+    )
 
-    return expect(await await User.find()).toHaveLength(2)
+    return expect(await User.find({})).toHaveLength(2)
   })
-
 
   test('articles should still be here', async () => {
     const articles = await Article.find()

--- a/graphql/models/version.js
+++ b/graphql/models/version.js
@@ -63,11 +63,7 @@ const versionSchema = new Schema(
  * @returns {mongoose.Collection} versions
  */
 versionSchema.statics.findByUser = function findVersionByUser(user) {
-  return this
-    .find({ 'owner': user?._id })
-    .sort([
-      ['updatedAt', -1],
-    ])
+  return this.find({ owner: user?._id }).sort([['updatedAt', -1]])
 }
 
 module.exports = mongoose.model('Version', versionSchema)

--- a/graphql/models/workspace.js
+++ b/graphql/models/workspace.js
@@ -51,11 +51,7 @@ const workspaceSchema = new Schema(
  * @returns {mongoose.Collection} workspaces
  */
 workspaceSchema.statics.findByUser = function findWorkspaceByUser(user) {
-  return this
-    .find({ 'members.user': user?._id })
-    .sort([
-      ['updatedAt', -1],
-    ])
+  return this.find({ 'members.user': user?._id }).sort([['updatedAt', -1]])
 }
 
 workspaceSchema.methods.findMembersByArticle =
@@ -88,6 +84,24 @@ workspaceSchema.statics.getWorkspaceById = function getWorkspaceById(
   return this.findOne({
     $and: [{ _id: workspaceId }, { 'members.user': user?._id }],
   })
+}
+
+/**
+ * Removes an article from all workspaces where it appears.
+ *
+ * @param articleId article unique identifier
+ * @returns {Promise<import('mongodb').UpdateResult<import('./workspace')>>}
+ */
+workspaceSchema.statics.removeArticle = function removeArticle(articleId) {
+  return this.updateMany(
+    { articles: articleId },
+    {
+      $pull: {
+        articles: articleId,
+      },
+    },
+    { timestamps: true }
+  )
 }
 
 module.exports = mongoose.model('Workspace', workspaceSchema)

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -389,36 +389,10 @@ module.exports = {
     /**
      * Delete an article.
      *
-     * @param {import('mongoose').Document} article
-     * @returns
+     * @param {import('mongoose').Document<ObjectId, any, Article>} article
+     * @returns {boolean} true if the article was deleted, false otherwise
      */
     async delete(article) {
-      // remove article from workspaces
-      await Workspace.updateMany(
-        {},
-        {
-          $pull: {
-            articles: article._id,
-          },
-        }
-      )
-      // remove article from corpus
-      await Corpus.updateMany(
-        {},
-        {
-          $pull: {
-            articles: {
-              article: article._id,
-            },
-          },
-        }
-      )
-      // remove article versions
-      const versions = article.versions
-      for (const version of versions) {
-        await Version.findByIdAndDelete(version)
-      }
-      // remove article!
       await article.remove()
       return article.$isDeleted()
     },

--- a/graphql/resolvers/articleResolver.test.js
+++ b/graphql/resolvers/articleResolver.test.js
@@ -98,7 +98,7 @@ describe('articles', () => {
     user: {},
     userId: null,
     token: {},
-    loaders: createLoaders()
+    loaders: createLoaders(),
   }
 
   beforeEach(async () => {
@@ -133,7 +133,7 @@ describe('articles', () => {
       color: '#f4a261',
       members: [
         {
-          user: user.id
+          user: user.id,
         },
       ],
       articles: [article.id],
@@ -157,7 +157,7 @@ describe('articles', () => {
 
   test('list user articles for a given workspace', async () => {
     const filter = {
-      workspaceId: workspace._id
+      workspaceId: workspace._id,
     }
     const articles = await ArticleQuery.articles({}, { filter }, context)
 
@@ -251,7 +251,6 @@ describe('duplicateArticle', () => {
   })
 })
 
-
 describe('deleteArticle', () => {
   let user
   const context = {
@@ -279,7 +278,7 @@ describe('deleteArticle', () => {
       md: '# Hello World',
       yaml: '',
       metadata: {},
-      bib: ''
+      bib: '',
     })
 
     const chapter2 = await Article.create({
@@ -324,12 +323,10 @@ describe('deleteArticle', () => {
     const chapter1After = await Article.findById(chapter1._id).exec()
     const chapter2After = await Article.findById(chapter2._id).exec()
 
-    expect(workspaceAfter.articles).toEqual([
-      chapter1._id
-    ])
-    expect(corpusAfter.articles.map(a => ({ article: a.article, order: a.order }))).toEqual([
-      { article: chapter1._id, order: 1 },
-    ])
+    expect(workspaceAfter.articles).toEqual([chapter1._id])
+    expect(
+      corpusAfter.articles.map((a) => ({ article: a.article, order: a.order }))
+    ).toEqual([{ article: chapter1._id, order: 1 }])
     expect(versionAfter).toBeNull()
     expect(chapter1After._id).toEqual(chapter1._id)
     expect(chapter2After).toBeNull()


### PR DESCRIPTION
#### Changements

- Déplace la logique de suppression de l'article des corpus et des espaces de travail dans le "model"
- Ajout d'un filtre sur `updateMany` afin de mettre à jour uniquement les corpus et les espaces de travail associés à l'article supprimé
- Ajout de l'option `{timestamps:  false}` afin de ne pas mettre à jour la date de dernière modification sur les corpus et les espaces de travail (à valider)
- Ajout d'un test sur la méthode `Article.remove`

resolves #1834 
