### PR TITLE
Corrige la navigation avec le bouton précédent du navigateur

### DIFF
--- a/front/src/components/molecules/Toggle.jsx
+++ b/front/src/components/molecules/Toggle.jsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { Children, useCallback, useEffect, useRef, useState } from 'react'
+import { Children, useCallback, useEffect, useState } from 'react'
 
 import { useKeyPress } from '../../hooks/events.js'
 
@@ -36,25 +36,22 @@ export default function ToggleSwitch({
 }) {
   const [isChecked, setChecked] = useState(checked)
   const [isActive, setActiveState] = useState(false)
-  const isMounted = useRef(false)
-  const setActive = useCallback(() => setActiveState(true))
-  const setInactive = useCallback(() => setActiveState(false))
+  const setActive = useCallback(() => setActiveState(true), [])
+  const setInactive = useCallback(() => setActiveState(false), [])
   const a11yLabel = labels[isChecked] ? labels[isChecked] : null
 
+  useEffect(() => {
+    setChecked(checked)
+  }, [checked])
+
   const toggle = useCallback(() => {
-    setActive(true)
-    setChecked(!isChecked)
-  }, [isChecked])
+    setActive()
+    const newValue = !isChecked
+    setChecked(newValue)
+    onChange(newValue)
+  }, [isChecked, onChange])
 
   const handleKeyEvents = useKeyPress(['Enter', 'Space'], toggle)
-
-  useEffect(() => {
-    if (isMounted.current) {
-      onChange(isChecked)
-    } else {
-      isMounted.current = true
-    }
-  }, [isChecked])
 
   if (!a11yLabel && !Children.count(children)) {
     console.warn(

--- a/front/src/components/molecules/Toggle.test.jsx
+++ b/front/src/components/molecules/Toggle.test.jsx
@@ -37,9 +37,9 @@ describe('Toggle', () => {
 
     await user.click(el)
 
-    await expect(el).toBeChecked()
+    expect(el).toBeChecked()
     expect(onChange).toHaveBeenCalledOnce()
-    await expect(onChange).toHaveBeenLastCalledWith(true)
+    expect(onChange).toHaveBeenLastCalledWith(true)
   })
 
   test('does not call onChange on mount when checked=false', () => {


### PR DESCRIPTION
Déplace l'appel `onChange` directement dans le handler toggle (au lieu d'un `useEffect`) pour éviter les entrées fantômes dans l'historique du navigateur. Ajoute un `useEffect` qui synchronise l'état interne avec la prop checked lorsqu'elle change depuis l'extérieur (navigation avant/arrière).

Resolves #1781