### PR TITLE
Utilise la version DHI de Node

### DIFF
--- a/graphql/dockerfile
+++ b/graphql/dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM dhi.io/node:22-alpine3.22
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Pas de privilège, pas de vulnérabilité.