### PR TITLE
Utilisation de monaco-editor@0.56

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -49,7 +49,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "lucide-react": "^0.564.0",
-    "monaco-editor": "^0.55.0",
+    "monaco-editor": "^0.56.0",
     "object-path-immutable": "^4.1.0",
     "pagedjs": "^0.4.0",
     "react": "~18.3",
@@ -73,7 +73,7 @@
     "unist-util-visit": "^5.1.0",
     "vite": "~8.0",
     "vite-plugin-handlebars": "~2.0",
-    "y-monaco": "^0.1.4",
+    "y-monaco": "^0.1.6",
     "y-websocket": "^3.0.0",
     "yjs": "^13.6.6"
   },

--- a/front/src/components/molecules/MonacoEditor.jsx
+++ b/front/src/components/molecules/MonacoEditor.jsx
@@ -1,6 +1,10 @@
 import Editor, { loader } from '@monaco-editor/react'
-import * as monaco from 'monaco-editor'
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import * as monaco from 'monaco-editor/editor'
+import editorWorker from 'monaco-editor/editor/editor.worker?worker'
+import 'monaco-editor/features/register.all.js'
+
+import 'monaco-editor/languages/definitions/markdown/register.js'
+import 'monaco-editor/languages/definitions/yaml/register.js'
 
 // Use monaco-editor as a npm package;
 // import it from node_modules and include monaco sources into your bundle (instead of using CDN).

