### PR TITLE
Décale l'interface de recherche Monaco afin de laisser de la place aux infos-bulles

### DIFF
--- a/front/src/components/molecules/modal.module.scss
+++ b/front/src/components/molecules/modal.module.scss
@@ -9,18 +9,6 @@ dialog::backdrop {
   body[data-scrolling='false'] {
     overflow: hidden;
   }
-
-  #root {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-  }
-
-  #content {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-  }
 }
 
 :root {

--- a/front/src/styles/general.scss
+++ b/front/src/styles/general.scss
@@ -213,3 +213,21 @@ select:disabled {
   height: 100%;
   box-sizing: border-box;
 }
+
+#root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+#content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+// otherwise tooltips overlap the buttons and flicker.
+// ref: https://github.com/EcrituresNumeriques/stylo/issues/1837
+.monaco-editor .find-widget {
+  right: 40px !important;
+}


### PR DESCRIPTION
Déplace les styles "globaux" dans `general.scss`.

resolves #1837 