### PR TITLE
Ne pas déclencher onChange au montage initial

### DIFF
--- a/front/src/components/molecules/Toggle.jsx
+++ b/front/src/components/molecules/Toggle.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { Children, useCallback, useEffect, useState } from 'react'
+import { Children, useCallback, useEffect, useRef, useState } from 'react'
 
 import { useKeyPress } from '../../hooks/events.js'
 
@@ -36,6 +36,7 @@ export default function ToggleSwitch({
 }) {
   const [isChecked, setChecked] = useState(checked)
   const [isActive, setActiveState] = useState(false)
+  const isMounted = useRef(false)
   const setActive = useCallback(() => setActiveState(true))
   const setInactive = useCallback(() => setActiveState(false))
   const a11yLabel = labels[isChecked] ? labels[isChecked] : null
@@ -48,7 +49,11 @@ export default function ToggleSwitch({
   const handleKeyEvents = useKeyPress(['Enter', 'Space'], toggle)
 
   useEffect(() => {
-    onChange(isChecked)
+    if (isMounted.current) {
+      onChange(isChecked)
+    } else {
+      isMounted.current = true
+    }
   }, [isChecked])
 
   if (!a11yLabel && !Children.count(children)) {

--- a/front/src/components/molecules/Toggle.test.jsx
+++ b/front/src/components/molecules/Toggle.test.jsx
@@ -32,11 +32,38 @@ describe('Toggle', () => {
     )
 
     const el = getByLabelText('label')
+
+    expect(onChange).not.toHaveBeenCalled()
+
     await user.click(el)
 
     await expect(el).toBeChecked()
-    // it is called once on mount, and once on change
+    expect(onChange).toHaveBeenCalledOnce()
     await expect(onChange).toHaveBeenLastCalledWith(true)
+  })
+
+  test('does not call onChange on mount when checked=false', () => {
+    const onChange = vi.fn()
+
+    render(
+      <Component checked={false} onChange={onChange}>
+        label
+      </Component>
+    )
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not call onChange on mount when checked=true', () => {
+    const onChange = vi.fn()
+
+    render(
+      <Component checked onChange={onChange}>
+        label
+      </Component>
+    )
+
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   test('w/ a11y labels', async () => {

--- a/front/src/components/molecules/ToggleWidget.jsx
+++ b/front/src/components/molecules/ToggleWidget.jsx
@@ -10,9 +10,9 @@ export default function ToggleWidget(props) {
     <Translation ns="form" useSuspense={false}>
       {(t) => (
         <Toggle
-          checked={props.value === 'checked'}
+          checked={props.value}
           title={t(title)}
-          onChange={() => props.onChange(!props.value)}
+          onChange={(value) => props.onChange(value)}
           className={styles.toggle}
         >
           {t(title)}


### PR DESCRIPTION
Le useEffect de Toggle appelait onChange dès le montage, ce qui combiné au handler de ToggleWidget qui inversait props.value, faisait passer la valeur false à true sans interaction utilisateur.

Resolves #2020