### PR TITLE
Corrige les warnings Biome sur le frontend

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -62,7 +62,13 @@
         "useValidAnchor": "warn"
       },
       "complexity": {
-        "noUselessFragments": "warn"
+        "noUselessFragments": "warn",
+        "noExcessiveLinesPerFunction": {
+          "level": "warn",
+          "options": {
+            "maxLines": 150
+          }
+        }
       },
       "correctness": {
         "noInvalidUseBeforeDeclaration": "warn",

--- a/front/src/components/atoms/Button.jsx
+++ b/front/src/components/atoms/Button.jsx
@@ -6,7 +6,7 @@ export default function Button(props) {
   const classNames = clsx({
     [styles.primary]: props.primary,
     [styles.secondary]:
-      props.secondary || (!props.primary && !props.tertiary && !props.link),
+      props.secondary || !(props.primary || props.tertiary || props.link),
     [styles.tertiary]: props.tertiary,
     [styles.small]: props.small,
     [styles.link]: props.link,

--- a/front/src/components/atoms/TimeAgo.jsx
+++ b/front/src/components/atoms/TimeAgo.jsx
@@ -31,7 +31,7 @@ export default function TimeAgo({ date, className }) {
   const formatter = new Intl.RelativeTimeFormat(i18n.language, {
     numeric: 'auto',
   })
-  let duration = (new Date(date) - new Date()) / 1000
+  let duration = (new Date(date) - Date.now()) / 1000
   let value
   if (Math.abs(duration) < 60) {
     value = t('time.fewSecondsAgo')

--- a/front/src/components/molecules/Alert.jsx
+++ b/front/src/components/molecules/Alert.jsx
@@ -16,7 +16,7 @@ function getIcon(type) {
   if (type === 'info') {
     return <Info color={'rgb(22, 119, 255)'} />
   }
-  return <></>
+  return null
 }
 
 function getStyle(type) {
@@ -49,7 +49,7 @@ export default function Alert({
   showIcon = true,
   className,
 }) {
-  const icon = showIcon ? getIcon(type) : <></>
+  const icon = showIcon ? getIcon(type) : null
   return (
     <div role="alert" className={clsx(styles.alert, getStyle(type), className)}>
       {icon} <span>{message}</span>

--- a/front/src/components/molecules/Form.jsx
+++ b/front/src/components/molecules/Form.jsx
@@ -152,44 +152,43 @@ function ArrayFieldTemplate(properties) {
           </Translation>
         </Button>
       )}
-      {items &&
-        items.map((element) => {
-          return (
-            <div
-              id={element.key}
-              key={element.key}
-              className={clsx(
-                element.className,
-                'can-add-remove',
-                element?.uiSchema?.['ui:className']
-              )}
-            >
-              {element.children}
-              {element.hasRemove && (
-                <Button
-                  icon={inlineRemoveButton}
-                  type="button"
-                  className={[
-                    styles.removeButton,
-                    inlineRemoveButton ? styles.inlineRemoveButton : '',
-                  ].join(' ')}
-                  tabIndex={-1}
-                  disabled={element.disabled || element.readonly}
-                  onClick={element.onDropIndexClick(element.index)}
-                >
-                  <Trash />
-                  {inlineRemoveButton ? (
-                    ''
-                  ) : (
-                    <Translation ns="form" useSuspense={false}>
-                      {(t) => t(removeItemTitle)}
-                    </Translation>
-                  )}
-                </Button>
-              )}
-            </div>
-          )
-        })}
+      {items?.map((element) => {
+        return (
+          <div
+            id={element.key}
+            key={element.key}
+            className={clsx(
+              element.className,
+              'can-add-remove',
+              element?.uiSchema?.['ui:className']
+            )}
+          >
+            {element.children}
+            {element.hasRemove && (
+              <Button
+                icon={inlineRemoveButton}
+                type="button"
+                className={[
+                  styles.removeButton,
+                  inlineRemoveButton ? styles.inlineRemoveButton : '',
+                ].join(' ')}
+                tabIndex={-1}
+                disabled={element.disabled || element.readonly}
+                onClick={element.onDropIndexClick(element.index)}
+              >
+                <Trash />
+                {inlineRemoveButton ? (
+                  ''
+                ) : (
+                  <Translation ns="form" useSuspense={false}>
+                    {(t) => t(removeItemTitle)}
+                  </Translation>
+                )}
+              </Button>
+            )}
+          </div>
+        )
+      })}
     </fieldset>
   )
 }
@@ -210,7 +209,7 @@ function FieldTemplate(properties) {
     : properties.label
 
   if (properties.hidden) {
-    return <></>
+    return null
   }
   return (
     <div className={classNames} style={style}>
@@ -241,8 +240,7 @@ function ObjectFieldTemplate(properties, context) {
       ({ fields, title, importFromArticle }) => {
         const elements = fields
           .filter(
-            (field) =>
-              (properties.uiSchema[field] || {})['ui:widget'] !== 'hidden'
+            (field) => properties.uiSchema[field]?.['ui:widget'] !== 'hidden'
           )
           .map((field) => {
             const element = properties.properties.find(

--- a/front/src/components/molecules/FormActions.jsx
+++ b/front/src/components/molecules/FormActions.jsx
@@ -40,7 +40,7 @@ export default function FormActions({
       <Button
         onClick={onSubmit && (() => onSubmit())}
         primary
-        disabled={submitButton?.disabled || false}
+        disabled={submitButton?.disabled}
         aria-label={submitButton?.label && t(submitButton.label)}
         title={submitButton?.title && t(submitButton.title)}
         className={submitButton?.className}

--- a/front/src/components/molecules/SelectWidget.jsx
+++ b/front/src/components/molecules/SelectWidget.jsx
@@ -23,7 +23,7 @@ const guessType = function guessType(value) {
 
 function asNumber(value) {
   if (value === '') {
-    return undefined
+    return
   }
   if (value === null) {
     return null
@@ -68,7 +68,7 @@ function processValue(schema, uiSchema, value) {
     if (uiSchema && typeof uiSchema['ui:emptyValue'] !== 'undefined') {
       return uiSchema['ui:emptyValue']
     }
-    return undefined
+    return
   } else if (type === 'array' && items && nums.has(items.type)) {
     return value.map(asNumber)
   } else if (type === 'boolean') {

--- a/front/src/components/molecules/Toggle.jsx
+++ b/front/src/components/molecules/Toggle.jsx
@@ -53,7 +53,7 @@ export default function ToggleSwitch({
 
   const handleKeyEvents = useKeyPress(['Enter', 'Space'], toggle)
 
-  if (!a11yLabel && !Children.count(children)) {
+  if (!(a11yLabel || Children.count(children))) {
     console.warn(
       'This component is not accessible as it lacks a label (either as a child node or with the `labels` props).'
     )

--- a/front/src/components/organisms/article/ArticleForm.jsx
+++ b/front/src/components/organisms/article/ArticleForm.jsx
@@ -134,34 +134,34 @@ function WorkspacesField({ workspaceId, articleId }) {
     return <Loading />
   }
 
-  const defaultValues = data.article.workspaces.map((w) => w._id)
-  if (workspaces.length > 0) {
-    return (
-      <div>
-        <span className={formStyles.fieldLabel}>{t('header')}</span>
-
-        <ul className={checkboxStyles.inlineList}>
-          {workspaces.map((workspace) => (
-            <li key={`selectWorkspace-${workspace._id}`}>
-              <Checkbox
-                name="workspaces[]"
-                value={workspace._id}
-                color={workspace.color}
-                defaultChecked={
-                  workspaceId === workspace._id ||
-                  defaultValues.includes(workspace._id)
-                }
-              >
-                {workspace.name}
-              </Checkbox>
-            </li>
-          ))}
-        </ul>
-      </div>
-    )
+  if (workspaces.length === 0) {
+    return null
   }
 
-  return <></>
+  const defaultValues = data.article.workspaces.map((w) => w._id)
+  return (
+    <div>
+      <span className={formStyles.fieldLabel}>{t('header')}</span>
+
+      <ul className={checkboxStyles.inlineList}>
+        {workspaces.map((workspace) => (
+          <li key={`selectWorkspace-${workspace._id}`}>
+            <Checkbox
+              name="workspaces[]"
+              value={workspace._id}
+              color={workspace.color}
+              defaultChecked={
+                workspaceId === workspace._id ||
+                defaultValues.includes(workspace._id)
+              }
+            >
+              {workspace.name}
+            </Checkbox>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }
 
 function TagsField({ defaultValues = [] }) {
@@ -174,30 +174,30 @@ function TagsField({ defaultValues = [] }) {
     return <Loading />
   }
 
-  if (tags.length > 0) {
-    return (
-      <div>
-        <span className={formStyles.fieldLabel}>
-          {t('article.createForm.tagsField')}
-        </span>
-
-        <ul className={checkboxStyles.inlineList}>
-          {tags.map((t) => (
-            <li key={`selectTag-${t._id}`}>
-              <Checkbox
-                name="tags[]"
-                value={t._id}
-                color={t.color}
-                defaultChecked={defaultValues.includes(t._id)}
-              >
-                {t.name}
-              </Checkbox>
-            </li>
-          ))}
-        </ul>
-      </div>
-    )
+  if (tags.length === 0) {
+    return null
   }
 
-  return <></>
+  return (
+    <div>
+      <span className={formStyles.fieldLabel}>
+        {t('article.createForm.tagsField')}
+      </span>
+
+      <ul className={checkboxStyles.inlineList}>
+        {tags.map((t) => (
+          <li key={`selectTag-${t._id}`}>
+            <Checkbox
+              name="tags[]"
+              value={t._id}
+              color={t.color}
+              defaultChecked={defaultValues.includes(t._id)}
+            >
+              {t.name}
+            </Checkbox>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }

--- a/front/src/components/organisms/contact/ContactSearch.jsx
+++ b/front/src/components/organisms/contact/ContactSearch.jsx
@@ -99,7 +99,7 @@ export default function ContactSearch({
       } else if (event.action === 'inactive') {
         await remove(userId)
       }
-      onUserUpdated && onUserUpdated(event)
+      onUserUpdated?.(event)
     },
     [activeUserId, contacts]
   )

--- a/front/src/components/organisms/corpus/CorpusArticleMetadataSelector.jsx
+++ b/front/src/components/organisms/corpus/CorpusArticleMetadataSelector.jsx
@@ -26,7 +26,7 @@ export default function CorpusArticleMetadataSelector({
     }) ?? []
   if (error) return <Alert message={error.message} />
   if (isLoading) return <Loading />
-  if (articles.length === 0) return <></>
+  if (articles.length === 0) return null
 
   return (
     <DropdownMenu

--- a/front/src/components/organisms/corpus/CorpusSelectItem.jsx
+++ b/front/src/components/organisms/corpus/CorpusSelectItem.jsx
@@ -43,20 +43,18 @@ export default function CorpusSelectItem({
     [articleId, id, onChange]
   )
   return (
-    <>
-      <li>
-        <label className={clsx(styles.corpus, selected && styles.selected)}>
-          <input
-            name={id}
-            value={id}
-            data-id={id}
-            type="checkbox"
-            checked={selected}
-            onChange={toggleCorpusArticle}
-          />
-          <span>{name}</span>
-        </label>
-      </li>
-    </>
+    <li>
+      <label className={clsx(styles.corpus, selected && styles.selected)}>
+        <input
+          name={id}
+          value={id}
+          data-id={id}
+          type="checkbox"
+          checked={selected}
+          onChange={toggleCorpusArticle}
+        />
+        <span>{name}</span>
+      </label>
+    </li>
   )
 }

--- a/front/src/components/organisms/corpus/CorpusSelectItems.jsx
+++ b/front/src/components/organisms/corpus/CorpusSelectItems.jsx
@@ -38,21 +38,20 @@ export default function CorpusSelectItems({ articleId }) {
 
   return (
     <>
-      {data &&
-        data.corpus
-          .sort((a, b) => a.name.localeCompare(b.name))
-          .map((c) => (
-            <CorpusSelectItem
-              key={c._id}
-              id={c._id}
-              name={c.name}
-              articleId={articleId}
-              selected={c.articles
-                .map((a) => a?.article?._id)
-                .includes(articleId)}
-              onChange={handleCorpusUpdate}
-            />
-          ))}
+      {data?.corpus
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((c) => (
+          <CorpusSelectItem
+            key={c._id}
+            id={c._id}
+            name={c.name}
+            articleId={articleId}
+            selected={c.articles
+              .map((a) => a?.article?._id)
+              .includes(articleId)}
+            onChange={handleCorpusUpdate}
+          />
+        ))}
     </>
   )
 }

--- a/front/src/components/organisms/nakala/NakalaRecords.jsx
+++ b/front/src/components/organisms/nakala/NakalaRecords.jsx
@@ -18,12 +18,11 @@ export default function NakalaRecords({ collectionUri }) {
   return (
     <section>
       <div className={styles.records}>
-        {records &&
-          records.map((item, index) => (
-            <article key={index}>
-              <NakalaRecord data={item} />
-            </article>
-          ))}
+        {records?.map((item, index) => (
+          <article key={index}>
+            <NakalaRecord data={item} />
+          </article>
+        ))}
       </div>
     </section>
   )

--- a/front/src/components/organisms/textEditor/CollaborativeEditorActiveVersion.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeEditorActiveVersion.jsx
@@ -13,24 +13,24 @@ export default function CollaborativeEditorActiveVersion({ versionId }) {
     return <Alert versionId={error.message()} />
   }
 
-  if (versionId && version) {
-    const versionNumber = `${version.version}.${version.revision}`
-    const versionCodename =
-      version.message.trim().length > 0 ? `"${version.message}"` : null
-
-    const versionDate = new Intl.DateTimeFormat(i18n.language, {
-      dateStyle: 'full',
-      timeStyle: 'short',
-    }).format(new Date(version.createdAt))
-    return (
-      <Alert
-        type="info"
-        message={`Vous êtes sur la version ${versionNumber}${
-          versionCodename ? ` ${versionCodename}` : ''
-        } du ${versionDate}`}
-      ></Alert>
-    )
+  if (!(versionId && version)) {
+    return null
   }
 
-  return <></>
+  const versionNumber = `${version.version}.${version.revision}`
+  const versionCodename =
+    version.message.trim().length > 0 ? `"${version.message}"` : null
+
+  const versionDate = new Intl.DateTimeFormat(i18n.language, {
+    dateStyle: 'full',
+    timeStyle: 'short',
+  }).format(new Date(version.createdAt))
+  return (
+    <Alert
+      type="info"
+      message={`Vous êtes sur la version ${versionNumber}${
+        versionCodename ? ` ${versionCodename}` : ''
+      } du ${versionDate}`}
+    ></Alert>
+  )
 }

--- a/front/src/components/organisms/textEditor/CollaborativeEditorWebSocketStatus.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeEditorWebSocketStatus.jsx
@@ -11,7 +11,7 @@ import styles from './CollaborativeEditorWebSocketStatus.module.scss'
  */
 export default function CollaborativeEditorWebSocketStatus({ status }) {
   if (status === 'connected') {
-    return <></>
+    return null
   }
 
   if (status === 'connecting') {

--- a/front/src/components/organisms/textEditor/CollaborativeTextEditor.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeTextEditor.jsx
@@ -91,7 +91,7 @@ export default function CollaborativeTextEditor({
     shallowEqual
   )
 
-  const hasVersion = useMemo(() => !!versionId, [versionId])
+  const hasVersion = useMemo(() => Boolean(versionId), [versionId])
   const isLoading =
     yText === null ||
     isPreviewLoading ||

--- a/front/src/components/organisms/textEditor/EditorMenuContent.jsx
+++ b/front/src/components/organisms/textEditor/EditorMenuContent.jsx
@@ -20,7 +20,7 @@ export default function EditorMenuContent({
   const { t } = useTranslation()
 
   if (!activeMenu) {
-    return <></>
+    return null
   }
 
   return (

--- a/front/src/components/organisms/textEditor/actions/delimited-block.js
+++ b/front/src/components/organisms/textEditor/actions/delimited-block.js
@@ -175,8 +175,8 @@ export function createDelimitedBlockEdit(
 export default function createDelimitedBlockCommand(
   id,
   {
-    keybindings = undefined,
-    className = undefined,
+    keybindings,
+    className,
     attrs = {},
     preamble = null,
     blockDelimiter = ':::',

--- a/front/src/components/organisms/textEditor/actions/index.js
+++ b/front/src/components/organisms/textEditor/actions/index.js
@@ -212,7 +212,7 @@ export function blockAttributes({ classNames = [], attrs = {} } = {}) {
           `${key}="${typeof value === 'function' ? value(key) : value}"`
       ),
   ]
-    .flatMap((d) => d)
+    .flat()
     .filter((d) => d)
 
   return parts.length ? `{${parts.join(' ')}}` : ''

--- a/front/src/components/organisms/textEditor/actions/inline-block.js
+++ b/front/src/components/organisms/textEditor/actions/inline-block.js
@@ -46,7 +46,7 @@ function defaultSelectionState(editor) {
  * @param {{ keybindings?: number[], run: (editor: ICodeEditor) => Promise<void> }} options
  * @returns {IActionDescriptor}
  */
-function buildCommandDescriptor(id, { keybindings = undefined, run }) {
+function buildCommandDescriptor(id, { keybindings, run }) {
   return {
     id: `stylo--infratextual-markup--${id}`,
     label: `actions.infratextual-inline.${id}`,
@@ -62,8 +62,8 @@ function buildCommandDescriptor(id, { keybindings = undefined, run }) {
 export default function createInlineBlockCommand(
   id,
   {
-    keybindings = undefined,
-    className = undefined,
+    keybindings,
+    className,
     attrs = {},
     contentBefore = '[',
     contentAfter = ']',

--- a/front/src/components/organisms/user/UserBackup.jsx
+++ b/front/src/components/organisms/user/UserBackup.jsx
@@ -13,25 +13,23 @@ export default function UserBackup() {
   const { t } = useTranslation()
   const downloadDataModal = useModal()
   return (
-    <>
-      <section className={styles.section}>
-        <h2>{t('user.data.title')}</h2>
-        <div>
-          <Button primary={true} onClick={() => downloadDataModal.show()}>
-            {t('user.data.download')}
-          </Button>
-        </div>
-        <Modal
-          {...downloadDataModal.bindings}
-          title={
-            <>
-              <Download /> {t('user.data.download')}
-            </>
-          }
-        >
-          <UserBackupDownload onCancel={() => downloadDataModal.close()} />
-        </Modal>
-      </section>
-    </>
+    <section className={styles.section}>
+      <h2>{t('user.data.title')}</h2>
+      <div>
+        <Button primary={true} onClick={() => downloadDataModal.show()}>
+          {t('user.data.download')}
+        </Button>
+      </div>
+      <Modal
+        {...downloadDataModal.bindings}
+        title={
+          <>
+            <Download /> {t('user.data.download')}
+          </>
+        }
+      >
+        <UserBackupDownload onCancel={() => downloadDataModal.close()} />
+      </Modal>
+    </section>
   )
 }

--- a/front/src/components/organisms/user/UserDelete.jsx
+++ b/front/src/components/organisms/user/UserDelete.jsx
@@ -15,31 +15,29 @@ export default function UserDelete() {
   const { t } = useTranslation('user', { useSuspense: false })
   const deleteAccountModal = useModal()
   return (
-    <>
-      <section className={styles.section}>
-        <h2>{t('actions.delete.title')}</h2>
-        <div className={styles.description}>
-          {t('actions.delete.description')}
-        </div>
-        <div>
-          <Button
-            className={styles.danger}
-            onClick={() => deleteAccountModal.show()}
-          >
-            {t('actions.delete.title')}
-          </Button>
-        </div>
-        <Modal
-          {...deleteAccountModal.bindings}
-          title={
-            <>
-              <Delete /> {t('actions.delete.title')}
-            </>
-          }
+    <section className={styles.section}>
+      <h2>{t('actions.delete.title')}</h2>
+      <div className={styles.description}>
+        {t('actions.delete.description')}
+      </div>
+      <div>
+        <Button
+          className={styles.danger}
+          onClick={() => deleteAccountModal.show()}
         >
-          <UserDeleteConfirm onCancel={() => deleteAccountModal.close()} />
-        </Modal>
-      </section>
-    </>
+          {t('actions.delete.title')}
+        </Button>
+      </div>
+      <Modal
+        {...deleteAccountModal.bindings}
+        title={
+          <>
+            <Delete /> {t('actions.delete.title')}
+          </>
+        }
+      >
+        <UserDeleteConfirm onCancel={() => deleteAccountModal.close()} />
+      </Modal>
+    </section>
   )
 }

--- a/front/src/components/organisms/version/CreateVersion.jsx
+++ b/front/src/components/organisms/version/CreateVersion.jsx
@@ -33,10 +33,9 @@ export default function CreateVersion({ articleId, onClose, onSubmit }) {
         toast(t('write.createVersion.defaultNotification'), { type: 'info' })
         onSubmit()
       } catch (err) {
-        const errorMessage =
-          err.messages && err.messages.length
-            ? err.messages[0].message
-            : err.message
+        const errorMessage = err.messages?.length
+          ? err.messages[0].message
+          : err.message
         toast(errorMessage, {
           type: 'error',
         })

--- a/front/src/components/organisms/workspace/WorkspaceSelectItem.jsx
+++ b/front/src/components/organisms/workspace/WorkspaceSelectItem.jsx
@@ -42,21 +42,19 @@ export default function WorkspaceSelectItem({
     [articleId, id]
   )
   return (
-    <>
-      <li className={activeWorkspaceId === id ? clsx(styles.active) : ''}>
-        <label className={clsx(styles.workspace, selected && styles.selected)}>
-          <input
-            name={id}
-            value={id}
-            data-id={id}
-            type="checkbox"
-            checked={selected}
-            onChange={toggleWorkspaceArticle}
-          />
-          <span>{name}</span>
-          <span className={styles.chip} style={{ backgroundColor: color }} />
-        </label>
-      </li>
-    </>
+    <li className={activeWorkspaceId === id ? clsx(styles.active) : ''}>
+      <label className={clsx(styles.workspace, selected && styles.selected)}>
+        <input
+          name={id}
+          value={id}
+          data-id={id}
+          type="checkbox"
+          checked={selected}
+          onChange={toggleWorkspaceArticle}
+        />
+        <span>{name}</span>
+        <span className={styles.chip} style={{ backgroundColor: color }} />
+      </label>
+    </li>
   )
 }

--- a/front/src/helpers/analytics.js
+++ b/front/src/helpers/analytics.js
@@ -1,3 +1,4 @@
+// biome-ignore lint/complexity/useMaxParams: signature required by the built-in Matomo API
 export function trackEvent(category, action, name, value, attrs) {
   // matomo
   const _paq = (window._paq = window._paq || [])

--- a/front/src/helpers/isidore.js
+++ b/front/src/helpers/isidore.js
@@ -26,11 +26,7 @@ export async function searchKeyword(searchValue) {
             )
       })
       .then((json) => {
-        if (
-          json.response &&
-          json.response.replies &&
-          json.response.replies.reply
-        ) {
+        if (json.response?.replies?.reply) {
           if (Array.isArray(json.response.replies.reply)) {
             return json.response.replies.reply
           } else {
@@ -73,11 +69,7 @@ export async function searchAuthor(searchValue) {
             )
       })
       .then((json) => {
-        if (
-          json.response &&
-          json.response.replies &&
-          json.response.replies.reply
-        ) {
+        if (json.response?.replies?.reply) {
           if (Array.isArray(json.response.replies.reply)) {
             return json.response.replies.reply
           } else {

--- a/front/src/helpers/zotero.js
+++ b/front/src/helpers/zotero.js
@@ -107,7 +107,7 @@ function getNextLink(headers) {
   // response has a Link header with a rel=next which indicate that there a next page
   const linkNext = links.refs.find((ref) => ref.rel === 'next')
 
-  return linkNext && linkNext.uri ? new URL(linkNext.uri) : null
+  return linkNext?.uri ? new URL(linkNext.uri) : null
 }
 
 /**

--- a/front/src/hooks/article.test.jsx
+++ b/front/src/hooks/article.test.jsx
@@ -32,7 +32,7 @@ describe('Article', () => {
       })
 
       if (isLoading || error) {
-        return <></>
+        return null
       }
 
       return (
@@ -81,7 +81,7 @@ describe('Article', () => {
       })
 
       if (isLoading || error) {
-        return <></>
+        return null
       }
 
       return (

--- a/front/src/hooks/bibliography.js
+++ b/front/src/hooks/bibliography.js
@@ -31,7 +31,7 @@ export default function useBibliography({ initialText }) {
       text: bibtex,
     }
     setValidationResult(validationResult)
-    callback && callback(validationResult)
+    callback?.(validationResult)
   }, 700)
 
   const updateText = async (bibtex, callback) => {

--- a/front/src/hooks/componentVisible.js
+++ b/front/src/hooks/componentVisible.js
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 /**
  * @see https://zellwk.com/blog/keyboard-focusable-elements/
  * @param {HTMLElement} node
- * @returns {HTMLElement}
+ * @returns {T[]}
  */
 function findToggleableElements(node) {
   return Array.from(
@@ -38,7 +38,7 @@ export default function useComponentVisible(initialIsVisible) {
       if (event.key === 'Tab') {
         // const relatedMenu =
         const all = findToggleableElements(ref.current)
-        const index = all.findIndex((el) => el === event.target)
+        const index = all.indexOf(event.target)
 
         // out of range, we rotate back
         if (!event.shiftKey && index + 1 === all.length) {

--- a/front/src/hooks/nakala.js
+++ b/front/src/hooks/nakala.js
@@ -32,7 +32,7 @@ function jsonFetcher({ url, payload }) {
  * @param {import('swr').SWRConfiguration} [swrOptions] - SWR configuration options.
  * @returns {import('swr').SWRResponse} The SWR response containing data, error, isLoading, etc.
  */
-function useNakalaApi(path, payload = undefined, swrOptions = {}) {
+function useNakalaApi(path, payload, swrOptions = {}) {
   const key = () => {
     if (path === undefined) {
       throw new Error('Missing required value')

--- a/front/src/hooks/stylo-export.js
+++ b/front/src/hooks/stylo-export.js
@@ -7,7 +7,9 @@ const fetcher = (url) => fetch(url).then((response) => response.json())
 function postFetcher([url, formData]) {
   const body = new FormData()
 
-  Object.entries(formData).forEach(([key, value]) => body.append(key, value))
+  for (const [key, value] of Object.entries(formData)) {
+    body.append(key, value)
+  }
 
   return fetch(url, { method: 'POST', body }).then((response) =>
     response.text()

--- a/front/src/hooks/workspace.test.jsx
+++ b/front/src/hooks/workspace.test.jsx
@@ -24,7 +24,7 @@ describe('Workspace', () => {
         useWorkspaceMembersActions('123')
 
       if (isLoading || error) {
-        return <></>
+        return null
       }
       return (
         <div>

--- a/front/src/schemas/schemas.js
+++ b/front/src/schemas/schemas.js
@@ -59,17 +59,17 @@ export function clean(obj) {
 }
 
 export function removeEmptyArray(obj) {
-  Object.keys(obj).forEach((key) => {
+  for (const key of Object.keys(obj)) {
     const prop = obj[key]
     if (Array.isArray(prop) && prop.length === 0) delete obj[key]
     if (typeof prop === 'object' && prop !== null) {
       removeEmptyArray(prop)
     }
-  })
+  }
 }
 
 export function removeEmptyObject(obj) {
-  Object.keys(obj).forEach((key) => {
+  for (const key of Object.keys(obj)) {
     const prop = obj[key]
     if (typeof prop === 'object' && prop !== null) {
       if (Object.keys(prop).length === 0) {
@@ -78,5 +78,5 @@ export function removeEmptyObject(obj) {
         removeEmptyObject(prop)
       }
     }
-  })
+  }
 }


### PR DESCRIPTION
- Remplace `forEach` par `for...of`
- Supprime la valeur par défaut explicite `undefined` sur les paramètres de fonctions
- Supprime la valeur par défaut explicite `undefined` sur les return
- Utilise le optional chaining quand possible
- Regroupe les inversions de conditions pour simplifier les expressions
- Configure la limite de complexité des méthodes à 150 lignes (par défaut 100)
- Utilise un early return si possible
- Remplace `new Date()` par `Date.now()`
- Supprime les wrappings `<></>` inutile