### PR TITLE
contraint le contenu des blocs figure

### DIFF
--- a/front/src/helpers/validator/rules/metopes.js
+++ b/front/src/helpers/validator/rules/metopes.js
@@ -203,6 +203,139 @@ export function figureMustContainImage(tree, _markdown, diagnostics) {
   })
 }
 
+const FIGURE_INLINE_RX = /\[[^\]]*\]\{([^}]*)\}/g
+// Lazy alt so it tolerates span syntax hijacked into the légende, e.g.
+// `![caption [crédit]{.credits}](url)`.
+const FIGURE_IMAGE_RX = /!\[[^\n]*?\]\([^)]*\)/g
+
+/**
+ * Returns the free text left on a figure body line once the allowed direct
+ * content has been removed: the image (and its légende/alt), and the `head`
+ * and `credits` inline spans. Typographic markup nested inside those is kept
+ * within them, so it is never reported as free text.
+ * @param {string} line
+ * @returns {string}
+ */
+function figureLineFreeText(line) {
+  return line
+    .replace(FIGURE_IMAGE_RX, ' ')
+    .replace(FIGURE_INLINE_RX, (span, attrs) => {
+      const classes = parseClasses(attrs)
+      return classes.includes('head') || classes.includes('credits')
+        ? ' '
+        : span
+    })
+    .trim()
+}
+
+/**
+ * Whether a figure body line carries an inline `.credits` span. The image is
+ * stripped first so that credits hijacked into the légende (alt) do not count.
+ * @param {string} line
+ * @returns {boolean}
+ */
+function hasInlineCredits(line) {
+  const text = line.replace(FIGURE_IMAGE_RX, ' ')
+  let match
+  FIGURE_INLINE_RX.lastIndex = 0
+  while ((match = FIGURE_INLINE_RX.exec(text)) !== null) {
+    if (parseClasses(match[1]).includes('credits')) return true
+  }
+  return false
+}
+
+/**
+ * Iterate the body lines of a figure that are not inside a child div.
+ * @param {import('../pandoc-divs.js').DivNode} figure
+ * @param {string[]} lines
+ * @param {(line: string, lineNum: number) => void} fn
+ */
+function eachFigureDirectLine(figure, lines, fn) {
+  const end = figure.endLine ?? lines.length
+  const childRanges = figure.children.map((c) => [
+    c.startLine,
+    c.endLine ?? end,
+  ])
+  for (let ln = figure.startLine + 1; ln < end; ln++) {
+    if (childRanges.some(([s, e]) => ln >= s && ln <= e)) continue
+    fn(lines[ln - 1], ln)
+  }
+}
+
+/**
+ * Le contenu direct d'un bloc figure est limité à l'image, au head et aux
+ * crédits : aucun texte libre ni autre bloc.
+ *
+ * @param {import('unist').Node} _tree
+ * @param {string} markdown
+ * @param {Array} diagnostics
+ */
+export function figureContentRestricted(_tree, markdown, diagnostics) {
+  const lines = markdown.split('\n')
+  walkDivs(parsePandocFencedDivs(markdown), (figure) => {
+    if (figure.className !== 'figure') return
+    for (const child of figure.children) {
+      if (child.className === 'credits') continue
+      diagnostics.push({
+        line: child.startLine,
+        column: 1,
+        endLine: child.startLine,
+        endColumn: 4,
+        severity: 'error',
+        message: `Un bloc figure ne peut contenir que l'image, le head et les crédits (bloc ".${child.className}" non autorisé)`,
+        code: 'figure-content-restricted',
+      })
+    }
+    eachFigureDirectLine(figure, lines, (line, lineNum) => {
+      if (figureLineFreeText(line) === '') return
+      const column = line.length - line.trimStart().length + 1
+      diagnostics.push({
+        line: lineNum,
+        column,
+        endLine: lineNum,
+        endColumn: line.length + 1,
+        severity: 'error',
+        message: `Un bloc figure ne peut contenir que l'image, le head et les crédits (texte libre non autorisé)`,
+        code: 'figure-content-restricted',
+      })
+    })
+  })
+}
+
+/**
+ * Les crédits d'une figure sont autorisés soit en span, soit en div, mais pas
+ * les deux simultanément.
+ *
+ * @param {import('unist').Node} _tree
+ * @param {string} markdown
+ * @param {Array} diagnostics
+ */
+export function figureCreditsSpanOrDiv(_tree, markdown, diagnostics) {
+  const lines = markdown.split('\n')
+  walkDivs(parsePandocFencedDivs(markdown), (figure) => {
+    if (figure.className !== 'figure') return
+    const hasCreditsDiv = figure.children.some((c) => c.className === 'credits')
+    let inlineCreditsLine = null
+    eachFigureDirectLine(figure, lines, (line, lineNum) => {
+      if (inlineCreditsLine === null && hasInlineCredits(line)) {
+        inlineCreditsLine = lineNum
+      }
+    })
+    if (hasCreditsDiv && inlineCreditsLine !== null) {
+      diagnostics.push({
+        line: inlineCreditsLine,
+        column: 1,
+        endLine: inlineCreditsLine,
+        endColumn: 4,
+        severity: 'error',
+        message:
+          'Les crédits doivent être en span ou en div, mais pas les deux à la fois',
+        code: 'figure-credits-span-and-div',
+      })
+    }
+  })
+}
+
 /**
  * @param {import('unist').Node} tree
  * @param {string} _markdown
@@ -310,6 +443,8 @@ export const metopesRules = [
   singleEpigraphClass,
   questionAnswerTextOnly,
   figureMustContainImage,
+  figureContentRestricted,
+  figureCreditsSpanOrDiv,
   prenoteRequiresOrigin,
   translationRequiresLang,
   translationNotNested,

--- a/front/src/helpers/validator/rules/metopes.test.js
+++ b/front/src/helpers/validator/rules/metopes.test.js
@@ -4,6 +4,8 @@ import { unified } from 'unified'
 import { describe, expect, test } from 'vitest'
 
 import {
+  figureContentRestricted,
+  figureCreditsSpanOrDiv,
   figureMustContainImage,
   indexEntryRequiresIdref,
   prenoteRequiresOrigin,
@@ -216,6 +218,121 @@ just text
     expect(d.severity).toBe('error')
     expect(d.code).toBe('figure-missing-image')
     expect(d.line).toBe(1)
+  })
+})
+
+// ─── figureContentRestricted ─────────────────────────────────────────────────
+
+describe('figureContentRestricted()', () => {
+  test('no diagnostic for image + head + credits div', () => {
+    const md = `:::{.figure}
+
+[Carte de l'Europe après le congrès de Vienne]{.head}
+
+![Carte de l'Europe en 1815](cartes/europe-1815.png)
+
+:::{.credits}
+© Bibliothèque nationale de France, département Cartes et plans
+:::
+
+:::`
+    expect(run(figureContentRestricted, md)).toHaveLength(0)
+  })
+
+  test('no diagnostic for image + head + inline credits', () => {
+    const md = `:::{.figure}
+
+[Portrait de John Dewey]{.head}
+
+![John Dewey vers 1902](portraits/dewey.jpg)
+
+[Source : Eva Watson-Schütze, domaine public]{.credits}
+:::`
+    expect(run(figureContentRestricted, md)).toHaveLength(0)
+  })
+
+  test('no diagnostic for credits hijacked in the légende (alt)', () => {
+    const md = `:::{.figure}
+![Vue de la bibliothèque [© Gallica / BnF]{.credits}](photos/bibliotheque.jpg)
+:::`
+    expect(run(figureContentRestricted, md)).toHaveLength(0)
+  })
+
+  test('error for free text', () => {
+    const md = `:::{.figure}
+![Carte de l'Europe en 1815](cartes/europe-1815.png)
+Cette carte illustre le redécoupage des frontières.
+:::`
+    const [d] = run(figureContentRestricted, md)
+    expect(d.severity).toBe('error')
+    expect(d.code).toBe('figure-content-restricted')
+    expect(d.line).toBe(3)
+  })
+
+  test('error for a disallowed nested block', () => {
+    const md = `:::{.figure}
+![Carte de l'Europe en 1815](cartes/europe-1815.png)
+:::{.box}
+Encadré explicatif
+:::
+:::`
+    const [d] = run(figureContentRestricted, md)
+    expect(d.code).toBe('figure-content-restricted')
+    expect(d.message).toContain('.box')
+    expect(d.line).toBe(3)
+  })
+
+  test('no false positive outside a figure', () => {
+    const md = `:::{.box}
+Un encadré peut contenir du texte libre.
+:::`
+    expect(run(figureContentRestricted, md)).toHaveLength(0)
+  })
+})
+
+// ─── figureCreditsSpanOrDiv ──────────────────────────────────────────────────
+
+describe('figureCreditsSpanOrDiv()', () => {
+  test('no diagnostic for credits as div only', () => {
+    const md = `:::{.figure}
+![John Dewey vers 1902](portraits/dewey.jpg)
+:::{.credits}
+Source : Eva Watson-Schütze, domaine public
+:::
+:::`
+    expect(run(figureCreditsSpanOrDiv, md)).toHaveLength(0)
+  })
+
+  test('no diagnostic for credits as span only', () => {
+    const md = `:::{.figure}
+![John Dewey vers 1902](portraits/dewey.jpg)
+[Source : Eva Watson-Schütze, domaine public]{.credits}
+:::`
+    expect(run(figureCreditsSpanOrDiv, md)).toHaveLength(0)
+  })
+
+  test('error for credits as both span and div', () => {
+    const md = `:::{.figure}
+![John Dewey vers 1902](portraits/dewey.jpg)
+[Source : Eva Watson-Schütze, domaine public]{.credits}
+:::{.credits}
+Source : Eva Watson-Schütze, domaine public
+:::
+:::`
+    const [d] = run(figureCreditsSpanOrDiv, md)
+    expect(d.severity).toBe('error')
+    expect(d.code).toBe('figure-credits-span-and-div')
+    expect(d.line).toBe(3)
+  })
+
+  test('credits in the légende (alt) does not count as a span', () => {
+    const md = `:::{.figure}
+![Vue de la bibliothèque [© Gallica / BnF]{.credits}](photos/bibliotheque.jpg)
+:::{.credits}
+© Bibliothèque nationale de France
+:::
+:::`
+    expect(run(figureCreditsSpanOrDiv, md)).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
- le contenu direct est limité à l'image, au head et aux crédits
- les crédits sont autorisés en span ou en div, mais pas les deux