### PR TITLE
Proposition de schéma pour l'API GraphQL

### DIFF
--- a/graphql/schema-v2.graphql
+++ b/graphql/schema-v2.graphql
@@ -1,0 +1,170 @@
+type Query {
+  me: User
+
+  tag(tagId: ID!): Tag
+  tags(name: String): [Tag!]
+
+  article(articleId: ID!): Article
+  articles(corpusId: ID, workspaceId: ID, tagId: ID, metadata: [MetadataFilter!], name: String): [Article!]
+  sharedArticle(articleId: ID!, accessKey: JWT): Article
+
+  workspace(workspaceId: ID!): Workspace
+  workspaces(name: String): [Workspace!]
+
+  corpus(corpusId: ID!): Corpus
+  corpuses(workspaceId: ID, metadata: [MetadataFilter!], name: String): [Corpus!]
+  sharedCorpus(corpusId: ID!, accessKey: JWT): Corpus
+
+  # public
+  stats: InstanceUsageStats
+
+  # admin
+  users(userId: ID, username: String, email: String): [User]
+}
+
+
+# no access to articles nor corpuses
+type Workspace {
+  id: ID!
+  name: String!
+  description: String
+  color: HexColorCode!
+  members: [User!]!
+  bibliographyStyle: String
+  formMetadata: WorkspaceFormMetadata
+  creator: UserIdentity!
+  createdAt: DateTime
+  updatedAt: DateTime
+  stats: WorkspaceStats
+}
+
+input MetadataFilter {
+  key: String!
+  value: JSON!
+}
+
+type Article {
+  id: ID!
+  name: String # rename title to name
+
+  workingCopy: WorkingCopy # rename workingVersion to workingCopy
+
+  nakalaLink: String
+  zoteroLink: String
+  preview: ArticlePreviewSettings
+
+  tags: [Tag!]!
+  contributors: [ArticleContributor]!
+  versions(versionId: ID, first: Int, last: Int): [ArticleVersion!]
+
+  creator: UserIdentity! # rename owner to creator
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+type ArticleVersion {
+  id: ID!
+  type: String # deprecated?
+  message: String
+
+  major: Int! # rename version to major
+  minor: Int! # rename revision to minor
+  revisionNumber: String! # format "major.minor"
+
+  bibliography: String
+  text: String
+  metadata: JSON
+
+  metadataFormType: String
+  metadataYaml(options: YamlFormattingInput): String
+
+  bibliographyEntries: [BibliographyEntry]
+  bibliographyPreview: String
+
+  creator: UserIdentity!
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+type WorkingCopy {
+  bibliography: String
+  text: String
+  metadata: JSON
+
+  metadataFormType: String
+  metadataYaml(options: YamlFormattingInput): String
+
+  bibliographyEntries: [BibliographyEntry]
+  bibliographyPreview: String
+}
+
+type Tag {
+  id: ID!
+  name: String!
+  description: String
+  color: HexColorCode
+
+  creator: UserIdentity!
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+type Corpus {
+  id: ID!
+  name: String!
+  description: String
+  type: CorpusType!
+  metadata: JSON
+  workspaceId: ID
+
+  articles: [CorpusArticle!]!
+
+  creatorId: Creator!
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+type CorpusArticle {
+  articleId: ID!
+  order: Int
+}
+
+type UserIdentity {
+  id: ID!
+  email: EmailAddress
+  username: String
+  displayName: String
+  firstName: String
+  lastName: String
+  institution: String
+}
+
+type User {
+  id: ID!
+  email: EmailAddress
+  username: String
+  displayName: String
+  firstName: String
+  lastName: String
+  institution: String
+
+  contacts(userId: ID, email: String, username: String): [UserIdentity!]! # rename acquintances to contacts
+
+  collaborators: [UserIdentity!]! # ensemble des utilisateurs collaborant avec cet utilisateur (i.e., utilisateurs travaillant au sein d'un même espace de travail ou d'un même article)
+
+  permissions: [UserPermission]
+  authProviders: AuthProvidersMap
+  authTypes: [AuthType]
+
+  createdAt: DateTime
+  updatedAt: DateTime
+  deletedAt: DateTime
+
+  stats: UserStats
+}
+
+type UserPermission {
+  roles: [String]
+  scope: String!
+  userId: ID!
+}


### PR DESCRIPTION
### Résumé des changements

#### Renommages                                                                                                                                                                                
   
| v1 | v2 |                                                                                                                                                                                  
|---|---|       
| `_id` | `id` (sur tous les types) |
| `Article.title` | `Article.name` |
| `Article.owner` | `Article.creator` |
| `Article.workingVersion` | `Article.workingCopy` |                                                                                                                                         
| `WorkingVersion` | `WorkingCopy` |
| `Version` | `ArticleVersion` |                                                                                                                                                             
| `Version.version` (Int) | `ArticleVersion.major` |
| `Version.revision` | `ArticleVersion.minor` |                                                                                                                                              
| `Version.md` | `ArticleVersion.text` |
| `Version.bib` | `ArticleVersion.bibliography` |                                                                                                                                            
| `Version.bibPreview` | `ArticleVersion.bibliographyPreview` |
| `WorkingVersion.md` | `WorkingCopy.text` |                                                                                                                                                 
| `WorkingVersion.bib` | `WorkingCopy.bibliography` |
| `User.acquintances` | `User.contacts` |                                                                                                                                                    
| `Query.user` | `Query.me` |
| `UserPermission.user: User!` | `UserPermission.userId: ID!` |                                                                                                                              
                  
####  Nouveaux éléments                                                                                                                                                                         
   
- **`ArticleVersion.revisionNumber`** : champ formaté `"major.minor"` (ex: `"2.3"`)                                                                                                          
- **`UserIdentity`** : nouveau type léger pour remplacer `User` dans les champs `creator`, `owner`, etc. (évite les requêtes profondes)
- **`MetadataFilter`** : input permettant de filtrer par métadonnées (`key`/`value`)                                                                                                         
- **`User.collaborators`** : liste des utilisateurs partageant un espace de travail ou un article
- **`Query.users`** : query admin avec filtres `userId`, `username`, `email`                                                                                                                 
- **`Query.articles`** : nouveaux filtres `corpusId`, `workspaceId`, `tagId`, `metadata`, `name`
- **`Query.corpuses`** : nouvelle query de liste (remplace `corpus(filter:...)`) avec filtres `workspaceId`, `metadata`, `name`                                                              
- **`Query.tags`** : filtre par `name`
                                                                                                                                                                                               
#### Suppressions / simplifications                                                                                                                                                            
                                                              
- **Champs mutants sur les types** supprimés (pattern v1 anti-GraphQL) : `Article.delete`, `Article.rename`, `Version.rename`, `Workspace.leave`, `Corpus.addArticle`, etc. → à déplacer vers
   des mutations racines                                                                                                                                                                       
- **`WorkspaceArticle` / `WorkspaceMember`** supprimés (types intermédiaires pour mutations embarquées)
- **`CorpusArticle`** simplifié : ne contient plus que `articleId` et `order` (plus de référence à `Article` ni de mutations embarquées)                                                     
- **`Corpus.workspace`** (String) → **`Corpus.workspaceId`** (ID)
- **`Tag.owner`** supprimé (remplacé par `creator: UserIdentity!`)                                                                                                                           
- **`Tag.articles`** supprimé du type `Tag`
- **`Workspace.articles` / `Workspace.corpus`** supprimés
                  
#### Philosophie générale du changement                                                                                                                                                        
                  
Le schéma v2 applique les bonnes pratiques GraphQL :                                                                                                                                         
   
1. **`id` au lieu de `_id`** — découplage de MongoDB                                                                                                                                         
2. **Mutations déplacées à la racine** — fini les mutations embarquées sur les types
3. **`UserIdentity`** comme type léger pour les références d'auteur/créateur — évite la récursion
4. **Filtres enrichis** sur les queries de liste                                                                                                                                             
5. **Nommage sémantique** plus clair (`workingCopy`, `major`/`minor`, `text`, `bibliography`)

