### PR TITLE
Supprime les colonnes bib et yaml de la collection des tags

### DIFF
--- a/graphql/migrations/20260309110000-remove-tags-bib-yaml.js
+++ b/graphql/migrations/20260309110000-remove-tags-bib-yaml.js
@@ -1,0 +1,29 @@
+exports.up = async function (db) {
+  const mongo = db._getDbInstance()
+  const tags = mongo.collection('tags')
+  const tagsCursor = tags.find({})
+  try {
+    while (await tagsCursor.hasNext()) {
+      const tag = await tagsCursor.next()
+      await tags.updateOne(
+        { _id: tag._id },
+        {
+          $unset: {
+            bib: '',
+            yaml: '',
+          },
+        },
+        { upsert: false }
+      )
+    }
+  } catch (err) {
+    console.log('Something went wrong while processing tags', err)
+    throw err
+  } finally {
+    await tagsCursor.close()
+  }
+}
+
+exports.down = function () {
+  return null
+}


### PR DESCRIPTION
Les colonnes n'apparaissent plus dans le type GraphQL, ni dans le modèle Mongoose.