### PR TITLE
fix(backup): inclut le contenu Markdown réel de la copie de travail

### DIFF
--- a/graphql/backup/index.js
+++ b/graphql/backup/index.js
@@ -6,6 +6,7 @@ const Article = require('../models/article')
 const { createLoaders } = require('../loaders')
 const Workspace = require('../models/workspace')
 const Version = require('../models/version')
+const { WorkingVersion } = require('../resolvers/articleResolver')
 
 /**
  * Error thrown when the backup request contains invalid parameters.
@@ -238,6 +239,13 @@ async function getArticles(config) {
       email,
       username,
     }
+    // The working copy's Markdown content lives in the Y.js CRDT document
+    // (`workingVersion.ydoc`), kept up to date by the collaborative editor.
+    // `workingVersion.md` is a legacy field that is no longer written to, so
+    // it must be derived from `ydoc` before the latter is discarded.
+    article.workingVersion.md = WorkingVersion.md(article.workingVersion, {
+      articleId: article._id,
+    })
     delete article.workingVersion.ydoc
     for (const tag of article.tags) {
       delete tag.articles

--- a/graphql/helpers/yjs-utils.mjs
+++ b/graphql/helpers/yjs-utils.mjs
@@ -132,6 +132,25 @@ export class WSSharedDoc extends Y.Doc {
 }
 
 /**
+ * Decodes the plain text (Markdown) content stored in a base64-encoded Y.js document update.
+ *
+ * @param {string} yjsdocBase64 - base64-encoded Y.js document state (`workingVersion.ydoc`)
+ * @return {string} the text content of the "main" shared text
+ */
+export const getTextFromYjsDoc = (yjsdocBase64) => {
+  if (!yjsdocBase64) {
+    return ''
+  }
+  const wsDoc = new WSSharedDoc(`ws/${Math.random().toString(36).slice(2)}`)
+  try {
+    Y.applyUpdate(wsDoc, Buffer.from(yjsdocBase64, 'base64'))
+    return wsDoc.getText('main').toString()
+  } finally {
+    wsDoc.destroy()
+  }
+}
+
+/**
  * Gets a Y.Doc by name, whether in memory or on disk
  *
  * @param {string} docname - the name of the Y.Doc to find or create

--- a/graphql/resolvers/articleResolver.js
+++ b/graphql/resolvers/articleResolver.js
@@ -1,6 +1,6 @@
 const { NotFoundError } = require('../helpers/errors.js')
 const YAML = require('js-yaml')
-const { WSSharedDoc, Y } = require('../helpers/yjs-utils.mjs')
+const { Y, getTextFromYjsDoc } = require('../helpers/yjs-utils.mjs')
 
 const Article = require('../models/article.js')
 const User = require('../models/user.js')
@@ -17,25 +17,12 @@ const {
 const { previewEntries } = require('../helpers/bibliography.js')
 const { logger } = require('../logger.js')
 const { toLegacyFormat } = require('../helpers/metadata.js')
-const mongoose = require('mongoose')
 const Sentry = require('@sentry/node')
 const {
   NotAuthenticatedError,
   BadRequestError,
 } = require('../helpers/errors.js')
 const { toEntries } = require('../helpers/bibtex')
-
-function getTextFromYjsDoc(yjsdocBase64) {
-  const wsDoc = new WSSharedDoc(
-    `ws/${new mongoose.Types.ObjectId().toString()}`
-  )
-  try {
-    Y.applyUpdate(wsDoc, Buffer.from(yjsdocBase64, 'base64'))
-    return wsDoc.getText('main').toString()
-  } finally {
-    wsDoc.destroy()
-  }
-}
 
 async function getUser(userId) {
   const user = await User.findById(userId)
@@ -651,14 +638,14 @@ module.exports = {
   },
 
   WorkingVersion: {
-    md({ ydoc = '' }) {
+    md({ ydoc = '' }, { articleId } = {}) {
       try {
         return getTextFromYjsDoc(ydoc)
       } catch (err) {
         Sentry.captureException(err)
-        console.error(
-          'Unable to load text content (Markdown) from the Y.js document on article',
-          err
+        logger.error(
+          { err, articleId },
+          'Unable to load text content (Markdown) from the Y.js document on the working version'
         )
         return ''
       }


### PR DESCRIPTION
Le téléchargement JSON/ZIP des articles lisait workingVersion.md directement depuis Mongo, un champ legacy qui n'est plus jamais réécrit depuis le passage à l'édition collaborative (Yjs). Le contenu Markdown vivant n'existe que dans workingVersion.ydoc (CRDT binaire), décodé jusqu'ici seulement par le resolver GraphQL WorkingVersion.md.

Comme la route /backup ne passe pas par GraphQL, ce resolver n'était jamais invoqué, d'où un article Markdown vide dans l'export alors que métadonnées et bibliographie apparaissaient normalement.

- extrait getTextFromYjsDoc() dans yjs-utils.mjs pour la partager
- graphql/backup/index.js appelle désormais WorkingVersion.md() directement pour peupler workingVersion.md avant de supprimer ydoc
- précise le message d'erreur du resolver et ajoute l'articleId au contexte de log

Fixes https://github.com/EcrituresNumeriques/stylo/issues/2075