### PR TITLE
Ajoute des balisages Métopes et Markdown manquants

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "root": true,
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/front/biome.json
+++ b/front/biome.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "root": false,
+  "extends": "//",
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "**",
+      "!public"
+    ]
+  }
+}

--- a/front/src/components/organisms/textEditor/CollaborativeTextEditor.module.scss
+++ b/front/src/components/organisms/textEditor/CollaborativeTextEditor.module.scss
@@ -306,6 +306,11 @@
         padding-top: 0.6em;
       }
 
+      .verse {
+        display: block;
+        white-space: pre-wrap;
+      }
+
       /* ─────────── ENCADRÉS ─────────── */
 
       .box {

--- a/front/src/components/organisms/textEditor/actions/delimited-block.js
+++ b/front/src/components/organisms/textEditor/actions/delimited-block.js
@@ -150,6 +150,31 @@ export function createDelimitedBlockEdit(
 // Command (depends on a Monaco editor instance)
 
 /**
+ *
+ * @param {string} id - Command id and default CSS class (unless `className` is provided)
+ * @param {string|(t: TFunction) => string} content - Content to insert
+ * @param {object} [opts]
+ * @param {number[]} [opts.keybindings] - Optional Monaco keybinding(s)
+ * @param {string} [opts.className] - CSS class for the fenced div (defaults to `id`)
+ * @param {{[key: string]: string}} [opts.attrs] - Additional pandoc attributes
+ * @param {null|TFunction} [opts.preamble] - Static content inserted before the opening delimiter
+ * @param {null|TFunction} [opts.preamble] - Static content inserted before the opening delimiter
+ * @param {string} [opts.contentBefore] - Static content inserted before the selected text
+ * @param {string} [opts.contentAfter] - Static content inserted after the selected text
+ * @returns {IActionDescriptor}
+ */
+export function createBlockCommand(id, content, options = {}) {
+  return createDelimitedBlockCommand(id, {
+    ...options,
+    className: '',
+    blockDelimiter: '',
+    contentBefore: '',
+    contentAfter: '',
+    preamble: typeof content === 'function' ? content : () => content,
+  })
+}
+
+/**
  * Creates a Monaco editor action that wraps the selected text (or cursor
  * position) in a pandoc fenced div (`:::`).
  * @param {string} id - Command id and default CSS class (unless `className` is provided)

--- a/front/src/components/organisms/textEditor/actions/index.js
+++ b/front/src/components/organisms/textEditor/actions/index.js
@@ -6,7 +6,9 @@ import {
   Selection,
 } from 'monaco-editor/esm/vs/editor/editor.api'
 
-import createDelimitedBlockCommand from './delimited-block.js'
+import createDelimitedBlockCommand, {
+  createBlockCommand,
+} from './delimited-block.js'
 import createInlineBlockCommand, {
   createEnclosingTextFormattingCommand,
   createHyperlinkCommand,
@@ -17,6 +19,17 @@ export { Separator } from 'monaco-editor/esm/vs/base/common/actions'
 /** @type {Record<string, Record<string, IActionDescriptor>>} */
 export const actions = {
   md: {
+    citation: createBlockCommand('citation', '> \n> \n> '),
+    delete: createEnclosingTextFormattingCommand('delete', {
+      formattingMark: '~~',
+      keybindings: [KeyMod.CtrlCmd | KeyCode.KeyD],
+    }),
+    headline1: createBlockCommand('section1', '# '),
+    headline2: createBlockCommand('section2', '## '),
+    headline3: createBlockCommand('section3', '### '),
+    headline4: createBlockCommand('section4', '#### '),
+    headline5: createBlockCommand('section5', '##### '),
+    headline6: createBlockCommand('section6', '###### '),
     italic: createEnclosingTextFormattingCommand('italic', {
       formattingMark: '_',
       keybindings: [KeyMod.CtrlCmd | KeyCode.KeyI],
@@ -30,6 +43,13 @@ export const actions = {
       keybindings: [KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyF],
     }),
     hyperlink: createHyperlinkCommand('hyperlink'),
+    separator: createBlockCommand('separator', '---'),
+    sub: createEnclosingTextFormattingCommand('sub', {
+      formattingMark: '~',
+    }),
+    sup: createEnclosingTextFormattingCommand('sup', {
+      formattingMark: '^',
+    }),
   },
   metopes: {
     acknowledgement: createDelimitedBlockCommand('ack', {
@@ -70,6 +90,12 @@ export const actions = {
     inlineQuote: createInlineBlockCommand('inlinequote', {
       className: 'inlinequote',
     }),
+    linguistic: createDelimitedBlockCommand('linguistic', {
+      attrs: { lang: 'lang-value', num: '123', label: 'value' },
+      contentBefore: '> ',
+      contentAfter:
+        '> \n[@<source>]\n\n:::{.translation lang="lang-value"}\n> \n> \n[@<source>]\n:::\n\n:::{.translation lang="lang-value"}\n> \n> \n> \n:::\n',
+    }),
     prenoteAuthor: createDelimitedBlockCommand('prenote.aut', {
       attrs: { origin: 'aut' },
       className: 'prenote',
@@ -86,30 +112,29 @@ export const actions = {
       contentBefore: '[nom de personne]{.speaker}',
     }),
     altQuote: createDelimitedBlockCommand('quote-alt'),
-    refs: createDelimitedBlockCommand('refs', {
-      preamble(t) {
-        return `\n\n## ${t('actions.preamble.refs')}`
-      },
-      blockDelimiter: '',
-      className: '',
-      // returns the cursor to its initial position
-      endCursorState({ selection }) {
-        return selection
-      },
-      // insert content at the last char of the last column
-      selectionState(editor) {
-        const model = editor.getModel()
-        const lastLineNumber = model.getLineCount()
-        const lastLineMaxChar = model.getLineMaxColumn(lastLineNumber)
+    refs: createBlockCommand(
+      'refs',
+      (t) => `\n\n## ${t('actions.preamble.refs')}`,
+      {
+        // returns the cursor to its initial position
+        endCursorState({ selection }) {
+          return selection
+        },
+        // insert content at the last char of the last column
+        selectionState(editor) {
+          const model = editor.getModel()
+          const lastLineNumber = model.getLineCount()
+          const lastLineMaxChar = model.getLineMaxColumn(lastLineNumber)
 
-        return new Selection(
-          lastLineNumber,
-          lastLineMaxChar,
-          lastLineNumber,
-          lastLineMaxChar
-        )
-      },
-    }),
+          return new Selection(
+            lastLineNumber,
+            lastLineMaxChar,
+            lastLineNumber,
+            lastLineMaxChar
+          )
+        },
+      }
+    ),
     richQuote: createDelimitedBlockCommand('rich-quote', {
       attrs: { lang: 'lang-value' },
       contentBefore: '> ',
@@ -124,10 +149,14 @@ export const actions = {
       className: 'smallcaps',
     }),
     sponsor: createDelimitedBlockCommand('sponsor'),
+    surtitle: createInlineBlockCommand('surtitle', { className: 'surtitle' }),
+    translation: createDelimitedBlockCommand('translation', {
+      attrs: { lang: 'lang-value' },
+    }),
     verse: createInlineBlockCommand('verse', {
       className: 'verse',
       contentBefore: '> [',
-      attrs: { num: '123' }
+      attrs: { num: '123' },
     }),
   },
 }
@@ -274,8 +303,11 @@ export function MetopesMenu({ editor, t }) {
         ),
         _bindAction(actions.metopes.endnote),
         _bindAction(actions.metopes.indexEntry),
+        _bindAction(actions.metopes.linguistic),
         _bindAction(actions.metopes.signature),
         _bindAction(actions.metopes.smallcaps),
+        _bindAction(actions.metopes.surtitle),
+        _bindAction(actions.metopes.translation),
       ]),
       new SubmenuAction('stylo--metopes--figure', t('stylo.metopes.figure'), [
         _bindAction(actions.metopes.figure),
@@ -294,10 +326,27 @@ export function MarkdownMenu({ editor, t }) {
     'stylo--markdown--root',
     t('stylo.markdown.rootMenu'),
     [
+      _bindAction(actions.md.hyperlink),
       _bindAction(actions.md.italic),
       _bindAction(actions.md.bold),
-      _bindAction(actions.md.hyperlink),
+      _bindAction(actions.md.delete),
+      _bindAction(actions.md.citation),
+      _bindAction(actions.md.sub),
+      _bindAction(actions.md.sup),
       _bindAction(actions.md.footnote),
+      _bindAction(actions.md.separator),
+      new SubmenuAction(
+        'stylo--markdown--headings',
+        t('stylo.markdown.headings'),
+        [
+          _bindAction(actions.md.headline1),
+          _bindAction(actions.md.headline2),
+          _bindAction(actions.md.headline3),
+          _bindAction(actions.md.headline4),
+          _bindAction(actions.md.headline5),
+          _bindAction(actions.md.headline6),
+        ]
+      ),
     ]
   )
 }

--- a/front/src/components/organisms/textEditor/actions/index.js
+++ b/front/src/components/organisms/textEditor/actions/index.js
@@ -124,6 +124,11 @@ export const actions = {
       className: 'smallcaps',
     }),
     sponsor: createDelimitedBlockCommand('sponsor'),
+    verse: createInlineBlockCommand('verse', {
+      className: 'verse',
+      contentBefore: '> [',
+      attrs: { num: '123' }
+    }),
   },
 }
 
@@ -255,6 +260,7 @@ export function MetopesMenu({ editor, t }) {
           _bindAction(actions.metopes.altQuote),
           _bindAction(actions.metopes.refs),
           _bindAction(actions.metopes.richQuote),
+          _bindAction(actions.metopes.verse),
         ]
       ),
       new SubmenuAction('stylo--metopes--texte', t('stylo.metopes.texte'), [

--- a/front/src/locales/en/editor.json
+++ b/front/src/locales/en/editor.json
@@ -28,7 +28,8 @@
       "index-entry": "Index entry",
       "inlinequote": "$t(types.inline) citation",
       "italic": "Italic",
-      "smallcaps": "$t(types.inline) small caps"
+      "smallcaps": "$t(types.inline) small caps",
+      "verse": "$t(types.inline) verse"
     },
     "preamble": {
       "refs": "Custom bibliography title"

--- a/front/src/locales/en/editor.json
+++ b/front/src/locales/en/editor.json
@@ -4,24 +4,35 @@
       "ack": "$t(types.block) acknowledgement",
       "answer": "$t(types.block) answer",
       "argument": "$t(types.block) argument",
+      "citation": "Quote",
       "credits": "$t(types.block) credits",
       "dedication": "$t(types.block) dedication",
       "epigraph": "$t(types.block) epigraph",
       "figure": "$t(types.block) figure",
+      "linguistic": "$t(types.block) linguistic",
       "outline": "$t(types.block) outline",
       "prenote.aut": "$t(types.block) preliminary note from author",
       "prenote.pbl": "$t(types.block) preliminary note from publisher",
       "prenote.tr": "$t(types.block) preliminary note from translator",
       "question": "$t(types.block) question",
-      "quote-alt": "$t(types.block) citation bis",
+      "quote-alt": "$t(types.block) alternative quote",
       "refs": "Customize bibliography heading",
       "rich-quote": "$t(types.block) rich quote",
+      "section1": "Heading 1",
+      "section2": "Heading 2",
+      "section3": "Heading 3",
+      "section4": "Heading 4",
+      "section5": "Heading 5",
+      "section6": "Heading 6",
+      "separator": "Separation line",
       "sig": "$t(types.block) signature",
-      "sponsor": "$t(types.block) sponsor"
+      "sponsor": "$t(types.block) sponsor",
+      "translation": "$t(types.block) translation"
     },
     "infratextual-inline": {
       "bold": "Bold",
       "credits": "$t(types.inline) credits",
+      "delete": "Deleted",
       "endnote": "$t(types.inline) end note",
       "footnote": "$t(types.inline) footnote",
       "hyperlink": "Hyperlink",
@@ -29,6 +40,9 @@
       "inlinequote": "$t(types.inline) citation",
       "italic": "Italic",
       "smallcaps": "$t(types.inline) small caps",
+      "sub": "Subscript",
+      "sup": "Superscript",
+      "surtitle": "$t(types.inline) surtitle",
       "verse": "$t(types.inline) verse"
     },
     "preamble": {
@@ -37,6 +51,7 @@
   },
   "stylo": {
     "markdown": {
+      "headings": "Titles",
       "rootMenu": "Lightweight markup language"
     },
     "metopes": {

--- a/front/src/locales/es/editor.json
+++ b/front/src/locales/es/editor.json
@@ -4,10 +4,12 @@
       "ack": "$t(types.block) agradecimiento",
       "answer": "$t(types.block) respuesta",
       "argument": "$t(types.block) entradilla",
+      "citation": "Cita",
       "credits": "$t(types.block) créditos",
       "dedication": "$t(types.block) dedicatoria",
       "epigraph": "$t(types.block) epígrafe",
       "figure": "$t(types.block) figura",
+      "linguistic": "$t(types.block) lingüístico",
       "outline": "$t(types.block) cuadro",
       "prenote.aut": "$t(types.block) nota preliminar del autor",
       "prenote.pbl": "$t(types.block) nota preliminar del editor",
@@ -16,12 +18,21 @@
       "quote-alt": "$t(types.block) cita bis",
       "refs": "Personalizar el título de la bibliografía",
       "rich-quote": "$t(types.block) cita compleja",
+      "section1": "Encabezado 1",
+      "section2": "Encabezado 2",
+      "section3": "Encabezado 3",
+      "section4": "Encabezado 4",
+      "section5": "Encabezado 5",
+      "section6": "Encabezado 6",
+      "separator": "Línea separadora",
       "sig": "$t(types.block) firma",
-      "sponsor": "$t(types.block) patrocinador"
+      "sponsor": "$t(types.block) patrocinador",
+      "translation": "$t(types.block) traducción"
     },
     "infratextual-inline": {
       "bold": "Negrita",
       "credits": "$t(types.inline) créditos",
+      "delete": "Eliminado",
       "endnote": "$t(types.inline) nota final",
       "footnote": "$t(types.inline) nota",
       "hyperlink": "Hipervínculo",
@@ -29,6 +40,9 @@
       "inlinequote": "$t(types.inline) cita",
       "italic": "Cursiva",
       "smallcaps": "$t(types.inline) versalitas",
+      "sub": "Subíndice",
+      "sup": "Superíndice",
+      "surtitle": "$t(types.inline) subtítulo",
       "verse": "$t(types.inline) verso"
     },
     "preamble": {
@@ -37,6 +51,7 @@
   },
   "stylo": {
     "markdown": {
+      "headings": "Títulos",
       "rootMenu": "Lenguaje de marcado ligero"
     },
     "metopes": {

--- a/front/src/locales/es/editor.json
+++ b/front/src/locales/es/editor.json
@@ -28,7 +28,8 @@
       "index-entry": "Entrada de índice",
       "inlinequote": "$t(types.inline) cita",
       "italic": "Cursiva",
-      "smallcaps": "$t(types.inline) versalitas"
+      "smallcaps": "$t(types.inline) versalitas",
+      "verse": "$t(types.inline) verso"
     },
     "preamble": {
       "refs": "Título personalizado de bibliografía"

--- a/front/src/locales/fr/editor.json
+++ b/front/src/locales/fr/editor.json
@@ -28,7 +28,8 @@
       "index-entry": "Entrée d'index",
       "inlinequote": "$t(types.inline) citation",
       "italic": "Italique",
-      "smallcaps": "$t(types.inline) petites capitales"
+      "smallcaps": "$t(types.inline) petites capitales",
+      "verse": "$t(types.inline) vers"
     },
     "preamble": {
       "refs": "Titre personnalisé de bibliographie"

--- a/front/src/locales/fr/editor.json
+++ b/front/src/locales/fr/editor.json
@@ -4,10 +4,12 @@
       "ack": "$t(types.block) remerciements",
       "answer": "$t(types.block) réponse",
       "argument": "$t(types.block) chapô introductif",
+      "citation": "Citation",
       "credits": "$t(types.block) crédits",
       "dedication": "$t(types.block) dédicace",
       "epigraph": "$t(types.block) épigraphe",
       "figure": "$t(types.block) figure",
+      "linguistic": "$t(types.block) linguistique",
       "outline": "$t(types.block) encadré",
       "prenote.aut": "$t(types.block) note préliminaire d'auteur·ice",
       "prenote.pbl": "$t(types.block) note préliminaire d'éditeur·ice",
@@ -16,12 +18,21 @@
       "quote-alt": "$t(types.block) citation bis",
       "refs": "Personnaliser le titre de la bibliographie",
       "rich-quote": "$t(types.block) citation complexe",
+      "section1": "Titre de niveau 1",
+      "section2": "Titre de niveau 2",
+      "section3": "Titre de niveau 3",
+      "section4": "Titre de niveau 4",
+      "section5": "Titre de niveau 5",
+      "section6": "Titre de niveau 6",
+      "separator": "Ligne de séparation",
       "sig": "$t(types.block) signature",
-      "sponsor": "$t(types.block) sponsor"
+      "sponsor": "$t(types.block) sponsor",
+      "translation": "$t(types.block) traduction"
     },
     "infratextual-inline": {
       "bold": "Gras",
       "credits": "$t(types.inline) crédits",
+      "delete": "Supprimé",
       "endnote": "$t(types.inline) note de fin",
       "footnote": "$t(types.inline) note de bas de page",
       "hyperlink": "Hyperlien",
@@ -29,6 +40,9 @@
       "inlinequote": "$t(types.inline) citation",
       "italic": "Italique",
       "smallcaps": "$t(types.inline) petites capitales",
+      "sub": "Indice",
+      "sup": "Exposant",
+      "surtitle": "$t(types.inline) surtitre",
       "verse": "$t(types.inline) vers"
     },
     "preamble": {
@@ -37,6 +51,7 @@
   },
   "stylo": {
     "markdown": {
+      "headings": "Titres",
       "rootMenu": "Balisage léger"
     },
     "metopes": {


### PR DESCRIPTION
J'ai reparcouru le doc de référence et déniché ces balisages absents : 

- `.linguistic`
- `.translation`
- `.verse`
- `.surtitle`

J'en ai profité pour rajouter les éléments de base Markdown : 

- incice
- exposant
- entête 1—6
- ligne de séparation
- suppression

fixes #1828 
fixes #902
refs #2010