### PR TITLE
Remplace les états éditeur par du state React local

### DIFF
--- a/front/src/components/organisms/article/ArticleStats.jsx
+++ b/front/src/components/organisms/article/ArticleStats.jsx
@@ -1,11 +1,17 @@
 import { useTranslation } from 'react-i18next'
-import { shallowEqual, useSelector } from 'react-redux'
 
 import styles from './ArticleStats.module.scss'
 
-export default function ArticleStats() {
+export default function ArticleStats({
+  stats = {
+    wordCount: 0,
+    charCountNoSpace: 0,
+    charCountPlusSpace: 0,
+    citationNb: 0,
+  },
+}) {
   const { t } = useTranslation()
-  const articleStats = useSelector((state) => state.articleStats, shallowEqual)
+  const articleStats = stats
   return (
     <ul className={styles.stats} aria-label={t('article.stats.menuLabel')}>
       <li>

--- a/front/src/components/organisms/article/ArticleStats.test.jsx
+++ b/front/src/components/organisms/article/ArticleStats.test.jsx
@@ -1,0 +1,49 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import { renderWithProviders } from '../../../../tests/setup.js'
+import ArticleStats from './ArticleStats.jsx'
+
+describe('ArticleStats', () => {
+  test('renders all counters at zero by default', () => {
+    renderWithProviders(<ArticleStats />)
+    expect(screen.getByRole('list')).toBeInTheDocument()
+    expect(screen.getByText(/0 words/)).toBeInTheDocument()
+    expect(screen.getByText(/0 characters/)).toBeInTheDocument()
+    expect(screen.getByText(/0 citations/)).toBeInTheDocument()
+  })
+
+  test('renders stats passed as props', () => {
+    renderWithProviders(
+      <ArticleStats
+        stats={{
+          wordCount: 42,
+          charCountNoSpace: 200,
+          charCountPlusSpace: 240,
+          citationNb: 5,
+        }}
+      />
+    )
+    expect(screen.getByText(/42 words/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/200 characters \(240 with spaces\)/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/5 citations/)).toBeInTheDocument()
+  })
+
+  test('uses singular form for 1 word, 1 character, 1 citation', () => {
+    renderWithProviders(
+      <ArticleStats
+        stats={{
+          wordCount: 1,
+          charCountNoSpace: 1,
+          charCountPlusSpace: 1,
+          citationNb: 1,
+        }}
+      />
+    )
+    expect(screen.getByText(/1 word/)).toBeInTheDocument()
+    expect(screen.getByText(/1 character/)).toBeInTheDocument()
+    expect(screen.getByText(/1 citation/)).toBeInTheDocument()
+  })
+})

--- a/front/src/components/organisms/metadata/ArticleMetadata.jsx
+++ b/front/src/components/organisms/metadata/ArticleMetadata.jsx
@@ -1,7 +1,6 @@
 import YAML from 'js-yaml'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 
 import { useArticleMetadata } from '../../../hooks/article.js'
 import { usePreferenceItem } from '../../../hooks/user.js'
@@ -17,12 +16,14 @@ import MonacoYamlEditor from './YamlEditor.jsx'
  * @param {string} props.versionId
  * @returns {JSX.Element}
  */
-export default function ArticleMetadata({ articleId, versionId }) {
-  /** @type {object} */
-  const articleWriters = useSelector((state) => state.articleWriters || {})
+export default function ArticleMetadata({
+  articleId,
+  versionId,
+  writers = {},
+}) {
   const multiUserActive = useMemo(
-    () => Object.keys(articleWriters).length > 1,
-    [articleWriters]
+    () => Object.keys(writers).length > 1,
+    [writers]
   )
   const readOnly = multiUserActive || versionId
   const { t } = useTranslation()

--- a/front/src/components/organisms/textEditor/ArticleTableOfContents.jsx
+++ b/front/src/components/organisms/textEditor/ArticleTableOfContents.jsx
@@ -1,17 +1,19 @@
 import { ArrowLeft } from 'lucide-react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch, useSelector } from 'react-redux'
 import { useMatch } from 'react-router'
 
 import { usePandocAnchoring } from '../../../hooks/pandoc.js'
 
 import styles from './ArticleTableOfContents.module.scss'
 
-export default function ArticleTableOfContents({ onBack }) {
+export default function ArticleTableOfContents({
+  onBack,
+  structure = [],
+  onCursorPositionChange,
+}) {
   const { t } = useTranslation()
-  const dispatch = useDispatch()
-  const articleStructure = useSelector((state) => state.articleStructure)
+  const articleStructure = structure
   const getAnchor = usePandocAnchoring()
   const routeMatch =
     useMatch('/article/:id/version/:versionId/*') || useMatch('/article/:id/*')
@@ -24,13 +26,12 @@ export default function ArticleTableOfContents({ onBack }) {
         ? document
             .querySelector(`#${target.dataset.headingAnchor}`)
             ?.scrollIntoView()
-        : dispatch({
-            type: 'UPDATE_EDITOR_CURSOR_POSITION',
+        : onCursorPositionChange?.({
             lineNumber: parseInt(target.dataset.index, 10),
             column: 0,
           })
     },
-    [hasHtmlAnchors]
+    [hasHtmlAnchors, onCursorPositionChange]
   )
 
   const title = onBack ? (

--- a/front/src/components/organisms/textEditor/ArticleTableOfContents.test.jsx
+++ b/front/src/components/organisms/textEditor/ArticleTableOfContents.test.jsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderWithProviders } from '../../../../tests/setup.js'
+import ArticleTableOfContents from './ArticleTableOfContents.jsx'
+
+const structure = [
+  { line: '## Introduction', index: 0, title: 'Introduction' },
+  { line: '### Section 1.1', index: 5, title: '↳Section 1.1' },
+  { line: '## Conclusion', index: 10, title: 'Conclusion' },
+]
+
+describe('ArticleTableOfContents', () => {
+  test('renders the heading and an empty list by default', () => {
+    renderWithProviders(<ArticleTableOfContents />)
+    expect(
+      screen.getByRole('heading', { name: /table of contents/i })
+    ).toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  test('renders entries from the structure', () => {
+    renderWithProviders(<ArticleTableOfContents structure={structure} />)
+    expect(screen.getByText('Introduction')).toBeInTheDocument()
+    expect(screen.getByText('↳Section 1.1')).toBeInTheDocument()
+    expect(screen.getByText('Conclusion')).toBeInTheDocument()
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+  })
+
+  test('calls onCursorPositionChange with the correct index on click', async () => {
+    const user = userEvent.setup()
+    const onCursorPositionChange = vi.fn()
+
+    renderWithProviders(
+      <ArticleTableOfContents
+        structure={structure}
+        onCursorPositionChange={onCursorPositionChange}
+      />
+    )
+
+    await user.click(screen.getByText('Introduction'))
+    expect(onCursorPositionChange).toHaveBeenCalledWith({
+      lineNumber: 0,
+      column: 0,
+    })
+
+    await user.click(screen.getByText('Conclusion'))
+    expect(onCursorPositionChange).toHaveBeenCalledWith({
+      lineNumber: 10,
+      column: 0,
+    })
+  })
+
+  test('does not throw when onCursorPositionChange is not provided', async () => {
+    const user = userEvent.setup()
+
+    renderWithProviders(<ArticleTableOfContents structure={structure} />)
+
+    await expect(
+      user.click(screen.getByText('Introduction'))
+    ).resolves.not.toThrow()
+  })
+})

--- a/front/src/components/organisms/textEditor/CollaborativeEditorArticleHeader.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeEditorArticleHeader.jsx
@@ -12,11 +12,13 @@ import CollaborativeEditorWriters from './CollaborativeEditorWriters.jsx'
  * @param {object} props
  * @param {string} props.articleTitle
  * @param {string|undefined} props.versionId
+ * @param {object} props.writers
  * @returns {import('react').ReactElement}
  */
 export default function CollaborativeEditorArticleHeader({
   articleTitle,
   versionId,
+  writers,
 }) {
   const { t } = useTranslation()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -43,7 +45,7 @@ export default function CollaborativeEditorArticleHeader({
         </Toggle>
 
         <div className={styles.writers}>
-          <CollaborativeEditorWriters />
+          <CollaborativeEditorWriters writers={writers} />
         </div>
       </div>
       <CollaborativeEditorActiveVersion versionId={versionId} />

--- a/front/src/components/organisms/textEditor/CollaborativeEditorWriters.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeEditorWriters.jsx
@@ -1,13 +1,12 @@
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 
 import { useDisplayName } from '../../../hooks/user.js'
 import { Avatar } from '../../molecules/index.js'
 
 import styles from './CollaborativeEditorWriters.module.scss'
 
-export default function CollaborativeEditorWriters() {
-  const articleWriters = useSelector((state) => state.articleWriters)
+export default function CollaborativeEditorWriters({ writers = {} }) {
+  const articleWriters = writers
   const { t } = useTranslation()
   const displayName = useDisplayName()
 

--- a/front/src/components/organisms/textEditor/CollaborativeEditorWriters.test.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeEditorWriters.test.jsx
@@ -1,0 +1,39 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import { renderWithProviders } from '../../../../tests/setup.js'
+import CollaborativeEditorWriters from './CollaborativeEditorWriters.jsx'
+
+describe('CollaborativeEditorWriters', () => {
+  test('renders an empty list by default', () => {
+    renderWithProviders(<CollaborativeEditorWriters />)
+    expect(screen.getByRole('list')).toBeEmptyDOMElement()
+  })
+
+  test('renders one avatar per writer', () => {
+    const writers = {
+      'user-1': {
+        user: { _id: 'user-1', displayName: 'Alice', color: '#ff0000' },
+      },
+      'user-2': {
+        user: { _id: 'user-2', displayName: 'Bob', color: '#0000ff' },
+      },
+    }
+
+    renderWithProviders(<CollaborativeEditorWriters writers={writers} />)
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+    expect(screen.getByTitle('Alice')).toBeInTheDocument()
+    expect(screen.getByTitle('Bob')).toBeInTheDocument()
+  })
+
+  test('falls back to username when displayName is absent', () => {
+    const writers = {
+      'user-1': { user: { _id: 'user-1', username: 'alice42' } },
+    }
+
+    renderWithProviders(<CollaborativeEditorWriters writers={writers} />)
+
+    expect(screen.getByTitle('alice42')).toBeInTheDocument()
+  })
+})

--- a/front/src/components/organisms/textEditor/CollaborativeTextEditor.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeTextEditor.jsx
@@ -4,7 +4,6 @@ import throttle from 'lodash.throttle'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
-import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { MonacoBinding } from 'y-monaco'
 import 'monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon.css'
 
@@ -41,15 +40,27 @@ import styles from './CollaborativeTextEditor.module.scss'
  * @param {string} props.articleId
  * @param {string|undefined} props.versionId
  * @param {'write' | 'compare' | 'preview'} props.mode
+ * @param {object} props.writers
+ * @param {{ lineNumber: number, column: number }} props.cursorPosition
+ * @param {function} props.onWritersChange
+ * @param {function} props.onStatsChange
+ * @param {function} props.onStructureChange
+ * @param {function} props.onWorkingCopyStatusChange
  * @returns {Element}
  */
 export default function CollaborativeTextEditor({
   articleId,
   versionId,
   mode,
+  writers,
+  cursorPosition,
+  onWritersChange,
+  onStatsChange,
+  onStructureChange,
+  onWorkingCopyStatusChange,
 }) {
   const { yText, awareness, websocketStatus, dynamicStyles } = useCollaboration(
-    { articleId, versionId }
+    { articleId, versionId, onWritersChange }
   )
   const { t } = useTranslation('editor')
 
@@ -84,12 +95,7 @@ export default function CollaborativeTextEditor({
     with_link_citations: true,
   })
 
-  const dispatch = useDispatch()
   const editorRef = useRef(null)
-  const editorCursorPosition = useSelector(
-    (state) => state.editorCursorPosition,
-    shallowEqual
-  )
 
   const hasVersion = useMemo(() => !!versionId, [versionId])
   const isLoading =
@@ -113,8 +119,8 @@ export default function CollaborativeTextEditor({
   const updateArticleStructureAndStats = useCallback(
     throttle(
       ({ text: md }) => {
-        dispatch({ type: 'UPDATE_ARTICLE_STATS', md })
-        dispatch({ type: 'UPDATE_ARTICLE_STRUCTURE', md })
+        onStatsChange?.(md)
+        onStructureChange?.(md)
       },
       250,
       { leading: false, trailing: true }
@@ -173,18 +179,12 @@ export default function CollaborativeTextEditor({
     if (yText) {
       updateArticleStructureAndStats({ text: yText.toString() })
       yText.observe(() => {
-        dispatch({
-          type: 'UPDATE_ARTICLE_WORKING_COPY_STATUS',
-          status: 'syncing',
-        })
+        onWorkingCopyStatusChange?.('syncing')
         if (timeoutId) {
           clearTimeout(timeoutId)
         }
         timeoutId = setTimeout(() => {
-          dispatch({
-            type: 'UPDATE_ARTICLE_WORKING_COPY_STATUS',
-            status: 'synced',
-          })
+          onWorkingCopyStatusChange?.('synced')
         }, 4000)
 
         updateArticleStructureAndStats({ text: yText.toString() })
@@ -194,8 +194,8 @@ export default function CollaborativeTextEditor({
 
   useEffect(() => {
     if (versionId) {
-      dispatch({ type: 'UPDATE_ARTICLE_STATS', md: version.md })
-      dispatch({ type: 'UPDATE_ARTICLE_STRUCTURE', md: version.md })
+      onStatsChange?.(version.md)
+      onStructureChange?.(version.md)
     }
   }, [versionId])
 
@@ -206,13 +206,14 @@ export default function CollaborativeTextEditor({
   }, [bibliography])
 
   useEffect(() => {
-    const line = editorCursorPosition.lineNumber
+    if (!cursorPosition) return
+    const line = cursorPosition.lineNumber
     const editor = editorRef.current
     editor?.focus()
     const endOfLineColumn = editor?.getModel()?.getLineMaxColumn(line + 1)
     editor?.setPosition({ lineNumber: line + 1, column: endOfLineColumn })
     editor?.revealLineNearTop(line + 1, 1) // smooth
-  }, [editorRef, editorCursorPosition])
+  }, [editorRef, cursorPosition])
 
   if (isLoading) {
     return <Loading />
@@ -232,6 +233,7 @@ export default function CollaborativeTextEditor({
       <CollaborativeEditorArticleHeader
         articleTitle={article.title}
         versionId={versionId}
+        writers={writers}
       />
 
       <CollaborativeEditorWebSocketStatus

--- a/front/src/components/organisms/textEditor/CollaborativeVersions.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeVersions.jsx
@@ -1,5 +1,4 @@
 import { Trans, useTranslation } from 'react-i18next'
-import { shallowEqual, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router'
 import { useArticleVersions } from '../../../hooks/article.js'
 import { useModal } from '../../../hooks/modal.js'
@@ -24,12 +23,9 @@ export default function CollaborativeVersions({
   showTitle,
   articleId,
   selectedVersion,
+  workingCopyStatus = 'synced',
 }) {
-  const articleWorkingCopyStatus = useSelector(
-    (state) => state.articleWorkingCopy.status,
-    shallowEqual
-  )
-  const syncing = articleWorkingCopyStatus === 'syncing'
+  const syncing = workingCopyStatus === 'syncing'
   const navigate = useNavigate()
   const { article, isLoading, error } = useArticleVersions({ articleId })
   const articleVersions = article?.versions

--- a/front/src/components/organisms/textEditor/EditorMenuContent.jsx
+++ b/front/src/components/organisms/textEditor/EditorMenuContent.jsx
@@ -15,6 +15,10 @@ export default function EditorMenuContent({
   articleId,
   versionId,
   activeMenu,
+  writers,
+  structure,
+  workingCopyStatus,
+  onCursorPositionChange,
 }) {
   const { article } = useRouteLoaderData('article')
   const { t } = useTranslation()
@@ -26,9 +30,18 @@ export default function EditorMenuContent({
   return (
     <div className={clsx(styles.content, styles.active)}>
       {activeMenu === 'metadata' && (
-        <ArticleMetadata articleId={articleId} versionId={versionId} />
+        <ArticleMetadata
+          articleId={articleId}
+          versionId={versionId}
+          writers={writers}
+        />
       )}
-      {activeMenu === 'toc' && <ArticleTableOfContents />}
+      {activeMenu === 'toc' && (
+        <ArticleTableOfContents
+          structure={structure}
+          onCursorPositionChange={onCursorPositionChange}
+        />
+      )}
       {activeMenu === 'bibliography' && (
         <ArticleBibliography articleId={articleId} />
       )}
@@ -50,6 +63,7 @@ export default function EditorMenuContent({
           articleId={articleId}
           selectedVersion={versionId}
           showTitle={true}
+          workingCopyStatus={workingCopyStatus}
         />
       )}
     </div>

--- a/front/src/components/pages/CollaborativeEditor.jsx
+++ b/front/src/components/pages/CollaborativeEditor.jsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useParams, useSearchParams } from 'react-router'
-
 import { executeQuery } from '../../helpers/graphQL.js'
+import { computeTextStats } from '../../helpers/markdown.js'
 import { getArticleInfo } from '../../hooks/Article.graphql'
 import { usePreferenceItem } from '../../hooks/user.js'
 import {
@@ -12,6 +12,23 @@ import {
 import EditorMenuContent from '../organisms/textEditor/EditorMenuContent.jsx'
 
 import styles from './CollaborativeEditor.module.scss'
+
+function parseArticleStructure(md) {
+  const text = (md || '').trim()
+  return text
+    .split('\n')
+    .map((line, index) => ({ line, index }))
+    .filter((lineWithIndex) => lineWithIndex.line.match(/^##+ /))
+    .map((lineWithIndex) => {
+      const title = lineWithIndex.line
+        .replace(/##/, '')
+        //arrow backspace (↳)
+        .replace(/#\s/g, '↳')
+        // middle dot (·) + non-breaking space (\xa0)
+        .replace(/#/g, '·\xa0')
+      return { ...lineWithIndex, title }
+    })
+}
 
 const articleIdRx = /^[a-f\d]{24}$/i
 
@@ -51,6 +68,30 @@ export default function CollaborativeEditor(props) {
     'article'
   )
 
+  const [articleStats, setArticleStats] = useState({
+    wordCount: 0,
+    charCountNoSpace: 0,
+    charCountPlusSpace: 0,
+    citationNb: 0,
+  })
+  const [articleStructure, setArticleStructure] = useState([])
+  const [writers, setWriters] = useState({})
+  const [workingCopyStatus, setWorkingCopyStatus] = useState('synced')
+  const [cursorPosition, setCursorPosition] = useState(null)
+
+  const handleStatsChange = useCallback(
+    (md) => setArticleStats(computeTextStats(md)),
+    []
+  )
+  const handleStructureChange = useCallback(
+    (md) => setArticleStructure(parseArticleStructure(md)),
+    []
+  )
+  const handleCursorPositionChange = useCallback(
+    (position) => setCursorPosition(position),
+    []
+  )
+
   const handleActiveMenuChange = useCallback(
     (value) => {
       setActiveMenu(value)
@@ -66,13 +107,23 @@ export default function CollaborativeEditor(props) {
             mode={mode}
             articleId={articleId}
             versionId={versionId}
+            writers={writers}
+            cursorPosition={cursorPosition}
+            onWritersChange={setWriters}
+            onStatsChange={handleStatsChange}
+            onStructureChange={handleStructureChange}
+            onWorkingCopyStatusChange={setWorkingCopyStatus}
           />
-          <ArticleStats />
+          <ArticleStats stats={articleStats} />
         </div>
         <EditorMenuContent
           articleId={articleId}
           versionId={versionId}
           activeMenu={activeMenu}
+          writers={writers}
+          structure={articleStructure}
+          workingCopyStatus={workingCopyStatus}
+          onCursorPositionChange={handleCursorPositionChange}
         />
       </div>
 

--- a/front/src/createReduxStore.js
+++ b/front/src/createReduxStore.js
@@ -2,8 +2,6 @@ import { createReduxEnhancer as createSentryReduxEnhancer } from '@sentry/react'
 
 import { applyMiddleware, compose, createStore } from 'redux'
 
-import { computeTextStats } from './helpers/markdown.js'
-
 const sessionTokenName = 'sessionToken'
 
 /**
@@ -26,11 +24,6 @@ const sessionTokenName = 'sessionToken'
 // Définition du store Redux et de l'ensemble des actions
 export const initialState = {
   sessionToken: localStorage.getItem(sessionTokenName),
-  articleWorkingCopy: {
-    status: 'synced',
-  },
-  articleStructure: [],
-  articleWriters: [],
   articlePreferences: localStorage.getItem('articlePreferences')
     ? JSON.parse(localStorage.getItem('articlePreferences'))
     : {
@@ -41,12 +34,6 @@ export const initialState = {
   articleFilters: {
     tagIds: [],
     text: '',
-  },
-  articleStats: {
-    wordCount: 0,
-    charCountNoSpace: 0,
-    charCountPlusSpace: 0,
-    citationNb: 0,
   },
   // Active user (authenticated)
   activeUser: {
@@ -73,10 +60,6 @@ export const initialState = {
         unnumbered: 0,
         book_division: 'part',
       },
-  editorCursorPosition: {
-    lineNumber: 0,
-    column: 0,
-  },
 }
 
 /**
@@ -108,12 +91,6 @@ function createRootReducer(state) {
     UPDATE_ACTIVE_USER_DETAILS: updateActiveUserDetails,
     LOGOUT: logoutUser,
 
-    // article reducers
-    UPDATE_ARTICLE_STATS: updateArticleStats,
-    UPDATE_ARTICLE_STRUCTURE: updateArticleStructure,
-    UPDATE_ARTICLE_WRITERS: updateArticleWriters,
-    UPDATE_ARTICLE_WORKING_COPY_STATUS: updateArticleWorkingCopyStatus,
-
     // user preferences reducers
     ARTICLE_PREFERENCES_TOGGLE: toggleArticlePreferences,
     CORPUS_PREFERENCES_TOGGLE: toggleCorpusPreferences,
@@ -123,8 +100,6 @@ function createRootReducer(state) {
     SET_CORPUS_PREFERENCES: setCorpusPreferences,
     SET_EXPORT_PREFERENCES: setExportPreferences,
     SET_USER_PREFERENCES: setUserPreferences,
-
-    UPDATE_EDITOR_CURSOR_POSITION: updateEditorCursorPosition,
 
     UPDATE_SELECTED_TAG: updateSelectedTag,
   })
@@ -226,43 +201,6 @@ function logoutUser() {
   return structuredClone(initialState)
 }
 
-function updateArticleStats(state, { md }) {
-  return {
-    ...state,
-    articleStats: computeTextStats(md),
-  }
-}
-
-function updateArticleStructure(state, { md }) {
-  const text = (md || '').trim()
-  const articleStructure = text
-    .split('\n')
-    .map((line, index) => ({ line, index }))
-    .filter((lineWithIndex) => lineWithIndex.line.match(/^##+ /))
-    .map((lineWithIndex) => {
-      const title = lineWithIndex.line
-        .replace(/##/, '')
-        //arrow backspace (\u21B3)
-        .replace(/#\s/g, '\u21B3')
-        // middle dot (\u00B7) + non-breaking space (\xa0)
-        .replace(/#/g, '\u00B7\xa0')
-      return { ...lineWithIndex, title }
-    })
-
-  return { ...state, articleStructure }
-}
-
-function updateArticleWriters(state, { articleWriters }) {
-  return { ...state, articleWriters }
-}
-
-function updateArticleWorkingCopyStatus(state, { status }) {
-  return {
-    ...state,
-    articleWorkingCopy: { ...state.articleWorkingCopy, status },
-  }
-}
-
 function togglePreferences(storeKey) {
   return function togglePreferencesReducer(state, { key, value }) {
     const preferences = state[storeKey]
@@ -298,16 +236,6 @@ const setUserPreferences = setPreferences('userPreferences')
 const toggleCorpusPreferences = togglePreferences('corpusPreferences')
 const setExportPreferences = setPreferences('exportPreferences')
 const setCorpusPreferences = setPreferences('corpusPreferences')
-
-function updateEditorCursorPosition(state, { lineNumber, column }) {
-  return {
-    ...state,
-    editorCursorPosition: {
-      lineNumber,
-      column,
-    },
-  }
-}
 
 function updateSelectedTag(state, { tagId }) {
   const { selectedTagIds } = state.activeUser

--- a/front/src/hooks/collaboration.js
+++ b/front/src/hooks/collaboration.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { shallowEqual, useDispatch, useSelector } from 'react-redux'
+import { shallowEqual, useSelector } from 'react-redux'
 
 import * as collaborating from '../components/organisms/textEditor/collaborating.js'
 import { applicationConfig } from '../config.js'
@@ -35,7 +35,7 @@ const colors = [
   '#DDDDDD',
 ]
 
-export function useCollaboration({ articleId }) {
+export function useCollaboration({ articleId, onWritersChange }) {
   const connectingRef = useRef(false)
   const [dynamicStyles, setDynamicStyles] = useState('')
   const [websocketStatus, setWebsocketStatus] = useState('')
@@ -51,7 +51,6 @@ export function useCollaboration({ articleId }) {
     }),
     shallowEqual
   )
-  const dispatch = useDispatch()
 
   const writerInfo = useMemo(
     () => ({
@@ -67,7 +66,7 @@ export function useCollaboration({ articleId }) {
   const handleWritersUpdated = useCallback(
     ({ states }) => {
       const writers = Object.fromEntries(states)
-      dispatch({ type: 'UPDATE_ARTICLE_WRITERS', articleWriters: writers })
+      onWritersChange?.(writers)
       setDynamicStyles(
         Object.entries(writers)
           .map(([key, writer]) => {


### PR DESCRIPTION
Retire 5 états du store Redux (`articleStats`, `articleStructure`, `articleWriters`, `articleWorkingCopy`, `editorCursorPosition`) en les ajoutant dans `CollaborativeEditor.jsx` et en les passant via props/callbacks aux composants enfants.

Cela va dans le sens de la suppression de Redux. Je commence par retirer les états qu'on peut passer par props/callbacks. Normalement il ne restera plus que l'authentification et les préférences utilisateurs qu'on pourra mettre dans un store Zustand.
