### PR TITLE
Déplacer les mutations Workspace vers la racine du schéma

### DIFF
--- a/front/src/components/organisms/workspace/WorkspaceSelectItem.jsx
+++ b/front/src/components/organisms/workspace/WorkspaceSelectItem.jsx
@@ -2,7 +2,10 @@ import clsx from 'clsx'
 import { useCallback } from 'react'
 
 import { useGraphQLClient } from '../../../helpers/graphQL.js'
-import { addArticle, removeArticle } from '../../../hooks/Workspaces.graphql'
+import {
+  addWorkspaceArticle,
+  removeWorkspaceArticle,
+} from '../../../hooks/Workspaces.graphql'
 import { useActiveWorkspaceId } from '../../../hooks/workspace.js'
 
 import styles from './WorkspaceSelectItem.module.scss'
@@ -32,7 +35,9 @@ export default function WorkspaceSelectItem({
     async (event) => {
       event.preventDefault()
       const [id, checked] = [event.target.value, event.target.checked]
-      const graphqlQuery = checked ? addArticle : removeArticle
+      const graphqlQuery = checked
+        ? addWorkspaceArticle
+        : removeWorkspaceArticle
       await query({
         query: graphqlQuery,
         variables: { articleId: articleId, workspaceId: id },

--- a/front/src/hooks/Workspaces.graphql
+++ b/front/src/hooks/Workspaces.graphql
@@ -76,26 +76,20 @@ query getWorkspaceMembers($workspaceId: ID!) {
 
 ## mutations
 
-mutation inviteMember($workspaceId: ID!, $userId: ID!) {
-  workspace(workspaceId: $workspaceId) {
-    inviteMember(userId: $userId) {
-      _id
-      members {
-        ...extendedPublicUserFields
-      }
+mutation inviteWorkspaceMember($workspaceId: ID!, $userId: ID!) {
+  inviteWorkspaceMember(workspaceId: $workspaceId, userId: $userId) {
+    _id
+    members {
+      ...extendedPublicUserFields
     }
   }
 }
 
-mutation removeMember($workspaceId: ID!, $userId: ID!) {
-  workspace(workspaceId: $workspaceId) {
-    member(userId: $userId) {
-      remove {
-        _id
-        members {
-          ...extendedPublicUserFields
-        }
-      }
+mutation removeWorkspaceMember($workspaceId: ID!, $userId: ID!) {
+  removeWorkspaceMember(workspaceId: $workspaceId, userId: $userId) {
+    _id
+    members {
+      ...extendedPublicUserFields
     }
   }
 }
@@ -122,11 +116,9 @@ mutation create($data: CreateWorkspaceInput!) {
   }
 }
 
-mutation leave($workspaceId: ID!) {
-  workspace(workspaceId: $workspaceId) {
-    leave {
-      _id
-    }
+mutation leaveWorkspace($workspaceId: ID!) {
+  leaveWorkspace(workspaceId: $workspaceId) {
+    _id
   }
 }
 
@@ -141,20 +133,14 @@ mutation updateFormMetadata(
 
 # Add/remove article
 
-mutation addArticle($workspaceId: ID!, $articleId: ID!) {
-  workspace(workspaceId: $workspaceId) {
-    addArticle(articleId: $articleId) {
-      _id
-    }
+mutation addWorkspaceArticle($workspaceId: ID!, $articleId: ID!) {
+  addWorkspaceArticle(workspaceId: $workspaceId, articleId: $articleId) {
+    _id
   }
 }
 
-mutation removeArticle($workspaceId: ID!, $articleId: ID!) {
-  workspace(workspaceId: $workspaceId) {
-    article(articleId: $articleId) {
-      remove {
-        _id
-      }
-    }
+mutation removeWorkspaceArticle($workspaceId: ID!, $articleId: ID!) {
+  removeWorkspaceArticle(workspaceId: $workspaceId, articleId: $articleId) {
+    _id
   }
 }

--- a/front/src/hooks/workspace.js
+++ b/front/src/hooks/workspace.js
@@ -10,9 +10,9 @@ import {
   create as createMutation,
   getWorkspaceMembers,
   getWorkspaces,
-  inviteMember as inviteMemberMutation,
-  leave as leaveMutation,
-  removeMember as removeMemberMutation,
+  inviteWorkspaceMember as inviteMemberMutation,
+  leaveWorkspace as leaveMutation,
+  removeWorkspaceMember as removeMemberMutation,
   updateFormMetadata as updateFormMetadataMutation,
 } from './Workspaces.graphql'
 

--- a/front/src/hooks/workspace.test.jsx
+++ b/front/src/hooks/workspace.test.jsx
@@ -54,7 +54,9 @@ describe('Workspace', () => {
     expect(fetch).toHaveBeenLastCalledWith(
       'http://localhost:3000/graphql',
       expect.objectContaining({
-        body: expect.stringMatching(/"query":"mutation inviteMember\(/),
+        body: expect.stringMatching(
+          /"query":"mutation inviteWorkspaceMember\(/
+        ),
       })
     )
   })

--- a/graphql/models/workspace.js
+++ b/graphql/models/workspace.js
@@ -143,4 +143,56 @@ const workspaceSchema = new Schema(
   }
 )
 
+workspaceSchema.methods.leave = async function leave(userId) {
+  return this.constructor.findOneAndUpdate(
+    { _id: this._id },
+    { $pull: { members: { user: new mongoose.Types.ObjectId(userId) } } },
+    { lean: true }
+  )
+}
+
+workspaceSchema.methods.inviteMember = async function inviteMember(userId) {
+  const memberAlreadyInvited = this.members.find(
+    (m) => String(m.user) === userId
+  )
+  if (memberAlreadyInvited) {
+    return this
+  }
+  this.members.push({ user: userId })
+  return this.save()
+}
+
+workspaceSchema.methods.addArticleById = async function addArticleById(
+  articleId
+) {
+  const articleAlreadyAdded = this.articles.find(
+    (id) => String(id) === articleId
+  )
+  if (articleAlreadyAdded) {
+    return this
+  }
+  this.articles.push({ _id: articleId })
+  return this.save()
+}
+
+workspaceSchema.methods.removeMember = async function removeMember(userId) {
+  const member = this.members.find((m) => String(m.user) === userId)
+  if (member) {
+    this.members.pull({ _id: member._id })
+    return this.save()
+  }
+  return this
+}
+
+workspaceSchema.methods.removeArticleById = async function removeArticleById(
+  articleId
+) {
+  const article = this.articles.find((a) => String(a._id) === articleId)
+  if (article) {
+    this.articles.pull({ _id: article._id })
+    return this.save()
+  }
+  return this
+}
+
 module.exports = mongoose.model('Workspace', workspaceSchema)

--- a/graphql/resolvers/workspaceResolver.js
+++ b/graphql/resolvers/workspaceResolver.js
@@ -1,4 +1,3 @@
-const { ObjectId } = require('mongoose').Types
 const {
   NotFoundError,
   NotAuthenticatedError,
@@ -27,6 +26,10 @@ async function getWorkspace(workspaceId, token, user) {
     return workspace
   }
 
+  if (!user) {
+    throw new NotAuthenticatedError()
+  }
+
   const workspace = await Workspace.findOne({
     $and: [{ _id: workspaceId }, { 'members.user': user?._id }],
   })
@@ -49,11 +52,8 @@ class WorkspaceArticle {
   }
 
   async remove() {
-    if (this.article) {
-      this.workspace.articles.pull({ _id: this.article._id })
-      return this.workspace.save()
-    }
-    return this.workspace
+    if (!this.article) return this.workspace
+    return this.workspace.removeArticleById(String(this.article._id))
   }
 }
 
@@ -64,11 +64,8 @@ class WorkspaceMember {
   }
 
   async remove() {
-    if (this.member) {
-      this.workspace.members.pull({ _id: this.member._id })
-      return this.workspace.save()
-    }
-    return this.workspace
+    if (!this.member) return this.workspace
+    return this.workspace.removeMember(String(this.member.user))
   }
 }
 
@@ -240,38 +237,17 @@ module.exports = {
       if (!user) {
         throw new NotAuthenticatedError()
       }
-
-      // TODO: remove workspace if there's no member left!
-      return Workspace.findOneAndUpdate(
-        { _id: new ObjectId(workspace._id) },
-        { $pull: { members: { user: new ObjectId(user.id) } } },
-        { lean: true }
-      )
+      return workspace.leave(user.id)
     },
 
     /** @deprecated Use addWorkspaceArticle root mutation instead. */
     async addArticle(workspace, { articleId }) {
-      const articleAlreadyAdded = workspace.articles.find(
-        (id) => String(id) === articleId
-      )
-      if (articleAlreadyAdded) {
-        return workspace
-      }
-      workspace.articles.push({ _id: articleId })
-      return workspace.save()
+      return workspace.addArticleById(articleId)
     },
 
     /** @deprecated Use inviteWorkspaceMember root mutation instead. */
     async inviteMember(workspace, { userId }) {
-      // question: should we check that the authenticated user "knows" the member?
-      const memberAlreadyInvited = workspace.members.find(
-        (id) => String(id) === userId
-      )
-      if (memberAlreadyInvited) {
-        return workspace
-      }
-      workspace.members.push({ user: userId })
-      return workspace.save()
+      return workspace.inviteMember(userId)
     },
   },
 }

--- a/graphql/resolvers/workspaceResolver.js
+++ b/graphql/resolvers/workspaceResolver.js
@@ -126,6 +126,35 @@ module.exports = {
      *
      */
     workspace,
+
+    async leaveWorkspace(_, { workspaceId }, { user, token }) {
+      const ws = await getWorkspace(workspaceId, token, user)
+      return ws.leave(user.id)
+    },
+
+    async inviteWorkspaceMember(_, { workspaceId, userId }, { user, token }) {
+      const ws = await getWorkspace(workspaceId, token, user)
+      return ws.inviteMember(userId)
+    },
+
+    async addWorkspaceArticle(_, { workspaceId, articleId }, { user, token }) {
+      const ws = await getWorkspace(workspaceId, token, user)
+      return ws.addArticleById(articleId)
+    },
+
+    async removeWorkspaceMember(_, { workspaceId, userId }, { user, token }) {
+      const ws = await getWorkspace(workspaceId, token, user)
+      return ws.removeMember(userId)
+    },
+
+    async removeWorkspaceArticle(
+      _,
+      { workspaceId, articleId },
+      { user, token }
+    ) {
+      const ws = await getWorkspace(workspaceId, token, user)
+      return ws.removeArticleById(articleId)
+    },
   },
 
   Query: {
@@ -206,6 +235,7 @@ module.exports = {
 
     // mutations
 
+    /** @deprecated Use leaveWorkspace root mutation instead. */
     async leave(workspace, _args, { user }) {
       if (!user) {
         throw new NotAuthenticatedError()
@@ -219,6 +249,7 @@ module.exports = {
       )
     },
 
+    /** @deprecated Use addWorkspaceArticle root mutation instead. */
     async addArticle(workspace, { articleId }) {
       const articleAlreadyAdded = workspace.articles.find(
         (id) => String(id) === articleId
@@ -230,6 +261,7 @@ module.exports = {
       return workspace.save()
     },
 
+    /** @deprecated Use inviteWorkspaceMember root mutation instead. */
     async inviteMember(workspace, { userId }) {
       // question: should we check that the authenticated user "knows" the member?
       const memberAlreadyInvited = workspace.members.find(

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -289,16 +289,14 @@ type WorkspaceArticle {
   workspace: Workspace!
   article: Article
 
-  # mutation
-  remove: Workspace!
+  remove: Workspace! @deprecated(reason: "Use removeWorkspaceArticle mutation at the root instead.")
 }
 
 type WorkspaceMember {
   workspace: Workspace!
   user: User
 
-  # mutation
-  remove: Workspace!
+  remove: Workspace! @deprecated(reason: "Use removeWorkspaceMember mutation at the root instead.")
 }
 
 type WorkspaceStats {
@@ -338,10 +336,9 @@ type Workspace {
 
   stats: WorkspaceStats
 
-  # mutations
-  leave: Workspace
-  inviteMember(userId: ID!): Workspace
-  addArticle(articleId: ID!): Workspace
+  leave: Workspace @deprecated(reason: "Use leaveWorkspace mutation at the root instead.")
+  inviteMember(userId: ID!): Workspace @deprecated(reason: "Use inviteWorkspaceMember mutation at the root instead.")
+  addArticle(articleId: ID!): Workspace @deprecated(reason: "Use addWorkspaceArticle mutation at the root instead.")
 }
 
 "Input to update the form metadata on a workspace"
@@ -627,6 +624,21 @@ type Mutation {
   Returns an error if the workspace does not exist or cannot be accessed.
   """
   workspace(workspaceId: ID!): Workspace
+
+  "Leave a workspace as the authenticated user."
+  leaveWorkspace(workspaceId: ID!): Workspace
+
+  "Invite a user to a workspace as a member."
+  inviteWorkspaceMember(workspaceId: ID!, userId: ID!): Workspace
+
+  "Add an article to a workspace."
+  addWorkspaceArticle(workspaceId: ID!, articleId: ID!): Workspace
+
+  "Remove a member from a workspace."
+  removeWorkspaceMember(workspaceId: ID!, userId: ID!): Workspace
+
+  "Remove an article from a workspace."
+  removeWorkspaceArticle(workspaceId: ID!, articleId: ID!): Workspace
 
   """
   Retrieve an article by ID to perform mutations on it.


### PR DESCRIPTION
Ajoute 5 root mutations : `leaveWorkspace`, `inviteWorkspaceMember`, `addWorkspaceArticle`, `removeWorkspaceMember`, `removeWorkspaceArticle`. La logique métier est remontée dans le modèle `Workspace`. Les mutations imbriquées sont conservées avec `@deprecated`.