### PR TITLE
évite le double chargement de Yjs (CJS + ESM)

### DIFF
--- a/graphql/app.js
+++ b/graphql/app.js
@@ -68,8 +68,10 @@ const {
 
 const { createLoaders } = require('./loaders.js')
 
-const Y = require('yjs')
 const yjsUtils = require('./helpers/yjs-utils.mjs')
+// Reuse the single (ESM) Yjs instance exposed by yjs-utils instead of
+// require('yjs') (CJS build) to avoid loading Yjs twice. See yjs#438.
+const Y = yjsUtils.Y
 const WebSocket = require('ws')
 const { handleEvents } = require('./events')
 const { requestHandler: backupRequestHandler } = require('./backup')

--- a/graphql/helpers/yjs-utils.mjs
+++ b/graphql/helpers/yjs-utils.mjs
@@ -3,10 +3,23 @@
 import * as decoding from 'lib0/decoding'
 import * as encoding from 'lib0/encoding'
 import * as map from 'lib0/map'
-import { LeveldbPersistence } from 'y-leveldb'
+// Import the ESM build of y-leveldb explicitly. Its package.json has no
+// `exports` map, so a bare `import 'y-leveldb'` resolves to `main`
+// (dist/y-leveldb.cjs), a CommonJS file that `require('yjs')` -> dist/yjs.cjs.
+// That would load Yjs a second time (alongside the ESM build used by
+// y-protocols/yjs here) and break constructor checks.
+// See https://github.com/yjs/yjs/issues/438
+// noinspection JSFileReferences
+import { LeveldbPersistence } from 'y-leveldb/src/y-leveldb.js'
 import * as awarenessProtocol from 'y-protocols/awareness'
 import * as syncProtocol from 'y-protocols/sync'
 import * as Y from 'yjs'
+
+// Re-export the ESM build of Yjs so CommonJS callers share the same module
+// instance. Mixing `require('yjs')` (dist/yjs.cjs) with the ESM `import`
+// (dist/yjs.mjs) loads Yjs twice and breaks constructor checks.
+// See https://github.com/yjs/yjs/issues/438
+export { Y }
 
 const wsReadyStateConnecting = 0
 const wsReadyStateOpen = 1

--- a/graphql/models/user.js
+++ b/graphql/models/user.js
@@ -1,4 +1,4 @@
-const Y = require('yjs')
+const { Y } = require('../helpers/yjs-utils.mjs')
 const mongoose = require('mongoose')
 const bcrypt = require('bcryptjs')
 const { randomUUID } = require('node:crypto')

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -66,7 +66,8 @@
     "ws": "~8.21.0",
     "y-leveldb": "^0.1.0",
     "y-protocols": "^1.0.5",
-    "y-websocket": "~3.0"
+    "y-websocket": "~3.0",
+    "yjs": "^13.6.31"
   },
   "devDependencies": {
     "c8": "~10.1",

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -1,6 +1,6 @@
 const { NotFoundError } = require('../helpers/errors.js')
 const YAML = require('js-yaml')
-const { WSSharedDoc } = require('../helpers/yjs-utils.mjs')
+const { WSSharedDoc, Y } = require('../helpers/yjs-utils.mjs')
 
 const Article = require('../models/article.js')
 const User = require('../models/user.js')
@@ -17,7 +17,6 @@ const {
 const { previewEntries } = require('../helpers/bibliography.js')
 const { logger } = require('../logger.js')
 const { toLegacyFormat } = require('../helpers/metadata.js')
-const Y = require('yjs')
 const mongoose = require('mongoose')
 const Sentry = require('@sentry/node')
 const {

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,7 +265,8 @@
         "ws": "~8.21.0",
         "y-leveldb": "^0.1.0",
         "y-protocols": "^1.0.5",
-        "y-websocket": "~3.0"
+        "y-websocket": "~3.0",
+        "yjs": "^13.6.31"
       },
       "devDependencies": {
         "c8": "~10.1",


### PR DESCRIPTION
Yjs était importé deux fois dans le même process : les fichiers CommonJS via require('yjs') (dist/yjs.cjs) et le reste via import ESM (dist/yjs.mjs), ce qui casse les checks de constructeur (issue yjs#438).

- yjs-utils.mjs ré-exporte Y ; app.js, articleResolver.js et user.js le récupèrent depuis yjs-utils au lieu de require('yjs')
- import explicite de la source ESM de y-leveldb (pas de carte exports, donc l'entrée par défaut est son build CJS qui require('yjs'))
- yjs ajouté en dépendance directe de graphql (était une dépendance fantôme)

Resolves #2063