### PR TITLE
Déplacer les mutations Article vers la racine du schéma

### DIFF
--- a/front/src/helpers/graphQL.js
+++ b/front/src/helpers/graphQL.js
@@ -79,12 +79,11 @@ export class GraphQLError extends Error {
 export function useGraphQLClient() {
   const sessionToken = useSelector((state) => state.sessionToken)
   return {
-    query: ({ query, variables, type = 'fetch', withCredentials = false }) =>
+    query: ({ query, variables, withCredentials = false }) =>
       executeQuery({
         query,
         variables,
         sessionToken,
-        type,
         credentials: withCredentials === false ? 'omit' : corsStrategy,
       }),
   }
@@ -96,7 +95,6 @@ export function useGraphQLClient() {
  * @param {'omit' | 'same-origin' | 'include'} context.credentials request variables
  * @param {{[key: string]: unknown}|undefined} context.variables request variables
  * @param {string} context.sessionToken session token (for authentication)
- * @param {'fetch'|'mutate'} context.type request type (either fetch or mutate)
  * @returns {Promise<string|{[key: string]: unknown}>}
  * @throws {Error} if something went wrong
  */
@@ -105,8 +103,7 @@ export function executeQuery({
   variables,
   sessionToken,
   credentials = 'omit',
-  type = 'fetch',
 }) {
   const query = typeof queryOrAST === 'string' ? queryOrAST : print(queryOrAST)
-  return executeRequest({ query, variables, sessionToken, type, credentials })
+  return executeRequest({ query, variables, sessionToken, credentials })
 }

--- a/front/src/hooks/Article.graphql
+++ b/front/src/hooks/Article.graphql
@@ -87,16 +87,12 @@ mutation updateArticle($updateArticleInput: UpdateArticleInput!) {
   }
 }
 
-query setZoteroLink($articleId: ID!, $url: String!) {
-  article(article: $articleId) {
-    setZoteroLink(zotero: $url)
-  }
+mutation setArticleZoteroLink($articleId: ID!, $url: String!) {
+  setArticleZoteroLink(articleId: $articleId, zotero: $url)
 }
 
-query setNakalaLink($articleId: ID!, $url: String!) {
-  article(article: $articleId) {
-    setNakalaLink(nakala: $url)
-  }
+mutation setArticleNakalaLink($articleId: ID!, $url: String!) {
+  setArticleNakalaLink(articleId: $articleId, nakala: $url)
 }
 
 query getArticleVersions($articleId: ID!) {
@@ -127,10 +123,8 @@ query getArticleContributors($articleId: ID!) {
   }
 }
 
-query deleteArticle($articleId: ID!) {
-  article(article: $articleId) {
-    delete(dryRun: false)
-  }
+mutation deleteArticle($articleId: ID!) {
+  deleteArticle(articleId: $articleId)
 }
 
 mutation duplicateArticle($user: ID, $articleId: ID!, $to: ID!) {
@@ -153,23 +147,19 @@ mutation updateArticleBibliography($input: UpdateArticleBibliographyInput!) {
   }
 }
 
-query addTags($articleId: ID!, $tags: [ID]!) {
-  article(article: $articleId) {
-    addTags(tags: $tags) {
-      _id
-      name
-      color
-    }
+mutation addArticleTags($articleId: ID!, $tags: [ID]!) {
+  addArticleTags(articleId: $articleId, tags: $tags) {
+    _id
+    name
+    color
   }
 }
 
-query removeTags($articleId: ID!, $tags: [ID]!) {
-  article(article: $articleId) {
-    removeTags(tags: $tags) {
-      _id
-      name
-      color
-    }
+mutation removeArticleTags($articleId: ID!, $tags: [ID]!) {
+  removeArticleTags(articleId: $articleId, tags: $tags) {
+    _id
+    name
+    color
   }
 }
 
@@ -193,11 +183,12 @@ query getArticleTags($articleId: ID!) {
   }
 }
 
-query updateWorkingVersion($articleId: ID!, $content: WorkingVersionInput!) {
-  article(article: $articleId) {
-    updateWorkingVersion(content: $content) {
-      updatedAt
-    }
+mutation updateArticleWorkingVersion(
+  $articleId: ID!
+  $content: WorkingVersionInput!
+) {
+  updateArticleWorkingVersion(articleId: $articleId, content: $content) {
+    updatedAt
   }
 }
 

--- a/front/src/hooks/ArticleContributors.graphql
+++ b/front/src/hooks/ArticleContributors.graphql
@@ -1,28 +1,24 @@
 #import './Credentials.graphql'
 
-query addContributor($userId: ID!, $articleId: ID!) {
-  article(article: $articleId) {
-    addContributor(userId: $userId) {
-      _id
-      contributors {
-        roles
-        user {
-          ...extendedPublicUserFields
-        }
+mutation addArticleContributor($userId: ID!, $articleId: ID!) {
+  addArticleContributor(articleId: $articleId, userId: $userId) {
+    _id
+    contributors {
+      roles
+      user {
+        ...extendedPublicUserFields
       }
     }
   }
 }
 
-query removeContributor($userId: ID!, $articleId: ID!) {
-  article(article: $articleId) {
-    removeContributor(userId: $userId) {
-      _id
-      contributors {
-        roles
-        user {
-          ...extendedPublicUserFields
-        }
+mutation removeArticleContributor($userId: ID!, $articleId: ID!) {
+  removeArticleContributor(articleId: $articleId, userId: $userId) {
+    _id
+    contributors {
+      roles
+      user {
+        ...extendedPublicUserFields
       }
     }
   }

--- a/front/src/hooks/Versions.graphql
+++ b/front/src/hooks/Versions.graphql
@@ -39,19 +39,18 @@ query getArticleVersion($versionId: ID!) {
   }
 }
 
-mutation createVersion(
+mutation createArticleVersion(
   $articleId: ID!
   $userId: ID!
   $major: Boolean!
   $message: String
 ) {
-  article(articleId: $articleId) {
-    createVersion(
-      articleVersionInput: { major: $major, message: $message, userId: $userId }
-    ) {
-      versions {
-        ...basicVersionFields
-      }
+  createArticleVersion(
+    articleId: $articleId
+    articleVersionInput: { major: $major, message: $message, userId: $userId }
+  ) {
+    versions {
+      ...basicVersionFields
     }
   }
 }

--- a/front/src/hooks/article.js
+++ b/front/src/hooks/article.js
@@ -5,18 +5,18 @@ import { toYaml } from '../components/organisms/metadata/yaml.js'
 import { executeQuery } from '../helpers/graphQL.js'
 import { clean } from '../schemas/schemas.js'
 import {
-  addTags,
+  addArticleTags,
   deleteArticle,
   duplicateArticle,
   getArticleMetadata,
   getArticleTags,
   getEditableArticle,
-  removeTags,
-  setNakalaLink,
-  setZoteroLink,
+  removeArticleTags,
+  setArticleNakalaLink,
+  setArticleZoteroLink,
   updateArticle,
   updateArticleBibliography,
-  updateWorkingVersion,
+  updateArticleWorkingVersion,
 } from './Article.graphql'
 import { createArticle, getWorkspaceArticles } from './Articles.graphql'
 import useFetchData, {
@@ -24,7 +24,7 @@ import useFetchData, {
   useMutateData,
 } from './graphql.js'
 import {
-  createVersion,
+  createArticleVersion,
   getArticleVersion,
   getArticleVersions,
   renameVersion,
@@ -42,7 +42,7 @@ export function useArticleTagActions({ articleId }) {
   )
   const add = async (tagId) => {
     const result = await executeQuery({
-      query: addTags,
+      query: addArticleTags,
       variables: {
         articleId,
         tags: [tagId],
@@ -50,7 +50,7 @@ export function useArticleTagActions({ articleId }) {
       sessionToken,
       type: 'mutation',
     })
-    const tags = result.article.addTags
+    const tags = result.addArticleTags
     mutate(
       {
         article: {
@@ -63,7 +63,7 @@ export function useArticleTagActions({ articleId }) {
   }
   const remove = async (tagId) => {
     const result = await executeQuery({
-      query: removeTags,
+      query: removeArticleTags,
       variables: {
         articleId,
         tags: [tagId],
@@ -71,7 +71,7 @@ export function useArticleTagActions({ articleId }) {
       sessionToken,
       type: 'mutation',
     })
-    const tags = result.article.removeTags
+    const tags = result.removeArticleTags
     mutate(
       {
         article: {
@@ -279,7 +279,7 @@ export function useArticleMetadata({ articleId, versionId }) {
 
     await executeQuery({
       sessionToken,
-      query: updateWorkingVersion,
+      query: updateArticleWorkingVersion,
       variables: {
         userId: activeUser._id,
         articleId: articleId,
@@ -310,7 +310,7 @@ export function useArticleMetadata({ articleId, versionId }) {
     }
     await executeQuery({
       sessionToken,
-      query: updateWorkingVersion,
+      query: updateArticleWorkingVersion,
       variables: {
         userId: activeUser._id,
         articleId: articleId,
@@ -436,12 +436,12 @@ export function useEditableArticle({ articleId, versionId }) {
   const updateZoteroLink = async (url) => {
     await executeQuery({
       sessionToken,
-      query: setZoteroLink,
+      query: setArticleZoteroLink,
       variables: {
         articleId: articleId,
         url,
       },
-      type: 'mutate',
+      type: 'mutation',
     })
     await mutate(
       async (data) => {
@@ -459,12 +459,12 @@ export function useEditableArticle({ articleId, versionId }) {
   const updateNakalaLink = async (url) => {
     await executeQuery({
       sessionToken,
-      query: setNakalaLink,
+      query: setArticleNakalaLink,
       variables: {
         articleId: articleId,
         url,
       },
-      type: 'mutate',
+      type: 'mutation',
     })
     await mutate(
       async (data) => {
@@ -545,7 +545,7 @@ export function useArticleVersionActions({ articleId }) {
   })
   const create = async (version) => {
     const response = await executeQuery({
-      query: createVersion,
+      query: createArticleVersion,
       variables: {
         userId: activeUser._id,
         articleId,
@@ -558,7 +558,7 @@ export function useArticleVersionActions({ articleId }) {
     await mutate(async (data) => ({
       article: {
         ...data?.article,
-        versions: response.article.createVersion.versions,
+        versions: response.createArticleVersion.versions,
       },
     }))
   }

--- a/front/src/hooks/article.js
+++ b/front/src/hooks/article.js
@@ -48,7 +48,6 @@ export function useArticleTagActions({ articleId }) {
         tags: [tagId],
       },
       sessionToken,
-      type: 'mutation',
     })
     const tags = result.addArticleTags
     mutate(
@@ -69,7 +68,6 @@ export function useArticleTagActions({ articleId }) {
         tags: [tagId],
       },
       sessionToken,
-      type: 'mutation',
     })
     const tags = result.removeArticleTags
     mutate(
@@ -109,7 +107,6 @@ export function useArticlesActions({ activeWorkspaceId }) {
       query: createArticle,
       variables: { createArticleInput: createInput },
       sessionToken,
-      type: 'mutation',
     })
     await mutateArticles(async (data) => {
       console.log({ data })
@@ -154,7 +151,6 @@ export function useArticleActions({ articleId, activeWorkspaceId }) {
         articleId,
       },
       sessionToken,
-      type: 'mutation',
     })
   }
   const duplicate = async (article) => {
@@ -166,7 +162,6 @@ export function useArticleActions({ articleId, activeWorkspaceId }) {
         articleId,
       },
       sessionToken,
-      type: 'mutation',
     })
     const duplicatedArticle = {
       ...article,
@@ -190,7 +185,6 @@ export function useArticleActions({ articleId, activeWorkspaceId }) {
       query: deleteArticle,
       variables: { articleId },
       sessionToken,
-      type: 'mutation',
     })
     await mutateArticles(async (data) => {
       const updatedArticles =
@@ -285,7 +279,6 @@ export function useArticleMetadata({ articleId, versionId }) {
         articleId: articleId,
         content: { metadataFormType },
       },
-      type: 'mutate',
     })
     // TODO use a common query for all mutations
     await mutate(
@@ -316,7 +309,6 @@ export function useArticleMetadata({ articleId, versionId }) {
         articleId: articleId,
         content: { metadata },
       },
-      type: 'mutate',
     })
     await mutate(
       async (data) => {
@@ -413,7 +405,6 @@ export function useEditableArticle({ articleId, versionId }) {
           bib: bibtex,
         },
       },
-      type: 'mutate',
     })
     const bibliography = result.updateArticleBibliography
     await mutate(
@@ -441,7 +432,6 @@ export function useEditableArticle({ articleId, versionId }) {
         articleId: articleId,
         url,
       },
-      type: 'mutation',
     })
     await mutate(
       async (data) => {
@@ -464,7 +454,6 @@ export function useEditableArticle({ articleId, versionId }) {
         articleId: articleId,
         url,
       },
-      type: 'mutation',
     })
     await mutate(
       async (data) => {
@@ -553,7 +542,6 @@ export function useArticleVersionActions({ articleId }) {
         message: version.description,
       },
       sessionToken,
-      type: 'mutation',
     })
     await mutate(async (data) => ({
       article: {
@@ -570,7 +558,6 @@ export function useArticleVersionActions({ articleId }) {
         name: description,
       },
       sessionToken,
-      type: 'mutation',
     })
     await mutate(async (data) => ({
       article: {

--- a/front/src/hooks/article.test.jsx
+++ b/front/src/hooks/article.test.jsx
@@ -57,7 +57,7 @@ describe('Article', () => {
     expect(fetch).toHaveBeenLastCalledWith(
       'http://localhost:3000/graphql',
       expect.objectContaining({
-        body: expect.stringMatching(/"query":"query addTags\(/),
+        body: expect.stringMatching(/"query":"mutation addArticleTags\(/),
       })
     )
   })
@@ -106,7 +106,7 @@ describe('Article', () => {
     expect(fetch).toHaveBeenLastCalledWith(
       'http://localhost:3000/graphql',
       expect.objectContaining({
-        body: expect.stringMatching(/"query":"query removeTags\(/),
+        body: expect.stringMatching(/"query":"mutation removeArticleTags\(/),
       })
     )
   })
@@ -172,7 +172,7 @@ describe('Article', () => {
     expect(fetch).toHaveBeenLastCalledWith(
       'http://localhost:3000/graphql',
       expect.objectContaining({
-        body: expect.stringMatching(/"query":"query deleteArticle\(/),
+        body: expect.stringMatching(/"query":"mutation deleteArticle\(/),
       })
     )
   })
@@ -186,10 +186,8 @@ describe('Article versions', () => {
         new Promise((resolve) =>
           resolve({
             data: {
-              article: {
-                createVersion: {
-                  versions: ['111', '222'],
-                },
+              createArticleVersion: {
+                versions: ['111', '222'],
               },
             },
           })
@@ -220,7 +218,7 @@ describe('Article versions', () => {
     expect(fetch).toHaveBeenLastCalledWith(
       'http://localhost:3000/graphql',
       expect.objectContaining({
-        body: expect.stringMatching(/"query":"mutation createVersion\(/),
+        body: expect.stringMatching(/"query":"mutation createArticleVersion\(/),
       })
     )
   })
@@ -231,19 +229,17 @@ describe('Article versions', () => {
         new Promise((resolve) =>
           resolve({
             data: {
-              article: {
-                createVersion: {
-                  versions: [
-                    {
-                      _id: '111',
-                      message: 'This is a minor version!',
-                    },
-                    {
-                      _id: '222',
-                      message: 'This is a major version!',
-                    },
-                  ],
-                },
+              createArticleVersion: {
+                versions: [
+                  {
+                    _id: '111',
+                    message: 'This is a minor version!',
+                  },
+                  {
+                    _id: '222',
+                    message: 'This is a major version!',
+                  },
+                ],
               },
             },
           })

--- a/front/src/hooks/contact.js
+++ b/front/src/hooks/contact.js
@@ -23,7 +23,6 @@ export function useContactActions() {
         contactId,
       },
       sessionToken,
-      type: 'mutation',
     })
     await mutate(
       {
@@ -39,7 +38,6 @@ export function useContactActions() {
       query: removeContact,
       variables: { contactId },
       sessionToken,
-      type: 'mutation',
     })
     await mutate(
       {

--- a/front/src/hooks/contributor.js
+++ b/front/src/hooks/contributor.js
@@ -3,8 +3,8 @@ import { useSelector } from 'react-redux'
 import { executeQuery } from '../helpers/graphQL.js'
 import { getArticleContributors } from './Article.graphql'
 import {
-  addContributor as addContributorQuery,
-  removeContributor as removeContributorQuery,
+  addArticleContributor as addContributorQuery,
+  removeArticleContributor as removeContributorQuery,
 } from './ArticleContributors.graphql'
 import { useMutateData } from './graphql.js'
 
@@ -22,7 +22,7 @@ export function useArticleContributorActions({ articleId }) {
     })
     await mutate(async () => ({
       article: {
-        contributors: response.article.addContributor.contributors,
+        contributors: response.addArticleContributor.contributors,
       },
     }))
   }
@@ -35,7 +35,7 @@ export function useArticleContributorActions({ articleId }) {
     })
     await mutate(async () => ({
       article: {
-        contributors: response.article.removeContributor.contributors,
+        contributors: response.removeArticleContributor.contributors,
       },
     }))
   }

--- a/front/src/hooks/graphql.js
+++ b/front/src/hooks/graphql.js
@@ -110,6 +110,5 @@ async function fetch({ query, variables, sessionToken }) {
     query,
     variables,
     sessionToken,
-    type: 'fetch',
   })
 }

--- a/front/src/hooks/user.js
+++ b/front/src/hooks/user.js
@@ -130,7 +130,6 @@ export function useUserTagActions() {
     const result = await query({
       query: createTag,
       variables: tag,
-      type: 'mutation',
     })
     await mutate(
       async (data) => {
@@ -149,7 +148,6 @@ export function useUserTagActions() {
     const result = await query({
       query: updateTag,
       variables: tag,
-      type: 'mutation',
     })
     await mutate(
       async (data) => ({

--- a/front/src/hooks/workspace.js
+++ b/front/src/hooks/workspace.js
@@ -68,7 +68,6 @@ export function useWorkspaceMembersActions(workspaceId) {
       query: removeMemberMutation,
       variables: { workspaceId, userId },
       sessionToken,
-      type: 'mutation',
     })
     const result = await mutate(
       async (data) => {
@@ -89,7 +88,6 @@ export function useWorkspaceMembersActions(workspaceId) {
       query: inviteMemberMutation,
       variables: { workspaceId, userId },
       sessionToken,
-      type: 'mutation',
     })
     const result = await mutate(
       async (data) => {

--- a/graphql/models/article.js
+++ b/graphql/models/article.js
@@ -166,6 +166,39 @@ articleSchema.methods.removeTags = async function removeTags(...tagIds) {
   return this.save({ timestamps: false })
 }
 
+articleSchema.methods.rename = async function rename(title) {
+  this.set('title', title)
+  const result = await this.save({ timestamps: false })
+  return result === this
+}
+
+articleSchema.methods.setZoteroLink = async function setZoteroLink(zotero) {
+  this.set('zoteroLink', zotero)
+  const result = await this.save({ timestamps: false })
+  return result === this
+}
+
+articleSchema.methods.setNakalaLink = async function setNakalaLink(nakala) {
+  this.set('nakalaLink', nakala)
+  const result = await this.save({ timestamps: false })
+  return result === this
+}
+
+articleSchema.methods.setPreviewSettings = async function setPreviewSettings(
+  settings
+) {
+  await this.set('preview', settings, { merge: true }).save()
+  return this
+}
+
+articleSchema.methods.updateWorkingVersion =
+  async function updateWorkingVersion(content) {
+    Object.entries(content).forEach(([key, value]) =>
+      this.set(`workingVersion.${key}`, value)
+    )
+    return this.save()
+  }
+
 articleSchema.methods.shareWith = async function shareWith(user) {
   const isAlreadyShared = this.contributors.find(({ user: u }) =>
     u.equals(user)

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -558,12 +558,14 @@ module.exports = {
       })
     },
 
+    /** @deprecated Use removeArticleContributor root mutation instead. */
     async removeContributor(article, { userId }) {
       const contributorUser = await getUser(userId)
       await article.unshareWith(contributorUser)
       return article
     },
 
+    /** @deprecated Use addArticleContributor root mutation instead. */
     async addContributor(article, { userId }) {
       const contributorUser = await User.findById(userId)
       if (!contributorUser) {
@@ -586,8 +588,7 @@ module.exports = {
     },
 
     /**
-     * Delete an article.
-     *
+     * @deprecated Use deleteArticle root mutation instead.
      * @param {import('mongoose').Document<ObjectId, any, Article>} article
      * @returns {boolean} true if the article was deleted, false otherwise
      */
@@ -596,42 +597,44 @@ module.exports = {
       return true
     },
 
+    /** @deprecated Use renameArticle root mutation instead. */
     async rename(article, { title }) {
       return article.rename(title)
     },
 
+    /** @deprecated Use setArticleZoteroLink root mutation instead. */
     async setZoteroLink(article, { zotero }) {
       return article.setZoteroLink(zotero)
     },
 
+    /** @deprecated Use setArticleNakalaLink root mutation instead. */
     async setNakalaLink(article, { nakala }) {
       return article.setNakalaLink(nakala)
     },
 
+    /** @deprecated Use addArticleTags root mutation instead. */
     async addTags(article, { tags }) {
       await article.addTags(...tags)
       return article.tags
     },
 
+    /** @deprecated Use removeArticleTags root mutation instead. */
     async removeTags(article, { tags }) {
       await article.removeTags(...tags)
       return article.tags
     },
 
+    /** @deprecated Use setArticlePreviewSettings root mutation instead. */
     async setPreviewSettings(article, { settings }) {
       return article.setPreviewSettings(settings)
     },
 
+    /** @deprecated Use updateArticleWorkingVersion root mutation instead. */
     async updateWorkingVersion(article, { content }) {
       return article.updateWorkingVersion(content)
     },
 
-    /**
-     * @param article
-     * @param articleVersionInput
-     * @param context
-     * @return {Promise<Article>}
-     */
+    /** @deprecated Use createArticleVersion root mutation instead. */
     async createVersion(article, { articleVersionInput }) {
       const result = await createVersion(article, {
         ...articleVersionInput,

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -404,6 +404,87 @@ module.exports = {
         yDoc.destroy()
       }
     },
+
+    async deleteArticle(_root, { articleId, dryRun }, context) {
+      const article = await getArticleByContext(articleId, context)
+      if (dryRun) return true
+      await article.deleteOne()
+      return true
+    },
+
+    async renameArticle(_root, { articleId, title }, context) {
+      const article = await getArticleByContext(articleId, context)
+      return article.rename(title)
+    },
+
+    async setArticleZoteroLink(_root, { articleId, zotero }, context) {
+      const article = await getArticleByContext(articleId, context)
+      return article.setZoteroLink(zotero)
+    },
+
+    async setArticleNakalaLink(_root, { articleId, nakala }, context) {
+      const article = await getArticleByContext(articleId, context)
+      return article.setNakalaLink(nakala)
+    },
+
+    async addArticleTags(_root, { articleId, tags }, context) {
+      const article = await getArticleByContext(articleId, context)
+      await article.addTags(...tags)
+      return article.tags
+    },
+
+    async removeArticleTags(_root, { articleId, tags }, context) {
+      const article = await getArticleByContext(articleId, context)
+      await article.removeTags(...tags)
+      return article.tags
+    },
+
+    async setArticlePreviewSettings(_root, { articleId, settings }, context) {
+      const article = await getArticleByContext(articleId, context)
+      return article.setPreviewSettings(settings)
+    },
+
+    async updateArticleWorkingVersion(_root, { articleId, content }, context) {
+      const article = await getArticleByContext(articleId, context)
+      return article.updateWorkingVersion(content)
+    },
+
+    async addArticleContributor(_root, { articleId, userId }, context) {
+      const article = await getArticleByContext(articleId, context)
+      const contributorUser = await User.findById(userId)
+      if (!contributorUser) {
+        throw new Error(`Unable to find user with id: ${userId}`)
+      }
+      await article.shareWith(contributorUser)
+      return article
+    },
+
+    async removeArticleContributor(_root, { articleId, userId }, context) {
+      const article = await getArticleByContext(articleId, context)
+      const contributorUser = await getUser(userId)
+      await article.unshareWith(contributorUser)
+      return article
+    },
+
+    async createArticleVersion(
+      _root,
+      { articleId, articleVersionInput },
+      context
+    ) {
+      const article = await getArticleByContext(articleId, context)
+      const result = await createVersion(article, {
+        ...articleVersionInput,
+        type: 'userAction',
+      })
+      if (result === false) {
+        throw new BadRequestError(
+          'NO_CHANGE',
+          'Unable to create a new version since there is no change'
+        )
+      }
+      await article.save()
+      return article
+    },
   },
 
   Query: {
@@ -516,21 +597,15 @@ module.exports = {
     },
 
     async rename(article, { title }) {
-      article.set('title', title)
-      const result = await article.save({ timestamps: false })
-      return result === article
+      return article.rename(title)
     },
 
     async setZoteroLink(article, { zotero }) {
-      article.set('zoteroLink', zotero)
-      const result = await article.save({ timestamps: false })
-      return result === article
+      return article.setZoteroLink(zotero)
     },
 
     async setNakalaLink(article, { nakala }) {
-      article.set('nakalaLink', nakala)
-      const result = await article.save({ timestamps: false })
-      return result === article
+      return article.setNakalaLink(nakala)
     },
 
     async addTags(article, { tags }) {
@@ -544,16 +619,11 @@ module.exports = {
     },
 
     async setPreviewSettings(article, { settings }) {
-      await article.set('preview', settings, { merge: true }).save()
-      return article
+      return article.setPreviewSettings(settings)
     },
 
     async updateWorkingVersion(article, { content }) {
-      Object.entries(content).forEach(([key, value]) =>
-        article.set(`workingVersion.${key}`, value)
-      )
-
-      return article.save()
+      return article.updateWorkingVersion(content)
     },
 
     /**

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -189,17 +189,17 @@ type Article {
   updatedAt: DateTime
   workspaces: [Workspace!]
 
-  addTags(tags: [ID]!): [Tag]
-  delete(dryRun: Boolean): Boolean
-  removeTags(tags: [ID]!): [Tag]
-  rename(title: String!): Boolean
-  setPreviewSettings(settings: ArticlePreviewInput!): Article
-  setZoteroLink(zotero: String!): Boolean
-  setNakalaLink(nakala: String!): Boolean
-  updateWorkingVersion(content: WorkingVersionInput!): Article
-  addContributor(userId: ID!): Article
-  removeContributor(userId: ID!): Article
-  createVersion(articleVersionInput: ArticleVersionInput!): Article
+  addTags(tags: [ID]!): [Tag] @deprecated(reason: "Use addArticleTags mutation at the root instead.")
+  delete(dryRun: Boolean): Boolean @deprecated(reason: "Use deleteArticle mutation at the root instead.")
+  removeTags(tags: [ID]!): [Tag] @deprecated(reason: "Use removeArticleTags mutation at the root instead.")
+  rename(title: String!): Boolean @deprecated(reason: "Use renameArticle mutation at the root instead.")
+  setPreviewSettings(settings: ArticlePreviewInput!): Article @deprecated(reason: "Use setArticlePreviewSettings mutation at the root instead.")
+  setZoteroLink(zotero: String!): Boolean @deprecated(reason: "Use setArticleZoteroLink mutation at the root instead.")
+  setNakalaLink(nakala: String!): Boolean @deprecated(reason: "Use setArticleNakalaLink mutation at the root instead.")
+  updateWorkingVersion(content: WorkingVersionInput!): Article @deprecated(reason: "Use updateArticleWorkingVersion mutation at the root instead.")
+  addContributor(userId: ID!): Article @deprecated(reason: "Use addArticleContributor mutation at the root instead.")
+  removeContributor(userId: ID!): Article @deprecated(reason: "Use removeArticleContributor mutation at the root instead.")
+  createVersion(articleVersionInput: ArticleVersionInput!): Article @deprecated(reason: "Use createArticleVersion mutation at the root instead.")
 }
 
 type ArticlePreviewSettings {
@@ -678,6 +678,73 @@ type Mutation {
   Requires authentication.
   """
   importArticle(input: ImportArticleInput!): Article
+
+  """
+  Delete an article by ID.
+  Returns true if the article was deleted.
+  Requires authentication with access to the article.
+  """
+  deleteArticle(articleId: ID!, dryRun: Boolean): Boolean
+
+  """
+  Rename an article by ID.
+  Requires authentication with access to the article.
+  """
+  renameArticle(articleId: ID!, title: String!): Boolean
+
+  """
+  Set the Zotero library link on an article.
+  Requires authentication with access to the article.
+  """
+  setArticleZoteroLink(articleId: ID!, zotero: String!): Boolean
+
+  """
+  Set the Nakala dataset link on an article.
+  Requires authentication with access to the article.
+  """
+  setArticleNakalaLink(articleId: ID!, nakala: String!): Boolean
+
+  """
+  Add tags to an article. Returns the updated list of tags.
+  Requires authentication with access to the article.
+  """
+  addArticleTags(articleId: ID!, tags: [ID]!): [Tag]
+
+  """
+  Remove tags from an article. Returns the updated list of tags.
+  Requires authentication with access to the article.
+  """
+  removeArticleTags(articleId: ID!, tags: [ID]!): [Tag]
+
+  """
+  Update the preview settings (stylesheet, template) of an article.
+  Requires authentication with access to the article.
+  """
+  setArticlePreviewSettings(articleId: ID!, settings: ArticlePreviewInput!): Article
+
+  """
+  Update the working version content of an article (markdown, bibliography, metadata).
+  Requires authentication with access to the article.
+  """
+  updateArticleWorkingVersion(articleId: ID!, content: WorkingVersionInput!): Article
+
+  """
+  Add a contributor to an article, granting them write access.
+  Requires authentication with access to the article.
+  """
+  addArticleContributor(articleId: ID!, userId: ID!): Article
+
+  """
+  Remove a contributor from an article, revoking their write access.
+  Requires authentication with access to the article.
+  """
+  removeArticleContributor(articleId: ID!, userId: ID!): Article
+
+  """
+  Create a new version snapshot of an article's working copy.
+  Requires authentication with access to the article.
+  """
+  createArticleVersion(articleId: ID!, articleVersionInput: ArticleVersionInput!): Article
 }`
 
 module.exports = makeExecutableSchema({ typeDefs, resolvers })


### PR DESCRIPTION
Ajoute 11 root mutations pour remplacer progressivement les mutations imbriquées sur le type Article. Les anciennes mutations imbriquées sont conservées avec `@deprecated` pour la rétrocompatibilité.

La logique métier (`rename`, `setZoteroLink`, `setNakalaLink`, `setPreviewSettings`, `updateWorkingVersion`) est remontée dans le modèle `Article` pour éviter la duplication entre les resolvers imbriqués et les nouvelles root mutations.
