### PR TITLE
Supprime le style explicite sur les paragraphes

### DIFF
--- a/front/src/styles/general.scss
+++ b/front/src/styles/general.scss
@@ -57,10 +57,6 @@ h6 {
   font-size: 1.067rem;
 }
 
-p {
-  font-size: 1rem;
-}
-
 small {
   font-size: 0.937rem;
 }


### PR DESCRIPTION
Permet d'avoir une taille de polices homogène sur l'interface d'annotation.

resolves #1840 