### PR TITLE
Ne ferme plus la modale lors d'un click externe

### DIFF
--- a/front/src/components/molecules/Modal.jsx
+++ b/front/src/components/molecules/Modal.jsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react'
-import { forwardRef } from 'react'
+import { forwardRef, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '../atoms/index.js'
@@ -22,11 +22,13 @@ export default forwardRef(function Modal(
   forwardedRef
 ) {
   const { t } = useTranslation()
+  const modalId = useId()
 
   return (
     <dialog
-      open={false}
+      open={visible}
       className={styles.modal}
+      id={modalId}
       ref={forwardedRef}
       onClose={cancel}
       aria-labelledby="modal-title"

--- a/front/src/components/organisms/article/Article.jsx
+++ b/front/src/components/organisms/article/Article.jsx
@@ -241,7 +241,7 @@ export default function Article({ article, corpus }) {
             <div className={styles.corpuses}>
               <Book size={18} />
               {corpus.map((c) => (
-                <div key={c.id}>{c.name}</div>
+                <div key={c._id}>{c.name}</div>
               ))}
             </div>
           )}

--- a/front/src/hooks/modal.js
+++ b/front/src/hooks/modal.js
@@ -4,38 +4,25 @@ export function useModal() {
   const ref = useRef(null)
   const [visible, setVisible] = useState(false)
 
-  const onClick = (event) => {
-    if (!event.target.contains(ref.current)) return
-
-    if (
-      event.offsetX < event.target.offsetWidth &&
-      event.offsetY < event.target.offsetHeight
-    ) {
-      // click is on scrollbar
-      return
-    }
-    close()
-  }
-
   function close() {
     ref.current?.close()
     setVisible(false)
     document.body.removeAttribute('data-scrolling')
-    document.removeEventListener('mousedown', onClick)
+    document.body.removeAttribute('inert')
   }
 
   function show() {
     ref.current?.showModal()
     setVisible(true)
+    document.body.setAttribute('inert', 'true')
     document.body.setAttribute('data-scrolling', 'false')
-    document.addEventListener('mousedown', onClick)
   }
 
   return {
     bindings: {
       ref,
       visible,
-      cancel: () => close(),
+      cancel: close,
     },
     show,
     close,


### PR DESCRIPTION
J'ai pris le parti de ne pas fermer la modale en cliquant en dehors. C'est un truc à perdre du travail en cours.

Avec #1926, on accède facilement à une action pour fermer la modale sans enregister les données.

fixes #1915