### PR TITLE
Supprime le lien vers les articles dans la collection users

### DIFF
--- a/graphql/models/user.js
+++ b/graphql/models/user.js
@@ -56,12 +56,6 @@ const userSchema = new Schema(
         ref: 'User',
       },
     ],
-    articles: [
-      {
-        type: Schema.Types.ObjectId,
-        ref: 'Article',
-      },
-    ],
     authProviders: {
       type: Map,
       of: AuthProviderSchema,
@@ -115,8 +109,6 @@ userSchema.methods.createDefaultArticle =
     })
 
     await newArticle.createNewVersion({ mode: 'MINOR', user: this })
-
-    this.articles.push(newArticle)
     return this.save()
   }
 

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -204,8 +204,6 @@ module.exports = {
         }
       }
 
-      user.articles.push(newArticle)
-      await user.save()
       return newArticle
     },
 
@@ -269,9 +267,7 @@ module.exports = {
       })
 
       newArticle.isNew = true
-      withUser.articles.push(newArticle)
-
-      await Promise.all([newArticle.save(), withUser.save()])
+      await newArticle.save()
 
       // Maintain links
       await Corpus.updateMany(


### PR DESCRIPTION
Dans un second temps, je ferais une migration afin de supprimer les données dans la base. Je ne veux pas le faire dans tout de suite au cas où on détecte une regression (toujours plus simple de réactiver du code que de remonter une sauvegarde).

Au passage j'ai aussi implémenté/corrigé la pagination avec limit + page. Cela dit, je crois que c'est la seule requête GraphQL où il y a une pagination. Autrement dit, je ne suis pas sur de l'intérêt et si cela a un intérêt il faudrait surement faire quelque chose d'un peu plus global.

resolves #866


