### PR TITLE
Externalise et traduit les messages de validation

### DIFF
--- a/front/src/components/organisms/textEditor/EditorValidation.jsx
+++ b/front/src/components/organisms/textEditor/EditorValidation.jsx
@@ -88,7 +88,9 @@ export default function EditorValidation({
                     <AlertTriangle size={14} />
                   )}
                 </span>
-                <span className={styles.message}>{d.message}</span>
+                <span className={styles.message}>
+                  {t(d.messageKey, d.messageParams)}
+                </span>
                 <span className={styles.location}>
                   {t('validation.line')} {d.line}
                 </span>

--- a/front/src/helpers/validator/rules/metopes.js
+++ b/front/src/helpers/validator/rules/metopes.js
@@ -75,7 +75,8 @@ export function unknownBlockClass(tree, _markdown, diagnostics) {
           endLine: node.position.start.line,
           endColumn: node.position.start.column + 3,
           severity: 'warning',
-          message: `Classe de bloc inconnue : ".${cls}"`,
+          messageKey: 'validation.rules.unknownBlockClass',
+          messageParams: { class: cls },
           code: 'unknown-block-class',
         })
       }
@@ -101,22 +102,22 @@ export function singleEpigraphClass(tree, _markdown, diagnostics) {
         endLine: node.position.start.line,
         endColumn: node.position.start.column + 3,
         severity: 'warning',
-        message: `Un seul épigraphe autorisé par document.`,
+        messageKey: 'validation.rules.singleEpigraph',
         code: 'single-epigraph-class',
       })
     }
   })
 }
 
