### PR TITLE
Suppression du champ "date" des ateliers

### DIFF
--- a/front/src/components/organisms/publications/Workshop.jsx
+++ b/front/src/components/organisms/publications/Workshop.jsx
@@ -26,30 +26,19 @@ export default function Workshop({ entry }) {
     <article className={styles.article} aria-labelledby={itemId}>
       <h3 id={itemId}>{title}</h3>
 
-      <ul className={styles.articleMetadata}>
-        {/*<li>
-          <MapPin className="icon" aria-label="Lieu :" /> Lyon
-        </li>*/}
-        <li>
-          <CalendarDays className="icon" aria-label={t('publication.date')} />
-          {date}
-        </li>
-        {/*<li>
-          <Building2 className="icon" aria-label="Organisateur :" /> Urfist
-        </li>*/}
-      </ul>
-
-      <a
-        href={link}
-        target="_blank"
-        rel="noreferrer noopener"
-        className={clsx(buttonStyles.linkSecondary, homeStyles.moreLink)}
-        aria-label={t('more.about.accessibleLabel', {
-          about: title,
-        })}
-      >
-        {t('more.about')}
-      </a>
+      <p>
+        <a
+          href={link}
+          target="_blank"
+          rel="noreferrer noopener"
+          className={clsx(buttonStyles.linkSecondary, homeStyles.moreLink)}
+          aria-label={t('more.about.accessibleLabel', {
+            about: title,
+          })}
+        >
+          {t('more.about')}
+        </a>
+      </p>
     </article>
   )
 }

--- a/front/src/components/pages/Home.module.scss
+++ b/front/src/components/pages/Home.module.scss
@@ -1,7 +1,6 @@
 @use '../organisms/header/header.module' as global;
 
 .changelog {
-  > summary,
   .generated-content {
     margin-bottom: 1em;
   }

--- a/front/src/layout.module.scss
+++ b/front/src/layout.module.scss
@@ -102,24 +102,29 @@ $base-spacing: 2em;
   display: flex;
   flex-direction: column;
   align-items: first baseline;
+  gap: calc($base-spacing / 2);
   padding: calc($base-spacing / 2);
   width: 100%;
 
-  :is(h1, h2, h3) {
-    margin: 0 0 calc($base-spacing / 4) 0;
+  :is(h1, h2, h3), p, ul {
+    margin: 0;
   }
 
   > :last-child {
     margin-bottom: 0;
+    margin-top: auto;
   }
 }
 
 .articleMetadata {
   list-style: none !important;
-  margin: calc($base-spacing / 2) 0 !important;
 
   li {
-    margin: 0 0 calc($base-spacing / 4) 0 !important;
+    margin: 0 0 .25em !important;
+
+    &:last-of-type {
+      margin-bottom: 0 !important;
+    }
   }
 }
 

--- a/front/src/locales/en/home.json
+++ b/front/src/locales/en/home.json
@@ -10,7 +10,7 @@
   "news.publications.title": "Publications",
   "news.release.title": "Latest update",
   "news.title": "News",
-  "news.workshops.title": "Upcoming workshops",
+  "news.workshops.title": "Workshops",
   "project.features": [
     "Lightweight markup languages (Markdown, YAML);",
     "Command palette and keyboard shortcuts;",

--- a/front/src/locales/es/home.json
+++ b/front/src/locales/es/home.json
@@ -10,7 +10,7 @@
   "news.publications.title": "Publicaciones",
   "news.release.title": "Última actualización",
   "news.title": "Noticias",
-  "news.workshops.title": "Próximos talleres",
+  "news.workshops.title": "Talleres",
   "project.features": [
     "Lenguajes de marcado ligeros (Markdown, YAML);",
     "Paleta de comandos y atajos de teclado;",

--- a/front/src/locales/fr/home.json
+++ b/front/src/locales/fr/home.json
@@ -10,7 +10,7 @@
   "news.publications.title": "Publications",
   "news.release.title": "Dernière mise à jour",
   "news.title": "Actualités",
-  "news.workshops.title": "Prochains ateliers",
+  "news.workshops.title": "Ateliers",
   "project.features": [
     "Langages de balisage légers (Markdown, YAML) ;",
     "Palette de commande et raccourcis claviers ;",


### PR DESCRIPTION
Et ajustement de la présentation pour que le bouton d'information soit aligné avec le bas de l'encadré : 

<img width="2866" height="570" alt="image" src="https://github.com/user-attachments/assets/bec981c9-8ac8-4cb6-8af8-5b7d707a23cd" />


fixes #1998