### PR TITLE
Déplace les mutations addContact et removeContact à la racine

### DIFF
--- a/front/src/hooks/Contacts.graphql
+++ b/front/src/hooks/Contacts.graphql
@@ -1,23 +1,19 @@
 #import './Credentials.graphql'
 
-query addContact($userId: ID!, $contactId: ID!) {
-  user(user: $userId) {
-    addContact(userId: $contactId) {
-      _id
-      acquintances {
-        ...extendedPublicUserFields
-      }
+mutation addContact($contactId: ID!) {
+  addContact(contactUserId: $contactId) {
+    _id
+    acquintances {
+      ...extendedPublicUserFields
     }
   }
 }
 
-query removeContact($userId: ID!, $contactId: ID!) {
-  user(user: $userId) {
-    removeContact(userId: $contactId) {
-      _id
-      acquintances {
-        ...extendedPublicUserFields
-      }
+mutation removeContact($contactId: ID!) {
+  removeContact(contactUserId: $contactId) {
+    _id
+    acquintances {
+      ...extendedPublicUserFields
     }
   }
 }

--- a/front/src/hooks/contact.js
+++ b/front/src/hooks/contact.js
@@ -21,7 +21,6 @@ export function useContactActions() {
     const result = await executeQuery({
       query: addContact,
       variables: {
-        userId: activeUserId,
         contactId,
       },
       sessionToken,
@@ -30,7 +29,7 @@ export function useContactActions() {
     await mutate(
       {
         user: {
-          acquintances: result.user.addContact.acquintances,
+          acquintances: result.addContact.acquintances,
         },
       },
       { revalidate: false }
@@ -39,14 +38,14 @@ export function useContactActions() {
   const remove = async (contactId) => {
     const result = await executeQuery({
       query: removeContact,
-      variables: { userId: activeUserId, contactId },
+      variables: { contactId },
       sessionToken,
       type: 'mutation',
     })
     await mutate(
       {
         user: {
-          acquintances: result.user.removeContact.acquintances,
+          acquintances: result.removeContact.acquintances,
         },
       },
       { revalidate: false }

--- a/graphql/resolvers/userResolver.js
+++ b/graphql/resolvers/userResolver.js
@@ -176,6 +176,37 @@ module.exports = {
       return await user.save()
     },
 
+    async addContact(_, { contactUserId }, context) {
+      const { userId } = isUser({}, context)
+
+      if (userId === contactUserId) {
+        throw new Error('You cannot add yourself as a contact!')
+      }
+      const contact = await User.findById(contactUserId)
+      if (!contact) {
+        throw new Error(`No user found with this id: ${contactUserId}`)
+      }
+      return User.findOneAndUpdate(
+        { _id: userId },
+        { $addToSet: { acquintances: contact._id } },
+        { new: true }
+      )
+    },
+
+    async removeContact(_, { contactUserId }, context) {
+      const { userId } = isUser({}, context)
+
+      const contact = await User.findById(contactUserId)
+      if (!contact) {
+        throw new Error(`No user found with this id: ${contactUserId}`)
+      }
+      return User.findOneAndUpdate(
+        { _id: userId },
+        { $pull: { acquintances: contact._id } },
+        { new: true }
+      )
+    },
+
     async addAcquintance(_, args, context) {
       const { userId } = isUser(args, context)
 

--- a/graphql/resolvers/userResolver.test.js
+++ b/graphql/resolvers/userResolver.test.js
@@ -1,3 +1,4 @@
+const { ObjectId } = require('mongoose').Types
 const { Mutation } = require('./userResolver.js')
 const User = require('../models/user.js')
 const { before, beforeEach, after, describe, test } = require('node:test')
@@ -367,6 +368,126 @@ describe('user resolver', () => {
         jwt,
         // eslint-disable-next-line security/detect-unsafe-regex
         /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/
+      )
+    })
+  })
+
+  describe('addContact', () => {
+    test('rejects adding oneself as a contact', async () => {
+      const user1 = new User({ email: 'user1@example.com' })
+      await user1.save()
+      const context = {
+        user1,
+        token: { admin: false, _id: user1.id },
+        session: {},
+      }
+      await assert.rejects(() =>
+        Mutation.addContact({}, { contactUserId: user1.id }, context)
+      )
+    })
+    test('adds a new contact', async () => {
+      const user1 = new User({ email: 'user1@example.com' })
+      const user2 = new User({ email: 'user2@example.com' })
+      await user1.save()
+      await user2.save()
+      const context = {
+        user1,
+        token: { admin: false, _id: user1.id },
+        session: {},
+      }
+      const user1Updated = await Mutation.addContact(
+        {},
+        { contactUserId: user2.id },
+        context
+      )
+      assert.deepStrictEqual(
+        user1Updated.acquintances.map((id) => id.toString()),
+        [user2.id]
+      )
+    })
+    test('adds an existing contact', async () => {
+      const user1 = new User({ email: 'user1@example.com' })
+      const user2 = new User({ email: 'user2@example.com' })
+      await user1.save()
+      await user2.save()
+      const context = {
+        user1,
+        token: { admin: false, _id: user1.id },
+        session: {},
+      }
+      await Mutation.addContact({}, { contactUserId: user2.id }, context)
+      // try to add the same contact
+      const user1Updated = await Mutation.addContact(
+        {},
+        { contactUserId: user2.id },
+        context
+      )
+      assert.deepStrictEqual(
+        user1Updated.acquintances.map((id) => id.toString()),
+        [user2.id]
+      )
+    })
+  })
+
+  describe('removeContact', () => {
+    test('rejects removing an unexisting user', async () => {
+      const user1 = new User({ email: 'user1@example.com' })
+      await user1.save()
+      const context = {
+        user1,
+        token: { admin: false, _id: user1.id },
+        session: {},
+      }
+      await assert.rejects(() =>
+        Mutation.removeContact({}, { contactUserId: new ObjectId() }, context)
+      )
+    })
+    test('removes an existing contact', async () => {
+      const user3Id = new ObjectId()
+      const user2 = new User({ email: 'user2@example.com' })
+      await user2.save()
+      const user1 = new User({
+        email: 'user1@example.com',
+        acquintances: [user2.id, user3Id],
+      })
+      await user1.save()
+      const context = {
+        user1,
+        token: { admin: false, _id: user1.id },
+        session: {},
+      }
+      const user1Updated = await Mutation.removeContact(
+        {},
+        { contactUserId: user2.id },
+        context
+      )
+      assert.deepStrictEqual(
+        user1Updated.acquintances.map((id) => id.toString()),
+        [user3Id.toString()]
+      )
+    })
+    test('removes an unexisting contact', async () => {
+      const user3Id = new ObjectId()
+      const user1 = new User({
+        email: 'user1@example.com',
+        acquintances: [user3Id],
+      })
+      const user2 = new User({ email: 'user2@example.com' })
+      await user1.save()
+      await user2.save()
+      const context = {
+        user1,
+        token: { admin: false, _id: user1.id },
+        session: {},
+      }
+      const user1Updated = await Mutation.removeContact(
+        {},
+        { contactUserId: user2.id },
+        context
+      )
+      assert.deepStrictEqual(
+        user1Updated.acquintances.map((id) => id.toString()),
+        [user3Id.toString()]
       )
     })
   })

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -81,8 +81,13 @@ type User {
   createdAt: DateTime
   updatedAt: DateTime
   deletedAt: DateTime
-
+  """
+  @deprecated Use addContact mutation at the root instead.
+  """
   addContact(userId: ID!): User
+  """
+  @deprecated Use removeContact mutation at the root instead.
+  """
   removeContact(userId: ID!): User
 
   stats: UserStats
@@ -493,8 +498,21 @@ type Mutation {
   unsetAuthToken(service: AuthTokenService!): User
 
   """
+  Add a user to your contacts list by their user ID.
+  Requires authentication.
+  """
+  addContact(contactUserId: ID!): User
+
+  """
+  Remove a user from your contacts list by their user ID.
+  Requires authentication.
+  """
+  removeContact(contactUserId: ID!): User
+
+  """
   Add a user to your contacts list by their email address.
   Requires authentication as the specified user.
+  @deprecated Use addContact instead.
   """
   addAcquintance(email: EmailAddress!, user: ID): User
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -127,8 +127,15 @@ type Mutation {
 
   Add a user to your contacts list by their email address.
   Requires authentication as the specified user.
+  @deprecated Use addContact instead.
   """
   addAcquintance(email: EmailAddress!, user: ID): User
+  """
+
+  Add a user to your contacts list by their user ID.
+  Requires authentication.
+  """
+  addContact(contactUserId: ID!): User
   """
 
   Grant access to a user account via an additional email address (credential).
@@ -207,6 +214,12 @@ type Mutation {
   duplicateArticle(article: ID!, to: ID!, user: ID): Article
   "Log out the currently authenticated user and invalidate the current session."
   logout: User
+  """
+
+  Remove a user from your contacts list by their user ID.
+  Requires authentication.
+  """
+  removeContact(contactUserId: ID!): User
   """
 
   Revoke access to a user account for a given email address.
@@ -327,6 +340,7 @@ type Tag {
 type User {
   _id: ID
   acquintances(limit: Int, page: Int): [User]
+  "@deprecated Use addContact mutation at the root instead."
   addContact(userId: ID!): User
   articles(limit: Int, page: Int): [Article]
   authProviders: AuthProvidersMap
@@ -339,6 +353,7 @@ type User {
   institution: String
   lastName: String
   permissions: [UserPermission]
+  "@deprecated Use removeContact mutation at the root instead."
   removeContact(userId: ID!): User
   stats: UserStats
   tags(limit: Int, page: Int): [Tag]


### PR DESCRIPTION
Conserve les "mutations" existantes en les passant `@deprecated`.

Ref https://github.com/EcrituresNumeriques/stylo/issues/1940