-const QA_DISALLOWED_LABELS = {
-  list: 'liste',
-  blockquote: 'citation',
-  table: 'tableau',
-  code: 'bloc de code',
-  heading: 'titre',
-  thematicBreak: 'séparateur',
-  containerDirective: 'bloc imbriqué',
-  leafDirective: 'bloc imbriqué',
+const QA_DISALLOWED_ELEMENTS = {
+  list: 'list',
+  blockquote: 'blockquote',
+  table: 'table',
+  code: 'code',
+  heading: 'heading',
+  thematicBreak: 'thematicBreak',
+  containerDirective: 'nested',
+  leafDirective: 'nested',
 }
 
 /**
@@ -133,14 +134,18 @@ export function questionAnswerTextOnly(tree, _markdown, diagnostics) {
     for (const child of node.children || []) {
       // Seuls les paragraphes de texte (y compris le label) sont autorisés.
       if (child.type === 'paragraph') continue
-      const label = QA_DISALLOWED_LABELS[child.type] || 'cet élément'
+      const element = QA_DISALLOWED_ELEMENTS[child.type] || 'default'
       diagnostics.push({
         line: child.position.start.line,
         column: child.position.start.column,
         endLine: child.position.end.line,
         endColumn: child.position.end.column,
         severity: 'error',
-        message: `Un bloc ${node.name} ne peut contenir que du texte (${label} non autorisé)`,
+        messageKey: 'validation.rules.questionAnswerTextOnly',
+        messageParams: {
+          block: node.name,
+          element: `validation.rules.elements.${element}`,
+        },
         code: 'qa-text-only',
       })
     }
@@ -172,7 +177,8 @@ export function unknownInlineClass(tree, markdown, diagnostics) {
             endLine: lineIndex + 1,
             endColumn: match.index + match[0].length + 1,
             severity: 'warning',
-            message: `Classe inline inconnue : ".${cls}"`,
+            messageKey: 'validation.rules.unknownInlineClass',
+            messageParams: { class: cls },
             code: 'unknown-inline-class',
           })
         }
@@ -196,7 +202,7 @@ export function figureMustContainImage(tree, _markdown, diagnostics) {
         endLine: node.position.start.line,
         endColumn: node.position.start.column + 3,
         severity: 'error',
-        message: 'Un bloc figure doit contenir une image `![caption](url)`',
+        messageKey: 'validation.rules.figureMustContainImage',
         code: 'figure-missing-image',
       })
     }
@@ -282,7 +288,8 @@ export function figureContentRestricted(_tree, markdown, diagnostics) {
         endLine: child.startLine,
         endColumn: 4,
         severity: 'error',
-        message: `Un bloc figure ne peut contenir que l'image, le head et les crédits (bloc ".${child.className}" non autorisé)`,
+        messageKey: 'validation.rules.figureContentRestrictedBlock',
+        messageParams: { class: child.className },
         code: 'figure-content-restricted',
       })
     }
@@ -295,7 +302,7 @@ export function figureContentRestricted(_tree, markdown, diagnostics) {
         endLine: lineNum,
         endColumn: line.length + 1,
         severity: 'error',
-        message: `Un bloc figure ne peut contenir que l'image, le head et les crédits (texte libre non autorisé)`,
+        messageKey: 'validation.rules.figureContentRestrictedText',
         code: 'figure-content-restricted',
       })
     })
@@ -328,8 +335,7 @@ export function figureCreditsSpanOrDiv(_tree, markdown, diagnostics) {
         endLine: inlineCreditsLine,
         endColumn: 4,
         severity: 'error',
-        message:
-          'Les crédits doivent être en span ou en div, mais pas les deux à la fois',
+        messageKey: 'validation.rules.figureCreditsSpanOrDiv',
         code: 'figure-credits-span-and-div',
       })
     }
@@ -351,8 +357,7 @@ export function prenoteRequiresOrigin(tree, _markdown, diagnostics) {
         endLine: node.position.start.line,
         endColumn: node.position.start.column + 3,
         severity: 'error',
-        message:
-          'Un bloc prenote doit avoir un attribut `origin` (aut, pbl ou tr)',
+        messageKey: 'validation.rules.prenoteRequiresOrigin',
         code: 'prenote-missing-origin',
       })
     }
@@ -376,7 +381,7 @@ export function translationRequiresLang(_tree, markdown, diagnostics) {
           endLine: child.startLine,
           endColumn: 4,
           severity: 'error',
-          message: 'Un bloc translation doit avoir un attribut `lang`',
+          messageKey: 'validation.rules.translationRequiresLang',
           code: 'translation-missing-lang',
         })
       }
@@ -401,7 +406,7 @@ export function translationNotNested(_tree, markdown, diagnostics) {
           endLine: child.startLine,
           endColumn: 4,
           severity: 'error',
-          message: 'Les blocs translation ne peuvent pas être imbriqués',
+          messageKey: 'validation.rules.translationNotNested',
           code: 'translation-nesting-invalid',
         })
       }
@@ -429,7 +434,7 @@ export function indexEntryRequiresIdref(tree, markdown, diagnostics) {
           endLine: lineIndex + 1,
           endColumn: match.index + match[0].length + 1,
           severity: 'warning',
-          message: "Une entrée d'index doit avoir un attribut `idref`",
+          messageKey: 'validation.rules.indexEntryRequiresIdref',
           code: 'index-entry-missing-idref',
         })
       }

--- a/front/src/helpers/validator/rules/metopes.test.js
+++ b/front/src/helpers/validator/rules/metopes.test.js
@@ -137,7 +137,11 @@ Voici la réponse.
     const [d] = run(questionAnswerTextOnly, md)
     expect(d.severity).toBe('error')
     expect(d.code).toBe('qa-text-only')
-    expect(d.message).toContain('liste')
+    expect(d.messageKey).toBe('validation.rules.questionAnswerTextOnly')
+    expect(d.messageParams).toEqual({
+      block: 'question',
+      element: 'validation.rules.elements.list',
+    })
   })
 
   test('error for a blockquote inside an answer', () => {
@@ -146,7 +150,7 @@ Voici la réponse.
 :::`
     const [d] = run(questionAnswerTextOnly, md)
     expect(d.code).toBe('qa-text-only')
-    expect(d.message).toContain('citation')
+    expect(d.messageParams.element).toBe('validation.rules.elements.blockquote')
   })
 
   test('no false positive outside question/answer', () => {
@@ -278,7 +282,8 @@ Encadré explicatif
 :::`
     const [d] = run(figureContentRestricted, md)
     expect(d.code).toBe('figure-content-restricted')
-    expect(d.message).toContain('.box')
+    expect(d.messageKey).toBe('validation.rules.figureContentRestrictedBlock')
+    expect(d.messageParams).toEqual({ class: 'box' })
     expect(d.line).toBe(3)
   })
 

--- a/front/src/hooks/useMarkdownValidator.js
+++ b/front/src/hooks/useMarkdownValidator.js
@@ -3,6 +3,7 @@ import * as monaco from 'monaco-editor'
 import { useCallback, useRef, useState } from 'react'
 
 import { VALIDATORS } from '../helpers/validator/index.js'
+import i18n from '../i18n.js'
 
 const MARKER_OWNER = 'stylo-validator'
 
@@ -14,6 +15,15 @@ function toMonacoSeverity(severity) {
   return severity === 'error'
     ? monaco.MarkerSeverity.Error
     : monaco.MarkerSeverity.Warning
+}
+
+/**
+ * Translate a diagnostic message from its i18n key and params.
+ * @param {{ messageKey: string, messageParams?: object }} diagnostic
+ * @returns {string}
+ */
+function translateMessage({ messageKey, messageParams }) {
+  return i18n.t(messageKey, { ns: 'editor', ...messageParams })
 }
 
 /**
@@ -62,7 +72,7 @@ export function useMarkdownValidator(editorRef, profiles = ['metopes']) {
             startColumn: d.column,
             endLineNumber: d.endLine,
             endColumn: d.endColumn,
-            message: d.message,
+            message: translateMessage(d),
             severity: toMonacoSeverity(d.severity),
             code: d.code,
           }))
@@ -76,7 +86,7 @@ export function useMarkdownValidator(editorRef, profiles = ['metopes']) {
         results.map((d) => ({
           range: new monaco.Range(d.line, 1, d.endLine || d.line, 1),
           options: {
-            linesDecorationsTooltip: d.message,
+            linesDecorationsTooltip: translateMessage(d),
             linesDecorationsClassName:
               d.severity === 'error' ? 'validator-error' : 'validator-warning',
             isWholeLine: false,

--- a/front/src/locales/en/editor.json
+++ b/front/src/locales/en/editor.json
@@ -63,6 +63,30 @@
       "metopes": "Métopes"
     },
     "refreshing": "Updating…",
+    "rules": {
+      "elements": {
+        "list": "a list",
+        "blockquote": "a quotation",
+        "table": "a table",
+        "code": "a code block",
+        "heading": "a heading",
+        "thematicBreak": "a separator",
+        "nested": "a nested block",
+        "default": "this element"
+      },
+      "figureContentRestrictedBlock": "A figure block may only contain the image, the head and the credits (block `.{{class}}` is not allowed).",
+      "figureContentRestrictedText": "A figure block may only contain the image, the head and the credits (free text is not allowed).",
+      "figureCreditsSpanOrDiv": "Figure credits must be provided either inline or as a block, but not both at once.",
+      "figureMustContainImage": "A figure block must contain an image `![caption](url)`.",
+      "indexEntryRequiresIdref": "An index entry must have an `idref` attribute.",
+      "prenoteRequiresOrigin": "A prenote block must have an `origin` attribute (aut, pbl or tr).",
+      "questionAnswerTextOnly": "A `{{block}}` block may only contain text (disallowed element: $t({{element}})).",
+      "singleEpigraph": "Only one epigraph is allowed per document.",
+      "translationNotNested": "Translation blocks cannot be nested.",
+      "translationRequiresLang": "A translation block must have a `lang` attribute.",
+      "unknownBlockClass": "Unknown block class: `.{{class}}`",
+      "unknownInlineClass": "Unknown inline class: `.{{class}}`"
+    },
     "run": "Validate",
     "running": "Validating…",
     "success": "No issues found",

--- a/front/src/locales/es/editor.json
+++ b/front/src/locales/es/editor.json
@@ -63,6 +63,30 @@
       "metopes": "Métopes"
     },
     "refreshing": "Actualizando…",
+    "rules": {
+      "elements": {
+        "list": "una lista",
+        "blockquote": "una cita",
+        "table": "una tabla",
+        "code": "un bloque de código",
+        "heading": "un título",
+        "thematicBreak": "un separador",
+        "nested": "un bloque anidado",
+        "default": "este elemento"
+      },
+      "figureContentRestrictedBlock": "Un bloque figure solo puede contener la imagen, el encabezado y los créditos (no se permite el bloque `.{{class}}`).",
+      "figureContentRestrictedText": "Un bloque figure solo puede contener la imagen, el encabezado y los créditos (no se permite texto libre).",
+      "figureCreditsSpanOrDiv": "Los créditos de una figura deben indicarse en línea o en bloque, pero no de ambas formas a la vez.",
+      "figureMustContainImage": "Un bloque figure debe contener una imagen `![leyenda](url)`.",
+      "indexEntryRequiresIdref": "Una entrada de índice debe tener un atributo `idref`.",
+      "prenoteRequiresOrigin": "Un bloque prenote debe tener un atributo `origin` (aut, pbl o tr).",
+      "questionAnswerTextOnly": "Un bloque `{{block}}` solo puede contener texto (elemento no permitido: $t({{element}})).",
+      "singleEpigraph": "Solo se permite un epígrafe por documento.",
+      "translationNotNested": "Los bloques translation no pueden anidarse.",
+      "translationRequiresLang": "Un bloque translation debe tener un atributo `lang`.",
+      "unknownBlockClass": "Clase de bloque desconocida: `.{{class}}`",
+      "unknownInlineClass": "Clase en línea desconocida: `.{{class}}`"
+    },
     "run": "Validar",
     "running": "Validando…",
     "success": "No se encontraron problemas",

--- a/front/src/locales/fr/editor.json
+++ b/front/src/locales/fr/editor.json
@@ -63,6 +63,30 @@
       "metopes": "Métopes"
     },
     "refreshing": "Mise à jour…",
+    "rules": {
+      "elements": {
+        "list": "une liste",
+        "blockquote": "une citation",
+        "table": "un tableau",
+        "code": "un bloc de code",
+        "heading": "un titre",
+        "thematicBreak": "un séparateur",
+        "nested": "un bloc imbriqué",
+        "default": "cet élément"
+      },
+      "figureContentRestrictedBlock": "Un bloc figure ne peut contenir que l'image, l'en-tête et les crédits (bloc `.{{class}}` non autorisé).",
+      "figureContentRestrictedText": "Un bloc figure ne peut contenir que l'image, l'en-tête et les crédits (texte libre non autorisé).",
+      "figureCreditsSpanOrDiv": "Les crédits d'une figure doivent être indiqués soit en ligne, soit en bloc, mais pas les deux à la fois.",
+      "figureMustContainImage": "Un bloc figure doit contenir une image `![légende](url)`.",
+      "indexEntryRequiresIdref": "Une entrée d'index doit avoir un attribut `idref`.",
+      "prenoteRequiresOrigin": "Un bloc prenote doit avoir un attribut `origin` (aut, pbl ou tr).",
+      "questionAnswerTextOnly": "Un bloc `{{block}}` ne peut contenir que du texte (élément non autorisé : $t({{element}})).",
+      "singleEpigraph": "Un seul épigraphe est autorisé par document.",
+      "translationNotNested": "Les blocs translation ne peuvent pas être imbriqués.",
+      "translationRequiresLang": "Un bloc translation doit avoir un attribut `lang`.",
+      "unknownBlockClass": "Classe de bloc inconnue : `.{{class}}`",
+      "unknownInlineClass": "Classe en ligne inconnue : `.{{class}}`"
+    },
     "run": "Valider",
     "running": "Validation en cours…",
     "success": "Aucun problème détecté",


### PR DESCRIPTION
Les règles émettent une clé i18n et ses paramètres au lieu d'un message littéral ; messages traduits en fr/en/es et débarrassés des anglicismes (inline, span, div, head, caption).