### PR TITLE
Corrige les warnings de Biome

### DIFF
--- a/graphql/app.js
+++ b/graphql/app.js
@@ -163,7 +163,7 @@ app.use(session(sessionOptions))
 
 app.use(passport.session(sessionOptions))
 
-app.get('/version', (req, res) =>
+app.get('/version', (_req, res) =>
   res.json({
     name: pkg.name,
     version: pkg.version,

--- a/graphql/auth/humanid.js
+++ b/graphql/auth/humanid.js
@@ -26,23 +26,23 @@ const strategy = new OidcStrategy(
 /**
  *
  * @param {import('express').Request} req
- * @param {string} issuer
+ * @param {string} _issuer
  * @param {import('passport').Profile} profile
- * @param {{{timestamp: number?, class: string?, methods: string[]?}}} context
- * @param {string} idToken
+ * @param {{{timestamp: number?, class: string?, methods: string[]?}}} _context
+ * @param {string} _idToken
  * @param {string} accessToken
- * @param {string} refreshToken
+ * @param {string} _refreshToken
  * @param {import('passport').DoneCallback} done
  * @returns {Promise<void>}
  */
 async function verify(
   req,
-  issuer,
+  _issuer,
   profile,
-  context,
-  idToken,
+  _context,
+  _idToken,
   accessToken,
-  refreshToken,
+  _refreshToken,
   done
 ) {
   const { id, displayName, emails } = profile

--- a/graphql/auth/hypothesis.js
+++ b/graphql/auth/hypothesis.js
@@ -32,7 +32,7 @@ async function getProfileFromToken(accessToken) {
   }
 }
 
-async function verify(req, accessToken, refreshToken, _, done) {
+async function verify(req, accessToken, _refreshToken, _, done) {
   const { id, displayName } = await getProfileFromToken(accessToken)
 
   let user = await User.findOne({

--- a/graphql/auth/index.js
+++ b/graphql/auth/index.js
@@ -15,7 +15,7 @@ const config = require('../config.js')
  * @return {import('express').RequestHandler}
  */
 function stampAuth(service, { alreadyLoggedIn = false } = {}) {
-  return function handler(req, res, next) {
+  return function handler(req, _res, next) {
     // enables dynamic redirect based on the Styll instance which originated the request
     // this way it also works on dynamic netlify deployments
     const origin = new URL(req.header('origin') || req.header('referer'))
@@ -35,7 +35,7 @@ function stampAuth(service, { alreadyLoggedIn = false } = {}) {
 /**
  * @type {import('express').RequestHandler}
  */
-function onAuthFailure(error, req, res) {
+function onAuthFailure(error, _req, res) {
   res.statusCode = 401
 
   res.redirect(`${res.session.origin}/login#error&message=${error.message}`)

--- a/graphql/auth/local.js
+++ b/graphql/auth/local.js
@@ -13,10 +13,10 @@ const strategy = new LocalStrategy({ session: false }, verify)
 /**
  *
  * @param {Error} error
- * @param {Request} req
+ * @param {Request} _req
  * @param {Error} res
  */
-function onFailure(error, req, res) {
+function onFailure(error, _req, res) {
   res.statusCode = 401
   res.json({ error })
 }

--- a/graphql/auth/zotero.js
+++ b/graphql/auth/zotero.js
@@ -36,7 +36,7 @@ async function getProfileFromToken(token) {
   }
 }
 
-async function verify(req, token, tokenSecret, profile, params, done) {
+async function verify(req, token, _tokenSecret, _profile, _params, done) {
   const { id, username } = await getProfileFromToken(token)
 
   const user = await User.findOne({ 'authProviders.zotero.id': id })

--- a/graphql/helpers/token.js
+++ b/graphql/helpers/token.js
@@ -39,7 +39,7 @@ module.exports.createJWTToken = async function createJWTToken({
 module.exports.populateUserFromJWT = function populateUserFromJWT({
   jwtSecret,
 }) {
-  return async function populateUserFromJWTMiddleware(req, res, next) {
+  return async function populateUserFromJWTMiddleware(req, _res, next) {
     const jwtToken = req.headers.authorization?.replace(/^Bearer\s+/, '')
 
     if (!jwtToken) {

--- a/graphql/models/article.js
+++ b/graphql/models/article.js
@@ -193,9 +193,9 @@ articleSchema.methods.setPreviewSettings = async function setPreviewSettings(
 
 articleSchema.methods.updateWorkingVersion =
   async function updateWorkingVersion(content) {
-    Object.entries(content).forEach(([key, value]) =>
+    for (const [key, value] of Object.entries(content)) {
       this.set(`workingVersion.${key}`, value)
-    )
+    }
     return this.save()
   }
 

--- a/graphql/policies/isUser.js
+++ b/graphql/policies/isUser.js
@@ -1,4 +1,4 @@
-const { format } = require('util')
+const { format } = require('node:util')
 
 module.exports = function resolveUserIdFromContext(args, { token, user } = {}) {
   const isAdmin = token.admin || user?.admin || false

--- a/graphql/resolvers/authResolver.js
+++ b/graphql/resolvers/authResolver.js
@@ -16,7 +16,7 @@ async function checkCredentials({ username, password }) {
     ],
   })
 
-  if (!user || !user.password || !(await user.comparePassword(password))) {
+  if (!user?.password || !(await user.comparePassword(password))) {
     const error = new Error(
       'Unable to authenticate, please check your username and password!'
     )

--- a/graphql/resolvers/userResolver.js
+++ b/graphql/resolvers/userResolver.js
@@ -89,7 +89,7 @@ module.exports = {
       })
     },
 
-    async logout(_, args, { token, user, session }) {
+    async logout(_, _args, { token, user, session }) {
       isUser({}, { token, user })
 
       delete session.fromAccount
@@ -273,7 +273,7 @@ module.exports = {
   },
 
   Query: {
-    async user(_root, args, context) {
+    async user(_root, _args, context) {
       if (!context.userId) {
         return null
       }
@@ -298,7 +298,7 @@ module.exports = {
       })
     },
 
-    async acquintances(user, args, context) {
+    async acquintances(user, _args, context) {
       return Promise.all(
         user.acquintances.map((contactId) =>
           context.loaders.users.load(contactId)
@@ -322,7 +322,7 @@ module.exports = {
       return Tag.find({ owner: user._id }).lean()
     },
 
-    async workspaces(user, args, { token }) {
+    async workspaces(user, _args, { token }) {
       if (token?.admin) {
         return Workspace.find()
       }

--- a/graphql/resolvers/workspaceResolver.js
+++ b/graphql/resolvers/workspaceResolver.js
@@ -147,7 +147,7 @@ module.exports = {
   },
 
   WorkspaceArticle: {
-    async article(workspaceArticle, { articleId }) {
+    async article(_workspaceArticle, { articleId }) {
       const article = workspace.articles.find(
         (a) => String(a._id) === articleId
       )
@@ -206,7 +206,7 @@ module.exports = {
 
     // mutations
 
-    async leave(workspace, args, { user }) {
+    async leave(workspace, _args, { user }) {
       if (!user) {
         throw new NotAuthenticatedError()
       }

--- a/graphql/tests/harness.js
+++ b/graphql/tests/harness.js
@@ -17,7 +17,7 @@ async function setup() {
     env: 'dev',
     config: {
       dev: {
-        url: connectionString + '/stylo-tests',
+        url: `${connectionString}/stylo-tests`,
         options: {
           directConnection: true,
         },
@@ -33,7 +33,7 @@ async function setup() {
   await migrateInstance.reset()
   await migrateInstance.up()
   mongoose.set('strictQuery', true)
-  await mongoose.connect(connectionString + '/stylo-tests', {
+  await mongoose.connect(`${connectionString}/stylo-tests`, {
     directConnection: true,
   })
   return container


### PR DESCRIPTION
Principalement pour suffixer les paramètres non utilisés par `_`.
D'ailleurs je viens de voir dans le code de passport qu'il va sélectionner la fonction `verify` à partir du nombre d'arguments:

```js
          try {
              if (self._passReqToCallback) {
                var arity = self._verify.length;
                if (arity == 6) {
                  self._verify(req, token, tokenSecret, params, profile, verified);
                } else { // arity == 5
                  self._verify(req, token, tokenSecret, profile, verified);
                }
              } else {
                var arity = self._verify.length;
                if (arity == 5) {
                  self._verify(token, tokenSecret, params, profile, verified);
                } else { // arity == 4
                  self._verify(token, tokenSecret, profile, verified);
                }
              }
```

Donc dans Zotero, je pense qu'on peut faire:


```diff
-async function verify(req, token, _tokenSecret, _profile, _params, done) {
+async function verify(req, token, _tokenSecret, _profile, done) {
```

Et c'est aussi un peu bizarre que `profile` soit en 4ème position mais en 5ème position si il y a `params` 🤷🏻 
Bref au moins ça rend explicite les paramètres non utilisés.