### PR TITLE
Utilise le runner Node pour lancer les tests unitaires

### DIFF
--- a/graphql/helpers/bibliography.test.js
+++ b/graphql/helpers/bibliography.test.js
@@ -1,9 +1,12 @@
 const { previewEntries } = require('./bibliography.js')
 
+const { describe, test } = require('node:test')
+const assert = require('node:assert')
+
 describe('previewEntries', () => {
   test('returns nothing if empty', () => {
-    expect(previewEntries('    \n')).toEqual('')
-    expect(previewEntries(null)).toEqual('')
+    assert.equal(previewEntries('    \n'), '')
+    assert.equal(previewEntries(null), '')
   })
 
   test('ignore invalid parts', () => {
@@ -18,7 +21,7 @@ describe('previewEntries', () => {
       title = {En finir avec {Word} ! {Pour} une analyse des enjeux relatifs aux traitements de texte et à leur utilisation}
     }`
 
-    expect(previewEntries(bib)).toEqual(expected)
+    assert.equal(previewEntries(bib), expected)
   })
 
   test('returns 2 different kinds when available', () => {
@@ -110,7 +113,7 @@ describe('previewEntries', () => {
       keywords = {Artificial intelligence, Biotechnology, Medical applications, Medical ethics, Moral and ethical aspects, Surgical robots},
     }`
 
-    expect(previewEntries(bib)).toEqual(expectation)
+    assert.equal(previewEntries(bib), expectation)
   })
 
   test('returns 1 kinds if no choice', () => {
@@ -149,7 +152,7 @@ describe('previewEntries', () => {
       journal = {MuseMedusa},
     }`
 
-    expect(previewEntries(bib)).toEqual(expectation)
+    assert.equal(previewEntries(bib), expectation)
   })
 
   test('limit to {count} entries', () => {
@@ -187,6 +190,6 @@ describe('previewEntries', () => {
       journal = {MuseMedusa},
     }`
 
-    expect(previewEntries(bib, 1)).toEqual(expectation)
+    assert.equal(previewEntries(bib, 1), expectation)
   })
 })

--- a/graphql/helpers/markdown.test.js
+++ b/graphql/helpers/markdown.test.js
@@ -1,5 +1,8 @@
 const { deriveToc } = require('./markdown.js')
 
+const { describe, test } = require('node:test')
+const assert = require('node:assert')
+
 describe('deriveToc', () => {
   const emptyText = ''
   const textWithOneHeadline = `
@@ -14,9 +17,10 @@ Well, and you?
 ### Level 3
 Not 2, not 4, but 3.`
   test('computeMajorVersion', () => {
-    expect(deriveToc(emptyText)).toEqual('')
-    expect(deriveToc(textWithOneHeadline)).toEqual('# Hello World')
-    expect(deriveToc(textWithManyHeadlines)).toEqual(
+    assert.equal(deriveToc(emptyText), '')
+    assert.equal(deriveToc(textWithOneHeadline), '# Hello World')
+    assert.equal(
+      deriveToc(textWithManyHeadlines),
       '# Hello World\n## How are you?\n### Level 3'
     )
   })

--- a/graphql/helpers/metadata.test.js
+++ b/graphql/helpers/metadata.test.js
@@ -5,8 +5,11 @@ const path = require('node:path')
 
 const inputFilename = path.join(__dirname, '__fixtures__', 'psp1515.input.yml')
 
+const { test } = require('node:test')
+const assert = require('node:assert')
+
 test('nocite always appears last', () => {
-  expect(
+  assert.equal(
     reformat(
       `---
 title: Stylo
@@ -15,21 +18,19 @@ subtitle: A user friendly text editor for humanities scholars.
 ---
 `,
       { id: 'abcd1234', replaceBibliography: true }
-    )
-  ).toMatchInlineSnapshot(`
-"---
+    ).trim(),
+    `---
 bibliography: "abcd1234.bib"
 subtitle: "A user friendly text editor for humanities scholars."
 title: "Stylo"
 title_f: "untitled"
 nocite: "@*"
----
-"
-`)
+---`
+  )
 })
 
 test('replace bibliography in YAML metadata', () => {
-  expect(
+  assert.equal(
     reformat(
       `---
 title: Stylo
@@ -42,9 +43,8 @@ authors:
 ---
 `,
       { id: 'abcd1234', replaceBibliography: true }
-    )
-  ).toMatchInlineSnapshot(`
-"---
+    ).trim(),
+    `---
 authors:
 - forname: "Marcello"
   orcid: "0000-0001-6424-3229"
@@ -53,13 +53,12 @@ bibliography: "abcd1234.bib"
 subtitle: "A user friendly text editor for humanities scholars."
 title: "Stylo"
 title_f: "untitled"
----
-"
-`)
+---`
+  )
 })
 
 test('year/month/day are derived from date', () => {
-  expect(
+  assert.equal(
     reformat(
       `---
 title: Stylo
@@ -67,20 +66,18 @@ date: '2021-02-25'
 ---
 `,
       { id: 'abcd1234' }
-    )
-  ).toMatchInlineSnapshot(`
-"---
+    ).trim(),
+    `---
 date: "2021/02/25"
 day: "25"
 month: "02"
 title: "Stylo"
 title_f: "untitled"
 year: "2021"
----
-"
-`)
+---`
+  )
 
-  expect(
+  assert.equal(
     reformat(
       `---
 title_f: Stylo
@@ -88,22 +85,20 @@ date: '2021/02/25'
 ---
 `,
       { id: 'abcd1234' }
-    )
-  ).toMatchInlineSnapshot(`
-"---
+    ).trim(),
+    `---
 date: "2021/02/25"
 day: "25"
 month: "02"
 title: "Stylo"
 title_f: "Stylo"
 year: "2021"
----
-"
-`)
+---`
+  )
 })
 
 test('replace XYZ_f fields by non-formatted XYZ field', () => {
-  expect(
+  assert.equal(
     reformat(
       `---
 title_f: "**Stylo**"
@@ -116,9 +111,8 @@ keywords:
     - null
 ---`,
       { id: 'abcd1234' }
-    )
-  ).toMatchInlineSnapshot(`
-"---
+    ).trim(),
+    `---
 keywords:
 - lang: "fr"
   list: "Tomme de Savoie, Comté"
@@ -127,13 +121,12 @@ subtitle: "T'as pas froid aux yeux ?"
 subtitle_f: "T'as pas _froid_ aux yeux ?"
 title: "Stylo"
 title_f: "**Stylo**"
----
-"
-`)
+---`
+  )
 })
 
 test('old/string based keywords[x].list_f are unformatted', () => {
-  expect(
+  assert.equal(
     reformat(
       `---
 title_f: "Stylo"
@@ -142,52 +135,52 @@ keywords:
   list_f: '**Tomme de Savoie**,Comté'
 ---`,
       { id: 'abcd1234' }
-    )
-  ).toMatchInlineSnapshot(`
-"---
+    ).trim(),
+    `---
 keywords:
 - lang: "fr"
   list: "Tomme de Savoie,Comté"
   list_f: "**Tomme de Savoie**,Comté"
 title: "Stylo"
 title_f: "Stylo"
----
-"
-`)
+---`
+  )
 })
 
 test('should return empty if YAML is empty', () => {
-  expect(reformat('', { id: 'abcd1234' })).toBe('')
+  assert.equal(reformat('', { id: 'abcd1234' }), '')
 })
 
 test('should return empty if YAML is blank', () => {
-  expect(reformat(' ', { id: 'abcd1234' })).toBe('')
+  assert.equal(reformat(' ', { id: 'abcd1234' }), '')
 })
 
 test('should return empty if YAML is undefined', () => {
-  expect(reformat(undefined, { id: 'abcd1234' })).toBe('')
+  assert.equal(reformat(undefined, { id: 'abcd1234' }), '')
 })
 
 test('should return empty if YAML is null', () => {
-  expect(reformat(null, { id: 'abcd1234' })).toBe('')
+  assert.equal(reformat(null, { id: 'abcd1234' }), '')
 })
 
 test('should return empty if YAML is invalid', () => {
-  expect(
+  assert.equal(
     reformat(
       `---
 \foo:---
 - bar:;`,
       { id: 'abcd1234' }
-    )
-  ).toBe('')
+    ),
+    ''
+  )
 })
 
 test('should be identical', async () => {
   const input = await fs.readFile(inputFilename, 'utf8')
 
-  expect(reformat(input, { id: 'abcd1234' })).toMatchInlineSnapshot(`
-"---
+  assert.equal(
+    reformat(input, { id: 'abcd1234' }).trim(),
+    `---
 abstract:
 - lang: "fr"
   text: "Le Groupe d’études sur le néolibéralisme et les alternatives (GENA) a organisé au Conservatoire national des Arts et Métiers (CNAM) un colloque franco-brésilien à Paris le mercredi\\_20\\_mars et le jeudi\\_21\\_mars 2019 intitulé «\\_La crise de la démocratie et le néolibéralisme à la lumière de la situation brésilienne\\_». C’est pour l’essentiel le contenu des contributions à ce colloque que vous allez lire dans ce dossier.\\n"
@@ -269,9 +262,8 @@ typeArticle:
 - "Sommaire dossier"
 url_article: "/articles/1515"
 year: "2020"
----
-"
-`)
+---`
+  )
 })
 
 test('should convert to legacy format', async () => {
@@ -283,136 +275,124 @@ test('should convert to legacy format', async () => {
 
   const input = JSON.parse(await fs.readFile(inputFilename, 'utf8'))
   const actual = toLegacyFormat(input)
-  expect(actual).toMatchInlineSnapshot(`
-{
-  "@version": "1.0",
-  "abstract": [
-    {
-      "lang": "en",
-      "text_f": "This article examines how three contemporary television series appropriate the utopian post-humanist visions of life after death in a virtual universe made possible by “mind uploading”, a technology that does not currently exist but is the subject of much discussion and projection.",
+  assert.deepEqual(actual, {
+    '@version': '1.0',
+    abstract: [
+      {
+        lang: 'en',
+        text_f:
+          'This article examines how three contemporary television series appropriate the utopian post-humanist visions of life after death in a virtual universe made possible by “mind uploading”, a technology that does not currently exist but is the subject of much discussion and projection.',
+      },
+      {
+        lang: 'fr',
+        text_f:
+          'Cet article se penche sur l’appropriation par trois séries télévisées contemporaines des visions utopiques post-humanistes de la vie après la mort dans un univers virtuel grâce au « téléchargement de conscience », une technologie actuellement inexistante, mais faisant l’objet de nombreuses discussions et projections.',
+      },
+    ],
+    acknowledgements: 'Merci à tous !',
+    articleslies: undefined,
+    authors: [
+      {
+        affiliations: 'aff',
+        biography: 'bio',
+        email: 'courriel',
+        foaf: 'foaf',
+        forname: 'Sylvaine',
+        isni: 'isni',
+        orcid: '0000-0001-6424-3229',
+        surname: 'Bataille',
+        viaf: 'viaf',
+        wikidata: 'wikidata',
+      },
+    ],
+    controlledKeywords: [
+      {
+        idRameau: '',
+        label: 'F# (langage de programmation)',
+        uriRameau: 'http://data.bnf.fr/ark:/12148/cb16191752f',
+      },
+    ],
+    date: '2024-05-28',
+    diffnum: 'Sens Public Web Publishing',
+    director: [
+      {
+        forname: 'Marcello',
+        surname: 'Vitali-Rosati',
+      },
+    ],
+    dossier: [
+      {
+        id: '1710',
+        title_f:
+          'L’œuvre numérique à son miroir : regards sur les créations digitales contemporaines',
+      },
+    ],
+    funder: {
+      funder_id: '',
+      funder_name: 'Université de Montréal',
     },
-    {
-      "lang": "fr",
-      "text_f": "Cet article se penche sur l’appropriation par trois séries télévisées contemporaines des visions utopiques post-humanistes de la vie après la mort dans un univers virtuel grâce au « téléchargement de conscience », une technologie actuellement inexistante, mais faisant l’objet de nombreuses discussions et projections.",
-    },
-  ],
-  "acknowledgements": "Merci à tous !",
-  "articleslies": undefined,
-  "authors": [
-    {
-      "affiliations": "aff",
-      "biography": "bio",
-      "email": "courriel",
-      "foaf": "foaf",
-      "forname": "Sylvaine",
-      "isni": "isni",
-      "orcid": "0000-0001-6424-3229",
-      "surname": "Bataille",
-      "viaf": "viaf",
-      "wikidata": "wikidata",
-    },
-  ],
-  "controlledKeywords": [
-    {
-      "idRameau": "",
-      "label": "F# (langage de programmation)",
-      "uriRameau": "http://data.bnf.fr/ark:/12148/cb16191752f",
-    },
-  ],
-  "date": "2024-05-28",
-  "diffnum": "Sens Public Web Publishing",
-  "director": [
-    {
-      "forname": "Marcello",
-      "surname": "Vitali-Rosati",
-    },
-  ],
-  "dossier": [
-    {
-      "id": "1710",
-      "title_f": "L’œuvre numérique à son miroir : regards sur les créations digitales contemporaines",
-    },
-  ],
-  "funder": {
-    "funder_id": "",
-    "funder_name": "Université de Montréal",
-  },
-  "id": "SP1711",
-  "issnnum": "2104-3272",
-  "issueDirectors": [
-    {
-      "forname": "Tony",
-      "surname": "Gheeraert",
-    },
-    {
-      "forname": "Mélanie",
-      "surname": "Lucciano",
-    },
-    {
-      "forname": "Sandra",
-      "surname": "Provini",
-    },
-  ],
-  "journal": "Sens Public",
-  "journal_email": "redaction@sens-public.org",
-  "journal_issue": "2024.8",
-  "keywords": [
-    {
-      "lang": "fr",
-      "list_f": [
-        "Arts et lettres",
-        "Cinéma",
-        "Fiction",
-      ],
-    },
-    {
-      "lang": "en",
-      "list_f": [
-        "Cinema",
-        "Fiction",
-        "Narrative",
-      ],
-    },
-  ],
-  "lang": "fr",
-  "prod": "Sens Public Prod",
-  "prodnum": "Sens Public Web Prod",
-  "publisher": "Sens Public Publishing",
-  "reviewers": [
-    {
-      "forname": "McCage",
-      "surname": "Griffiths",
-    },
-  ],
-  "rights": "CC BY-SA 4.0",
-  "subtitle_f": "Téléchargement de conscience, réflexivité et ré-enchantement de la technologie dans trois fictions sérielles anglophones",
-  "title_f": "Uploaded to the cloud… Sounds like heaven!",
-  "transcribers": undefined,
-  "translatedTitle": [
-    {
-      "lang": "en",
-      "text_f": undefined,
-    },
-  ],
-  "translationOf": [
-    undefined,
-  ],
-  "translations": undefined,
-  "translator": [
-    {
-      "forname": "Shaun",
-      "surname": "Nicks",
-    },
-  ],
-  "type": "article",
-  "typeArticle": [
-    "Essai",
-    "Entretien",
-    "Chronique",
-  ],
-  "url_article": "https://sens-public.org/articles/1711/",
-}
-`)
+    id: 'SP1711',
+    issnnum: '2104-3272',
+    issueDirectors: [
+      {
+        forname: 'Tony',
+        surname: 'Gheeraert',
+      },
+      {
+        forname: 'Mélanie',
+        surname: 'Lucciano',
+      },
+      {
+        forname: 'Sandra',
+        surname: 'Provini',
+      },
+    ],
+    journal: 'Sens Public',
+    journal_email: 'redaction@sens-public.org',
+    journal_issue: '2024.8',
+    keywords: [
+      {
+        lang: 'fr',
+        list_f: ['Arts et lettres', 'Cinéma', 'Fiction'],
+      },
+      {
+        lang: 'en',
+        list_f: ['Cinema', 'Fiction', 'Narrative'],
+      },
+    ],
+    lang: 'fr',
+    prod: 'Sens Public Prod',
+    prodnum: 'Sens Public Web Prod',
+    publisher: 'Sens Public Publishing',
+    reviewers: [
+      {
+        forname: 'McCage',
+        surname: 'Griffiths',
+      },
+    ],
+    rights: 'CC BY-SA 4.0',
+    subtitle_f:
+      'Téléchargement de conscience, réflexivité et ré-enchantement de la technologie dans trois fictions sérielles anglophones',
+    title_f: 'Uploaded to the cloud… Sounds like heaven!',
+    transcribers: undefined,
+    translatedTitle: [
+      {
+        lang: 'en',
+        text_f: undefined,
+      },
+    ],
+    translationOf: [undefined],
+    translations: undefined,
+    translator: [
+      {
+        forname: 'Shaun',
+        surname: 'Nicks',
+      },
+    ],
+    type: 'article',
+    typeArticle: ['Essai', 'Entretien', 'Chronique'],
+    url_article: 'https://sens-public.org/articles/1711/',
+  })
 })
 
 test('should convert from legacy format', async () => {
@@ -424,136 +404,126 @@ test('should convert from legacy format', async () => {
 
   const input = JSON.parse(await fs.readFile(inputFilename, 'utf8'))
   const actual = fromLegacyFormat(input)
-  expect(actual).toMatchInlineSnapshot(`
-{
-  "@version": "1.0",
-  "abstract": "Cet article se penche sur l’appropriation par trois séries télévisées contemporaines des visions utopiques post-humanistes de la vie après la mort dans un univers virtuel grâce au « téléchargement de conscience », une technologie actuellement inexistante, mais faisant l’objet de nombreuses discussions et projections.",
-  "acknowledgements": "Merci à tous !",
-  "authors": [
-    {
-      "affiliations": "aff",
-      "biography": "bio",
-      "email": "courriel",
-      "foaf": "foaf",
-      "forename": "Sylvaine",
-      "isni": "isni",
-      "orcid": "0000-0001-6424-3229",
-      "surname": "Bataille",
-      "viaf": "viaf",
-      "wikidata": "wikidata",
+  assert.deepEqual(actual, {
+    '@version': '1.0',
+    abstract:
+      'Cet article se penche sur l’appropriation par trois séries télévisées contemporaines des visions utopiques post-humanistes de la vie après la mort dans un univers virtuel grâce au « téléchargement de conscience », une technologie actuellement inexistante, mais faisant l’objet de nombreuses discussions et projections.',
+    acknowledgements: 'Merci à tous !',
+    authors: [
+      {
+        affiliations: 'aff',
+        biography: 'bio',
+        email: 'courriel',
+        foaf: 'foaf',
+        forename: 'Sylvaine',
+        isni: 'isni',
+        orcid: '0000-0001-6424-3229',
+        surname: 'Bataille',
+        viaf: 'viaf',
+        wikidata: 'wikidata',
+      },
+    ],
+    controlledKeywords: [
+      {
+        idRameau: '',
+        label: 'F# (langage de programmation)',
+        uriRameau: 'http://data.bnf.fr/ark:/12148/cb16191752f',
+      },
+    ],
+    funder: {
+      id: '',
+      organization: 'Université de Montréal',
     },
-  ],
-  "controlledKeywords": [
-    {
-      "idRameau": "",
-      "label": "F# (langage de programmation)",
-      "uriRameau": "http://data.bnf.fr/ark:/12148/cb16191752f",
+    id: 'SP1711',
+    issue: {
+      identifier: '1710',
+      number: '2024.8',
+      title:
+        'L’œuvre numérique à son miroir : regards sur les créations digitales contemporaines',
     },
-  ],
-  "funder": {
-    "id": "",
-    "organization": "Université de Montréal",
-  },
-  "id": "SP1711",
-  "issue": {
-    "identifier": "1710",
-    "number": "2024.8",
-    "title": "L’œuvre numérique à son miroir : regards sur les créations digitales contemporaines",
-  },
-  "issueDirectors": [
-    {
-      "forename": "Tony",
-      "surname": "Gheeraert",
+    issueDirectors: [
+      {
+        forename: 'Tony',
+        surname: 'Gheeraert',
+      },
+      {
+        forename: 'Mélanie',
+        surname: 'Lucciano',
+      },
+      {
+        forename: 'Sandra',
+        surname: 'Provini',
+      },
+    ],
+    journal: {
+      email: 'redaction@sens-public.org',
+      name: 'Sens Public',
+      publisher: 'Sens Public Publishing',
+      url: undefined,
     },
-    {
-      "forename": "Mélanie",
-      "surname": "Lucciano",
-    },
-    {
-      "forename": "Sandra",
-      "surname": "Provini",
-    },
-  ],
-  "journal": {
-    "email": "redaction@sens-public.org",
-    "name": "Sens Public",
-    "publisher": "Sens Public Publishing",
-    "url": undefined,
-  },
-  "journalDirectors": [
-    {
-      "forename": "Marcello",
-      "surname": "Vitali-Rosati",
-    },
-  ],
-  "keywords": [
-    "Arts et lettres",
-    "Cinéma",
-    "Fiction",
-  ],
-  "lang": "fr",
-  "license": "CC BY-SA 4.0",
-  "localizedContent": [
-    {
-      "abstract": "This article examines how three contemporary television series appropriate the utopian post-humanist visions of life after death in a virtual universe made possible by “mind uploading”, a technology that does not currently exist but is the subject of much discussion and projection.",
-      "keywords": [
-        "Cinema",
-        "Fiction",
-        "Narrative",
+    journalDirectors: [
+      {
+        forename: 'Marcello',
+        surname: 'Vitali-Rosati',
+      },
+    ],
+    keywords: ['Arts et lettres', 'Cinéma', 'Fiction'],
+    lang: 'fr',
+    license: 'CC BY-SA 4.0',
+    localizedContent: [
+      {
+        abstract:
+          'This article examines how three contemporary television series appropriate the utopian post-humanist visions of life after death in a virtual universe made possible by “mind uploading”, a technology that does not currently exist but is the subject of much discussion and projection.',
+        keywords: ['Cinema', 'Fiction', 'Narrative'],
+        lang: 'en',
+        title: undefined,
+      },
+    ],
+    production: {
+      entities: [
+        {
+          media: '',
+          name: 'Sens Public Prod',
+          type: 'producer',
+        },
+        {
+          media: 'digital',
+          name: 'Sens Public Web Prod',
+          type: 'producer',
+        },
+        {
+          media: 'digital',
+          name: 'Sens Public Web Publishing',
+          type: 'publisher',
+        },
       ],
-      "lang": "en",
-      "title": undefined,
+      issn: '2104-3272',
     },
-  ],
-  "production": {
-    "entities": [
+    publicationDate: '2024-05-28',
+    reviewers: [
       {
-        "media": "",
-        "name": "Sens Public Prod",
-        "type": "producer",
-      },
-      {
-        "media": "digital",
-        "name": "Sens Public Web Prod",
-        "type": "producer",
-      },
-      {
-        "media": "digital",
-        "name": "Sens Public Web Publishing",
-        "type": "publisher",
+        forename: 'McCage',
+        surname: 'Griffiths',
       },
     ],
-    "issn": "2104-3272",
-  },
-  "publicationDate": "2024-05-28",
-  "reviewers": [
-    {
-      "forename": "McCage",
-      "surname": "Griffiths",
+    senspublic: {
+      categories: ['Essai', 'Entretien', 'Chronique'],
+      linkedArticles: undefined,
+      translations: undefined,
     },
-  ],
-  "senspublic": {
-    "categories": [
-      "Essai",
-      "Entretien",
-      "Chronique",
+    subtitle:
+      'Téléchargement de conscience, réflexivité et ré-enchantement de la technologie dans trois fictions sérielles anglophones',
+    title: 'Uploaded to the cloud… Sounds like heaven!',
+    transcribers: undefined,
+    translators: [
+      {
+        forename: 'Shaun',
+        surname: 'Nicks',
+      },
     ],
-    "linkedArticles": undefined,
-    "translations": undefined,
-  },
-  "subtitle": "Téléchargement de conscience, réflexivité et ré-enchantement de la technologie dans trois fictions sérielles anglophones",
-  "title": "Uploaded to the cloud… Sounds like heaven!",
-  "transcribers": undefined,
-  "translators": [
-    {
-      "forename": "Shaun",
-      "surname": "Nicks",
-    },
-  ],
-  "type": "article",
-  "url": "https://sens-public.org/articles/1711/",
-}
-`)
+    type: 'article',
+    url: 'https://sens-public.org/articles/1711/',
+  })
 })
 
 test('should not throw an exception when converting legacy keywords', async () => {

--- a/graphql/helpers/preview.test.js
+++ b/graphql/helpers/preview.test.js
@@ -1,5 +1,8 @@
 const { prefixRulesWith, sanitizeTemplate } = require('./preview.js')
 
+const { describe, test } = require('node:test')
+const assert = require('node:assert')
+
 describe('prefixRulesWith', () => {
   const sample = `@page {
     size: 8.5in 11in;
@@ -60,40 +63,48 @@ section { break-before: right; }
   const transformedCss = prefixRulesWith('stylo-pagedjs-container', sample)
 
   test('works with empty input', () => {
-    expect(prefixRulesWith('stylo-pagedjs-container', '')).toEqual('')
+    assert.equal(prefixRulesWith('stylo-pagedjs-container', ''), '')
   })
 
   test('skip non rules', () => {
-    expect(transformedCss).toMatch(
-      '@page{size:8.5in 11in;margin:20mm 25mm;@footnote{'
+    assert.match(
+      transformedCss,
+      /@page\{size:8.5in 11in;margin:20mm 25mm;@footnote{/
     )
-    expect(transformedCss).toMatch(
-      '@page :left{margin:20mm 40mm 20mm 30mm;@top-left{'
+    assert.match(
+      transformedCss,
+      /@page :left\{margin:20mm 40mm 20mm 30mm;@top-left{/
     )
-    expect(transformedCss).toMatch(
-      '@font-face{font-family:"Stix";font-weight:normal;font-style:normal}'
+    assert.match(
+      transformedCss,
+      /@font-face\{font-family:"Stix";font-weight:normal;font-style:normal}/
     )
   })
 
   test('prefix adequate rules', () => {
-    expect(transformedCss).toMatch('}:root{--red: #f00}')
-    expect(transformedCss).toMatch(
-      '}.stylo-pagedjs-container h1{string-set:booktitle content(text)}'
+    assert.match(transformedCss, /}:root\{--red: #f00}/)
+    assert.match(
+      transformedCss,
+      /}.stylo-pagedjs-container h1\{string-set:booktitle content\(text\)}/
     )
-    expect(transformedCss).toMatch(
-      '}.stylo-pagedjs-container section{break-before:right}'
+    assert.match(
+      transformedCss,
+      /}.stylo-pagedjs-container section\{break-before:right}/
     )
-    expect(transformedCss).toMatch(
-      '}.stylo-pagedjs-container .copyright-rw{padding:0}'
+    assert.match(
+      transformedCss,
+      /}.stylo-pagedjs-container .copyright-rw\{padding:0}/
     )
-    expect(transformedCss).toMatch(
-      '{.stylo-pagedjs-container p{font-family:sans-serif}'
+    assert.match(
+      transformedCss,
+      /{.stylo-pagedjs-container p\{font-family:sans-serif}/
     )
   })
 
   test('substitute body with selectorName', () => {
-    expect(transformedCss).toMatch(
-      '}.stylo-pagedjs-container{font:Stix,sans-serif}'
+    assert.match(
+      transformedCss,
+      /}.stylo-pagedjs-container\{font:Stix,sans-serif}/
     )
   })
 })
@@ -113,6 +124,6 @@ describe('sanitizeTemplate', () => {
   test('returns the body innerHTML with sanitized tags', () => {
     const safeHtml = sanitizeTemplate(html)
 
-    expect(safeHtml).toMatch(/^\s+<h1>Coucou<\/h1>\n\s+<h2>Sous-titre<\/h2>/)
+    assert.match(safeHtml, /^\s+<h1>Coucou<\/h1>\n\s+<h2>Sous-titre<\/h2>/)
   })
 })

--- a/graphql/helpers/versions.test.js
+++ b/graphql/helpers/versions.test.js
@@ -1,33 +1,42 @@
 const { computeMajorVersion, computeMinorVersion } = require('./versions.js')
 
+const { describe, test } = require('node:test')
+const assert = require('node:assert')
+
 describe('computeVersion', () => {
   test('computeMajorVersion', () => {
-    expect(computeMajorVersion(undefined)).toEqual({ version: 1, revision: 0 })
-    expect(computeMajorVersion({ version: 0, revision: 0 })).toEqual({
+    assert.deepEqual(computeMajorVersion(undefined), {
       version: 1,
       revision: 0,
     })
-    expect(computeMajorVersion({ version: 1, revision: 0 })).toEqual({
+    assert.deepEqual(computeMajorVersion({ version: 0, revision: 0 }), {
+      version: 1,
+      revision: 0,
+    })
+    assert.deepEqual(computeMajorVersion({ version: 1, revision: 0 }), {
       version: 2,
       revision: 0,
     })
-    expect(computeMajorVersion({ version: 1, revision: 9 })).toEqual({
+    assert.deepEqual(computeMajorVersion({ version: 1, revision: 9 }), {
       version: 2,
       revision: 0,
     })
   })
 
   test('computeMinorVersion', () => {
-    expect(computeMinorVersion(undefined)).toEqual({ version: 0, revision: 1 })
-    expect(computeMinorVersion({ version: 0, revision: 0 })).toEqual({
+    assert.deepEqual(computeMinorVersion(undefined), {
       version: 0,
       revision: 1,
     })
-    expect(computeMinorVersion({ version: 1, revision: 0 })).toEqual({
+    assert.deepEqual(computeMinorVersion({ version: 0, revision: 0 }), {
+      version: 0,
+      revision: 1,
+    })
+    assert.deepEqual(computeMinorVersion({ version: 1, revision: 0 }), {
       version: 1,
       revision: 1,
     })
-    expect(computeMinorVersion({ version: 1, revision: 9 })).toEqual({
+    assert.deepEqual(computeMinorVersion({ version: 1, revision: 9 }), {
       version: 1,
       revision: 10,
     })

--- a/graphql/jest.config.js
+++ b/graphql/jest.config.js
@@ -11,4 +11,5 @@ module.exports = {
   watchPathIgnorePatterns: ['globalConfig'],
 
   setupFilesAfterEnv: ['./tests/setup-db.js'],
+  modulePathIgnorePatterns: ['helpers'],
 }

--- a/graphql/models/user.test.js
+++ b/graphql/models/user.test.js
@@ -57,21 +57,21 @@ describe('softDelete', () => {
 
     const ta1 = await Tag.create({
       name: 'User A tag #1',
-      owner: userA
+      owner: userA,
     })
     const ta2 = await Tag.create({
       name: 'User A tag #2',
-      owner: userA
+      owner: userA,
     })
     const tb1 = await Tag.create({
       name: 'User B tag',
-      owner: userB
+      owner: userB,
     })
 
     const articleA = await Article.create({
       title: 'User A article #1',
       owner: userA,
-      tags: [ta1, ta2]
+      tags: [ta1, ta2],
     })
 
     await articleA.createNewVersion({
@@ -111,22 +111,28 @@ describe('softDelete', () => {
       color: '#C00',
       creator: userB.id,
       articles: [articleA, articleB],
-      members: [{ user: userA }]
+      members: [{ user: userA }],
     })
 
     await Corpus.create({
       name: 'User B Corpus #1',
       description: 'because it is part of workspace which will be removed',
       creator: userB.id,
-      articles: [{ article: articleA.id, order: 1 }, { article: articleB.id, order: 2 }],
-      workspace: w1
+      articles: [
+        { article: articleA.id, order: 1 },
+        { article: articleB.id, order: 2 },
+      ],
+      workspace: w1,
     })
 
     await Corpus.create({
       name: 'User B Corpus #2',
       color: '#C00',
       creator: userB.id,
-      articles: [{ article: articleA.id, order: 1 }, { article: articleB.id, order: 2 }],
+      articles: [
+        { article: articleA.id, order: 1 },
+        { article: articleB.id, order: 2 },
+      ],
     })
 
     await userA.softDelete()
@@ -137,11 +143,13 @@ describe('softDelete', () => {
 
     expect(user).toHaveProperty('deletedAt', expect.any(Date))
     expect(user).toHaveProperty('password', null)
-    expect(user).toHaveProperty('email', expect.stringMatching(/^deleted-user-[a-f0-9-]+@example.com$/))
+    expect(user).toHaveProperty(
+      'email',
+      expect.stringMatching(/^deleted-user-[a-f0-9-]+@example.com$/)
+    )
 
-    return expect(await await User.find()).toHaveLength(2)
+    return expect(await User.find({})).toHaveLength(2)
   })
-
 
   test('articles should still be here', async () => {
     const articles = await Article.find()

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -11,7 +11,9 @@
   "scripts": {
     "delete-user": "node bin/delete-user.mjs",
     "generate-service-token": "node -p \"require('jsonwebtoken').sign({ admin: true, roles: ['read'], readonly: true }, process.env.JWT_SECRET_SESSION_COOKIE, { expiresIn: '1 year' })\"",
-    "test": "jest --collectCoverage --coverageReporters html --coverageReporters text-summary --coverageReporters lcovonly --detectOpenHandles",
+    "unit-test": "node --test helpers/*.test.js",
+    "int-test": "jest --collectCoverage --coverageReporters html --coverageReporters text-summary --coverageReporters lcovonly --detectOpenHandles",
+    "test": "npm run unit-test && npm run int-test",
     "migrations": "DOTENV_CONFIG_PATH=${DOTENV_CONFIG_PATH:-../.env} node -r dotenv/config ./node_modules/.bin/db-migrate up",
     "posttest": "eslint '**/*.js'",
     "prestart": "npm run migrations",


### PR DESCRIPTION
La seconde étape sera d'utiliser le runner Node pour les tests d'intégrations (avec `@testcontainers/mongodb`) et de reconfigurer/adapter la couverture de code.