--- a/front/src/components/organisms/bibliography/BibliographyBibtexEditor.jsx
+++ b/front/src/components/organisms/bibliography/BibliographyBibtexEditor.jsx
@@ -1,4 +1,4 @@
-import * as monaco from 'monaco-editor'
+import { Range } from 'monaco-editor/editor'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -37,7 +37,7 @@ export default function BibliographyBibtexEditor({
         setErrorDecorations(
           editorRef.current.createDecorationsCollection(
             errors.map((error) => ({
-              range: new monaco.Range(error.line, 1, error.line, 1),
+              range: new Range(error.line, 1, error.line, 1),
               options: {
                 glyphMarginHoverMessage: {
                   value: t(`biblatexparser.error.${error.type}`, error),
@@ -56,7 +56,7 @@ export default function BibliographyBibtexEditor({
         setWarningDecorations(
           editorRef.current.createDecorationsCollection(
             warnings.map((warning) => ({
-              range: new monaco.Range(warning.line, 1, warning.line, 1),
+              range: new Range(warning.line, 1, warning.line, 1),
               options: {
                 glyphMarginHoverMessage: {
                   value: t(`biblatexparser.warning.${warning.type}`, warning),

--- a/front/src/components/organisms/bibliography/BibtexEditor.jsx
+++ b/front/src/components/organisms/bibliography/BibtexEditor.jsx
@@ -1,6 +1,6 @@
 import { loader } from '@monaco-editor/react'
 import clsx from 'clsx'
-import * as monaco from 'monaco-editor'
+import * as monaco from 'monaco-editor/editor'
 import { useCallback, useMemo } from 'react'
 import fieldStyles from '../../atoms/Field.module.scss'
 

--- a/front/src/components/organisms/bibliography/support.js
+++ b/front/src/components/organisms/bibliography/support.js
@@ -1,4 +1,4 @@
-import * as vscode from 'monaco-editor'
+import { Range } from 'monaco-editor/editor'
 
 import { applicationConfig } from '../../../config.js'
 
@@ -96,7 +96,7 @@ export function onDropIntoEditor(editor) {
         const placeholder = `<!-- Uploading ${file.name} -->`
         editor.executeEdits('insert-uploading-placeholder', [
           {
-            range: new vscode.Range(lineNumber, column, lineNumber, column),
+            range: new Range(lineNumber, column, lineNumber, column),
             text: `${placeholder} `,
             forceMoveMarkers: true,
           },

--- a/front/src/components/organisms/metadata/YamlEditor.jsx
+++ b/front/src/components/organisms/metadata/YamlEditor.jsx
@@ -1,6 +1,8 @@
 import { loader } from '@monaco-editor/react'
-import * as monaco from 'monaco-editor'
+import * as monaco from 'monaco-editor/editor'
 import { useMemo } from 'react'
+
+import 'monaco-editor/languages/definitions/yaml/register.js'
 
 import { MonacoEditor } from '../../molecules/index.js'
 import defaultEditorOptions from '../monaco/options.js'

--- a/front/src/components/organisms/textEditor/CollaborativeTextEditor.jsx
+++ b/front/src/components/organisms/textEditor/CollaborativeTextEditor.jsx
@@ -4,8 +4,9 @@ import throttle from 'lodash.throttle'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { useTranslation } from 'react-i18next'
-import { MonacoBinding } from 'y-monaco'
-import 'monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon.css'
+// import { MonacoBinding } from 'y-monaco'
+
+import 'monaco-editor/features/codicon/register.js'
 
 import {
   useArticleVersion,
@@ -191,7 +192,7 @@ export default function CollaborativeTextEditor({
       // https://github.com/yjs/y-monaco/issues/27
       model.setEOL(monaco.editor.EndOfLineSequence.LF)
       if (yText && awareness) {
-        new MonacoBinding(yText, model, new Set([editor]), awareness)
+        // new MonacoBinding(yText, model, new Set([editor]), awareness)
       }
 
       onEditorReadyRef.current?.()

--- a/front/src/components/organisms/textEditor/actions/delimited-block.js
+++ b/front/src/components/organisms/textEditor/actions/delimited-block.js
@@ -1,11 +1,11 @@
-import { Selection } from 'monaco-editor/esm/vs/editor/editor.api'
+import { Selection } from 'monaco-editor/editor'
 
 import { blockAttributes } from './index.js'
 
 /**
- * @typedef {import('monaco-editor').editor.IActionDescriptor} IActionDescriptor
+ * @typedef {import('monaco-editor/editor').editor.IActionDescriptor} IActionDescriptor
  * @typedef {import('i18next').TFunction} TFunction
- * @typedef {import('monaco-editor').editor.ICodeEditor} ICodeEditor
+ * @typedef {import('monaco-editor/editor').editor.ICodeEditor} ICodeEditor
  * @typedef {import('./inline-block.js').EditResult} EditResult
  */
 const newLineRE = /\n/g

--- a/front/src/components/organisms/textEditor/actions/delimited-block.test.js
+++ b/front/src/components/organisms/textEditor/actions/delimited-block.test.js
@@ -1,4 +1,4 @@
-import { Selection } from 'monaco-editor/esm/vs/editor/editor.api'
+import { Selection } from 'monaco-editor/editor'
 import { describe, expect, test } from 'vitest'
 
 import { createDelimitedBlockEdit } from './delimited-block.js'

--- a/front/src/components/organisms/textEditor/actions/index.js
+++ b/front/src/components/organisms/textEditor/actions/index.js
@@ -1,10 +1,11 @@
-import { SubmenuAction } from 'monaco-editor/esm/vs/base/common/actions'
 import {
   editor as _editor,
   KeyCode,
   KeyMod,
   Selection,
-} from 'monaco-editor/esm/vs/editor/editor.api'
+} from 'monaco-editor/editor'
+
+export { Separator, SubmenuAction } from 'monaco-editor/base/common/actions'
 
 import createDelimitedBlockCommand, {
   createBlockCommand,
@@ -13,8 +14,6 @@ import createInlineBlockCommand, {
   createEnclosingTextFormattingCommand,
   createHyperlinkCommand,
 } from './inline-block.js'
-
-export { Separator } from 'monaco-editor/esm/vs/base/common/actions'
 
 /** @type {Record<string, Record<string, IActionDescriptor>>} */
 export const actions = {

--- a/front/src/components/organisms/textEditor/actions/inline-block.js
+++ b/front/src/components/organisms/textEditor/actions/inline-block.js
@@ -1,16 +1,12 @@
-import {
-  KeyCode,
-  KeyMod,
-  Selection,
-} from 'monaco-editor/esm/vs/editor/editor.api'
+import { KeyCode, KeyMod, Selection } from 'monaco-editor/editor'
 
 import { blockAttributes } from './index.js'
 
 /**
- * @typedef {import('monaco-editor').editor.IActionDescriptor} IActionDescriptor
- * @typedef {import('monaco-editor').editor.ICodeEditor} ICodeEditor
- * @typedef {import('monaco-editor').IRange} IRange
- * @typedef {import('monaco-editor').ISelection} ISelection
+ * @typedef {import('monaco-editor/editor').editor.IActionDescriptor} IActionDescriptor
+ * @typedef {import('monaco-editor/editor').editor.ICodeEditor} ICodeEditor
+ * @typedef {import('monaco-editor/editor').IRange} IRange
+ * @typedef {import('monaco-editor/editor').ISelection} ISelection
  */
 
 /**

--- a/front/src/hooks/useMarkdownValidator.js
+++ b/front/src/hooks/useMarkdownValidator.js
@@ -1,5 +1,5 @@
 import throttle from 'lodash.throttle'
-import * as monaco from 'monaco-editor'
+import { MarkerSeverity, Range } from 'monaco-editor/editor'
 import { useCallback, useRef, useState } from 'react'
 
 import { VALIDATORS } from '../helpers/validator/index.js'
@@ -12,9 +12,7 @@ const MARKER_OWNER = 'stylo-validator'
  * @returns {number}
  */
 function toMonacoSeverity(severity) {
-  return severity === 'error'
-    ? monaco.MarkerSeverity.Error
-    : monaco.MarkerSeverity.Warning
+  return severity === 'error' ? MarkerSeverity.Error : MarkerSeverity.Warning
 }
 
 /**
@@ -64,7 +62,7 @@ export function useMarkdownValidator(editorRef, profiles = ['metopes']) {
 
       const model = editor.getModel()
       if (model) {
-        monaco.editor.setModelMarkers(
+        editor.setModelMarkers(
           model,
           MARKER_OWNER,
           results.map((d) => ({
@@ -84,7 +82,7 @@ export function useMarkdownValidator(editorRef, profiles = ['metopes']) {
       }
       decorationsRef.current = editor.createDecorationsCollection(
         results.map((d) => ({
-          range: new monaco.Range(d.line, 1, d.endLine || d.line, 1),
+          range: new Range(d.line, 1, d.endLine || d.line, 1),
           options: {
             linesDecorationsTooltip: translateMessage(d),
             linesDecorationsClassName:
@@ -133,7 +131,7 @@ export function useMarkdownValidator(editorRef, profiles = ['metopes']) {
     const editor = editorRef.current
     const model = editor?.getModel()
     if (model) {
-      monaco.editor.setModelMarkers(model, MARKER_OWNER, [])
+      editor.setModelMarkers(model, MARKER_OWNER, [])
     }
     if (decorationsRef.current) {
       decorationsRef.current.clear()

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
         "lucide-react": "^0.564.0",
-        "monaco-editor": "^0.55.0",
+        "monaco-editor": "^0.56.0",
         "object-path-immutable": "^4.1.0",
         "pagedjs": "^0.4.0",
         "react": "~18.3",
@@ -72,7 +72,7 @@
         "unist-util-visit": "^5.1.0",
         "vite": "~8.0",
         "vite-plugin-handlebars": "~2.0",
-        "y-monaco": "^0.1.4",
+        "y-monaco": "^0.1.6",
         "y-websocket": "^3.0.0",
         "yjs": "^13.6.6"
       },
@@ -9275,19 +9275,19 @@
       "license": "MIT"
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "3.4.8",
         "marked": "14.0.0"
       }
     },
     "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
- [ ] compatibilité de `y-monaco` avec les nouveaux chemins (cf. https://github.com/yjs/y-monaco/pull/31)


## Après

```
build/assets/ContactSearch--TL11JWN.js                10.90 kB │ gzip:     3.08 kB │ map:     17.95 kB
build/assets/graphql-BQuOVZrF.js                      12.00 kB │ gzip:     5.30 kB │ map:     84.90 kB
build/assets/Articles-B3h0dKKw.js                     16.93 kB │ gzip:     4.46 kB │ map:     35.99 kB
build/assets/translation-DIHjll9c.js                  19.07 kB │ gzip:     5.35 kB │ map:     22.56 kB
build/assets/translation-CgN_QXVe.js                  20.44 kB │ gzip:     5.96 kB │ map:     23.92 kB
build/assets/translation-Cr87XXn3.js                  20.79 kB │ gzip:     6.02 kB │ map:     24.28 kB
build/assets/Corpus-DXnsXcxu.js                       28.39 kB │ gzip:     6.73 kB │ map:     76.11 kB
build/assets/graphQL-CzakA68d.js                      29.41 kB │ gzip:     6.35 kB │ map:     67.83 kB
build/assets/molecules-D-wqo8mj.js                    51.17 kB │ gzip:    15.86 kB │ map:    267.12 kB
build/assets/core-Bu-XPn5w.js                        461.47 kB │ gzip:   142.66 kB │ map:  1,660.92 kB
build/assets/index-CAdrFh0D.js                       998.35 kB │ gzip:   271.28 kB │ map:  4,187.63 kB
build/assets/textEditor-lW6zdkkI.js                3,914.77 kB │ gzip: 1,004.23 kB │ map: 14,815.40 kB
```

## Avant

```
build/assets/ContactSearch-CTW2XGBp.js                10.90 kB │ gzip:     3.08 kB │ map:     17.95 kB
build/assets/graphql-BQuOVZrF.js                      12.00 kB │ gzip:     5.30 kB │ map:     84.90 kB
build/assets/Articles-BsEE7VvG.js                     16.93 kB │ gzip:     4.46 kB │ map:     35.99 kB
build/assets/translation-DIHjll9c.js                  19.07 kB │ gzip:     5.35 kB │ map:     22.56 kB
build/assets/translation-CgN_QXVe.js                  20.44 kB │ gzip:     5.96 kB │ map:     23.92 kB
build/assets/translation-Cr87XXn3.js                  20.79 kB │ gzip:     6.02 kB │ map:     24.28 kB
build/assets/Corpus-C2xHLMKz.js                       28.39 kB │ gzip:     6.73 kB │ map:     76.11 kB
build/assets/graphQL-CzakA68d.js                      29.41 kB │ gzip:     6.35 kB │ map:     67.83 kB
build/assets/molecules-BuDT93kQ.js                    51.17 kB │ gzip:    15.86 kB │ map:    266.94 kB
build/assets/core-Bu-XPn5w.js                        461.47 kB │ gzip:   142.66 kB │ map:  1,660.92 kB
build/assets/index-BAg4ypIP.js                       998.34 kB │ gzip:   271.35 kB │ map:  4,187.76 kB
build/assets/textEditor-BucJaPMI.js                4,289.57 kB │ gzip: 1,100.59 kB │ map: 15,809.49 kB
```