### PR TITLE
Charge le script Hypothesis après le rendu du HTML

### DIFF
--- a/front/src/components/pages/Annotate.jsx
+++ b/front/src/components/pages/Annotate.jsx
@@ -123,14 +123,18 @@ export default function Annotate({ strategy: strategyId }) {
         },
       }
     }
+  }, [windowWidth])
+
+  useEffect(() => {
+    if (isPreviewLoading || isDataLoading) return
 
     const script = document.createElement('script')
     script.src = 'https://hypothes.is/embed.js'
     script.async = true
     document.body.appendChild(script)
 
-    return () => document.body.removeChild(script)
-  }, [])
+    return () => { document.body.removeChild(script) }
+  }, [isPreviewLoading, isDataLoading])
 
   const { data, isLoading: isDataLoading } = useFetchData(
     strategy.query({ id, version, workspaceId }),


### PR DESCRIPTION
Le script était injecté au montage du composant avant que le contenu HTML ne soit récupéré via le service d'export, empêchant Hypothesis d'attacher les annotations correctement.