### PR TITLE
feat(graphql): déplace les mutations Corpus et Version vers la racine du schéma

### DIFF
--- a/front/src/hooks/Corpus.graphql
+++ b/front/src/hooks/Corpus.graphql
@@ -106,44 +106,32 @@ mutation createCorpus($createCorpusInput: CreateCorpusInput!) {
 }
 
 mutation deleteCorpus($corpusId: ID!) {
-  corpus(corpusId: $corpusId) {
-    delete {
-      _id
-    }
+  deleteCorpus(corpusId: $corpusId) {
+    _id
   }
 }
 
 mutation updateMetadata($corpusId: ID!, $metadata: JSON!) {
-  corpus(corpusId: $corpusId) {
-    updateMetadata(metadata: $metadata) {
-      _id
-    }
+  updateCorpusMetadata(corpusId: $corpusId, metadata: $metadata) {
+    _id
   }
 }
 
 mutation updateCorpus($corpusId: ID!, $updateCorpusInput: UpdateCorpusInput!) {
-  corpus(corpusId: $corpusId) {
-    update(updateCorpusInput: $updateCorpusInput) {
-      _id
-    }
+  updateCorpus(corpusId: $corpusId, updateCorpusInput: $updateCorpusInput) {
+    _id
   }
 }
 
 mutation removeArticleFromCorpus($corpusId: ID!, $articleId: ID!) {
-  corpus(corpusId: $corpusId) {
-    article(articleId: $articleId) {
-      remove {
-        _id
-      }
-    }
+  removeCorpusArticle(corpusId: $corpusId, articleId: $articleId) {
+    _id
   }
 }
 
 mutation addArticleToCorpus($corpusId: ID!, $articleId: ID!) {
-  corpus(corpusId: $corpusId) {
-    addArticle(articleId: $articleId) {
-      _id
-    }
+  addCorpusArticle(corpusId: $corpusId, articleId: $articleId) {
+    _id
   }
 }
 
@@ -151,10 +139,11 @@ mutation updateArticlesOrder(
   $corpusId: ID!
   $articlesOrderInput: [ArticleOrder!]!
 ) {
-  corpus(corpusId: $corpusId) {
-    updateArticlesOrder(articlesOrderInput: $articlesOrderInput) {
-      _id
-    }
+  updateCorpusArticlesOrder(
+    corpusId: $corpusId
+    articlesOrderInput: $articlesOrderInput
+  ) {
+    _id
   }
 }
 

--- a/front/src/hooks/Versions.graphql
+++ b/front/src/hooks/Versions.graphql
@@ -12,10 +12,8 @@ fragment basicVersionFields on Version {
   type
 }
 
-query renameVersion($version: ID!, $name: String) {
-  version(version: $version) {
-    rename(name: $name)
-  }
+mutation renameVersion($versionId: ID!, $name: String) {
+  renameVersion(versionId: $versionId, name: $name)
 }
 
 query getArticleVersions($article: ID!) {

--- a/front/src/hooks/article.js
+++ b/front/src/hooks/article.js
@@ -554,7 +554,7 @@ export function useArticleVersionActions({ articleId }) {
     await executeQuery({
       query: renameVersion,
       variables: {
-        version: versionId,
+        versionId,
         name: description,
       },
       sessionToken,

--- a/front/src/hooks/article.test.jsx
+++ b/front/src/hooks/article.test.jsx
@@ -270,7 +270,7 @@ describe('Article versions', () => {
     expect(fetch).toHaveBeenLastCalledWith(
       'http://localhost:3000/graphql',
       expect.objectContaining({
-        body: expect.stringMatching(/"query":"query renameVersion\(/),
+        body: expect.stringMatching(/"query":"mutation renameVersion\(/),
       })
     )
   })

--- a/graphql/models/corpus.js
+++ b/graphql/models/corpus.js
@@ -84,4 +84,101 @@ const corpusSchema = new Schema(
   }
 )
 
+corpusSchema.methods.rename = async function rename(name) {
+  this.name = name
+  return this.save()
+}
+
+corpusSchema.methods.updateMetadata = async function updateMetadata(metadata) {
+  this.metadata = metadata
+  return this.save()
+}
+
+corpusSchema.methods.update = async function update(updateCorpusInput) {
+  const name = updateCorpusInput.name
+  if (name !== undefined && name !== null) {
+    this.name = name
+  }
+  const description = updateCorpusInput.description
+  if (description !== undefined && description !== null) {
+    this.description = description
+  }
+  const metadata = updateCorpusInput.metadata
+  if (metadata !== undefined) {
+    this.metadata = metadata
+  }
+  return this.save()
+}
+
+corpusSchema.methods.addArticleById = async function addArticleById(
+  articleId,
+  order
+) {
+  const articleAlreadyAdded = this.articles.find(
+    ({ article }) => article.id === articleId
+  )
+  if (articleAlreadyAdded) {
+    return this
+  }
+  this.articles.push({ article: { _id: articleId }, order })
+  return this.save()
+}
+
+corpusSchema.methods.removeArticleById = async function removeArticleById(
+  articleId
+) {
+  const entry = this.articles.find(({ article }) => article.equals(articleId))
+  if (entry) {
+    this.articles.pull({ _id: entry._id })
+    return this.save()
+  }
+  return this
+}
+
+corpusSchema.methods.moveArticle = async function moveArticle(
+  articleId,
+  order
+) {
+  const entry = this.articles.find(({ article }) => article.equals(articleId))
+  if (!entry) {
+    return this
+  }
+  const map = new Map(this.articles.map((obj) => [obj.order, obj]))
+  const currentOrder = entry.order
+  if (order < currentOrder) {
+    for (let i = order; i < currentOrder; i++) {
+      const a = map.get(i)
+      if (a) {
+        a.order = a.order + 1
+      }
+    }
+  } else {
+    for (let i = currentOrder; i < order; i++) {
+      const a = map.get(i)
+      if (a) {
+        a.order = a.order - 1
+      }
+    }
+  }
+  entry.order = order
+  return this.save()
+}
+
+corpusSchema.methods.updateArticlesOrder = async function updateArticlesOrder(
+  articlesOrderInput
+) {
+  const articlesOrderMap = articlesOrderInput.reduce((acc, item) => {
+    acc[item.articleId] = item.order
+    return acc
+  }, {})
+  this.articles = this.articles.map((corpusArticle) => {
+    const order = articlesOrderMap[corpusArticle.article._id]
+    return {
+      article: corpusArticle.article,
+      order,
+    }
+  })
+  return this.save()
+}
+
 module.exports = mongoose.model('Corpus', corpusSchema)

--- a/graphql/models/version.js
+++ b/graphql/models/version.js
@@ -61,4 +61,10 @@ const versionSchema = new Schema(
   }
 )
 
+versionSchema.methods.rename = async function rename(name) {
+  this.set('message', name)
+  const result = await this.save({ timestamps: false })
+  return result === this
+}
+
 module.exports = mongoose.model('Version', versionSchema)

--- a/graphql/resolvers/corpusResolver.js
+++ b/graphql/resolvers/corpusResolver.js
@@ -58,37 +58,26 @@ class CorpusArticle {
 
   async remove() {
     if (this._article) {
-      this.corpus.articles.pull({ _id: this._article._id })
-      return this.corpus.save()
+      return this.corpus.removeArticleById(articleRefId(this._article.article))
     }
     return this.corpus
   }
 
   async move(order) {
     if (this._article) {
-      const articles = this.corpus.articles
-      const map = new Map(articles.map((obj) => [obj.order, obj]))
-      const currentOrder = this._article.order
-      if (order < currentOrder) {
-        for (let i = order; i < currentOrder; i++) {
-          const article = map.get(i)
-          if (article) {
-            article.order = article.order + 1
-          }
-        }
-      } else {
-        for (let i = currentOrder; i < order; i++) {
-          const article = map.get(i)
-          if (article) {
-            article.order = article.order - 1
-          }
-        }
-      }
-      this._article.order = order
-      return this.corpus.save()
+      return this.corpus.moveArticle(articleRefId(this._article.article), order)
     }
     return this.corpus
   }
+}
+
+/**
+ * A corpus article's `article` ref field is normally a bare ObjectId, but
+ * some code paths (and fixtures) store the whole Article document instead.
+ * Extract the actual article id string in either case.
+ */
+function articleRefId(article) {
+  return String(article?._id ?? article)
 }
 
 module.exports = {
@@ -150,6 +139,51 @@ module.exports = {
         return corpus.save()
       }
       return corpus
+    },
+
+    async deleteCorpus(_, { corpusId }, context) {
+      const corpus = await getCorpusByContext(corpusId, context)
+      await corpus.deleteOne()
+      return corpus
+    },
+
+    async renameCorpus(_, { corpusId, name }, context) {
+      const corpus = await getCorpusByContext(corpusId, context)
+      return corpus.rename(name)
+    },
+
+    async updateCorpusMetadata(_, { corpusId, metadata }, context) {
+      const corpus = await getCorpusByContext(corpusId, context)
+      return corpus.updateMetadata(metadata)
+    },
+
+    async updateCorpus(_, { corpusId, updateCorpusInput }, context) {
+      const corpus = await getCorpusByContext(corpusId, context)
+      return corpus.update(updateCorpusInput)
+    },
+
+    async addCorpusArticle(_, { corpusId, articleId }, context) {
+      const corpus = await getCorpusByContext(corpusId, context)
+      return corpus.addArticleById(articleId)
+    },
+
+    async removeCorpusArticle(_, { corpusId, articleId }, context) {
+      const corpus = await getCorpusByContext(corpusId, context)
+      return corpus.removeArticleById(articleId)
+    },
+
+    async moveCorpusArticle(_, { corpusId, articleId, order }, context) {
+      const corpus = await getCorpusByContext(corpusId, context)
+      return corpus.moveArticle(articleId, order)
+    },
+
+    async updateCorpusArticlesOrder(
+      _,
+      { corpusId, articlesOrderInput },
+      context
+    ) {
+      const corpus = await getCorpusByContext(corpusId, context)
+      return corpus.updateArticlesOrder(articlesOrderInput)
     },
   },
 
@@ -251,62 +285,36 @@ module.exports = {
       return new CorpusArticle(corpus, article)
     },
 
+    /** @deprecated Use renameCorpus root mutation instead. */
     async rename(corpus, { name }) {
-      corpus.name = name
-      return corpus.save()
+      return corpus.rename(name)
     },
 
+    /** @deprecated Use updateCorpusMetadata root mutation instead. */
     async updateMetadata(corpus, { metadata }) {
-      corpus.metadata = metadata
-      return corpus.save()
+      return corpus.updateMetadata(metadata)
     },
 
+    /** @deprecated Use addCorpusArticle root mutation instead. */
     async addArticle(corpus, { articleId, order }) {
-      const articleAlreadyAdded = corpus.articles.find(
-        ({ article }) => article.id === articleId
-      )
-      if (articleAlreadyAdded) {
-        return corpus
-      }
-      corpus.articles.push({ article: { _id: articleId }, order })
-      return corpus.save()
+      return corpus.addArticleById(articleId, order)
     },
 
+    /** @deprecated Use deleteCorpus root mutation instead. */
     async delete(corpus) {
       await corpus.deleteOne()
 
       return corpus
     },
 
+    /** @deprecated Use updateCorpus root mutation instead. */
     async update(corpus, { updateCorpusInput }) {
-      const name = updateCorpusInput.name
-      if (name !== undefined && name !== null) {
-        corpus.name = name
-      }
-      const description = updateCorpusInput.description
-      if (description !== undefined && description !== null) {
-        corpus.description = description
-      }
-      const metadata = updateCorpusInput.metadata
-      if (metadata !== undefined) {
-        corpus.metadata = metadata
-      }
-      return await corpus.save()
+      return corpus.update(updateCorpusInput)
     },
 
+    /** @deprecated Use updateCorpusArticlesOrder root mutation instead. */
     async updateArticlesOrder(corpus, { articlesOrderInput }) {
-      const articlesOrderMap = articlesOrderInput.reduce((acc, item) => {
-        acc[item.articleId] = item.order
-        return acc
-      }, {})
-      corpus.articles = corpus.articles.map((corpusArticle) => {
-        const order = articlesOrderMap[corpusArticle.article._id]
-        return {
-          article: corpusArticle.article,
-          order,
-        }
-      })
-      return corpus.save()
+      return corpus.updateArticlesOrder(articlesOrderInput)
     },
   },
 }

--- a/graphql/resolvers/versionResolver.js
+++ b/graphql/resolvers/versionResolver.js
@@ -10,6 +10,17 @@ const { toLegacyFormat } = require('../helpers/metadata')
 const { toEntries } = require('../helpers/bibtex')
 
 module.exports = {
+  Mutation: {
+    async renameVersion(_, { versionId, name }) {
+      // TODO need to make sure user should have access to this version
+      const version = await Version.findById(versionId)
+      if (!version) {
+        throw new NotFoundError('Version', versionId)
+      }
+      return version.rename(name)
+    },
+  },
+
   Query: {
     async version(_, { version: versionId }) {
       // TODO need to make sure user should have access to this version
@@ -29,11 +40,9 @@ module.exports = {
       return context.loaders.users.load(version.owner._id)
     },
 
+    /** @deprecated Use renameVersion root mutation instead. */
     async rename(version, { name }) {
-      version.set('message', name)
-      const result = await version.save({ timestamps: false })
-
-      return result === version
+      return version.rename(name)
     },
 
     bibPreview({ bib }) {

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -142,7 +142,7 @@ type Version {
   createdAt: DateTime
   updatedAt: DateTime
 
-  rename(name: String): Boolean
+  rename(name: String): Boolean @deprecated(reason: "Use renameVersion mutation at the root instead.")
 }
 
 input ArticleVersionInput {
@@ -365,8 +365,8 @@ type CorpusArticle {
   order: Int
 
   # mutation
-  remove: Corpus!
-  move(order: Int): Corpus
+  remove: Corpus! @deprecated(reason: "Use removeCorpusArticle mutation at the root instead.")
+  move(order: Int): Corpus @deprecated(reason: "Use moveCorpusArticle mutation at the root instead.")
 }
 
 input ArticleOrder {
@@ -395,12 +395,12 @@ type Corpus {
   article(articleId: ID!): CorpusArticle
 
   # mutations
-  addArticle(articleId: ID!): Corpus
-  rename(name: String!): Corpus
-  updateMetadata(metadata: JSON!): Corpus
-  updateArticlesOrder(articlesOrderInput: [ArticleOrder!]!): Corpus
-  delete: Corpus!
-  update(updateCorpusInput: UpdateCorpusInput!): Corpus!
+  addArticle(articleId: ID!): Corpus @deprecated(reason: "Use addCorpusArticle mutation at the root instead.")
+  rename(name: String!): Corpus @deprecated(reason: "Use renameCorpus mutation at the root instead.")
+  updateMetadata(metadata: JSON!): Corpus @deprecated(reason: "Use updateCorpusMetadata mutation at the root instead.")
+  updateArticlesOrder(articlesOrderInput: [ArticleOrder!]!): Corpus @deprecated(reason: "Use updateCorpusArticlesOrder mutation at the root instead.")
+  delete: Corpus! @deprecated(reason: "Use deleteCorpus mutation at the root instead.")
+  update(updateCorpusInput: UpdateCorpusInput!): Corpus! @deprecated(reason: "Use updateCorpus mutation at the root instead.")
 }
 
 input CreateCorpusInput {
@@ -671,6 +671,54 @@ type Mutation {
   createCorpus(createCorpusInput: CreateCorpusInput!): Corpus
 
   """
+  Delete a corpus by ID.
+  Requires authentication with access to the corpus.
+  """
+  deleteCorpus(corpusId: ID!): Corpus!
+
+  """
+  Rename a corpus by ID.
+  Requires authentication with access to the corpus.
+  """
+  renameCorpus(corpusId: ID!, name: String!): Corpus
+
+  """
+  Update the metadata of a corpus.
+  Requires authentication with access to the corpus.
+  """
+  updateCorpusMetadata(corpusId: ID!, metadata: JSON!): Corpus
+
+  """
+  Update a corpus's name, description, or metadata.
+  Requires authentication with access to the corpus.
+  """
+  updateCorpus(corpusId: ID!, updateCorpusInput: UpdateCorpusInput!): Corpus!
+
+  """
+  Add an article to a corpus.
+  Requires authentication with access to the corpus.
+  """
+  addCorpusArticle(corpusId: ID!, articleId: ID!): Corpus
+
+  """
+  Remove an article from a corpus.
+  Requires authentication with access to the corpus.
+  """
+  removeCorpusArticle(corpusId: ID!, articleId: ID!): Corpus!
+
+  """
+  Move an article to a new position within a corpus.
+  Requires authentication with access to the corpus.
+  """
+  moveCorpusArticle(corpusId: ID!, articleId: ID!, order: Int): Corpus
+
+  """
+  Reorder the articles within a corpus.
+  Requires authentication with access to the corpus.
+  """
+  updateCorpusArticlesOrder(corpusId: ID!, articlesOrderInput: [ArticleOrder!]!): Corpus
+
+  """
   Update the bibliography of an article from a BibTeX string.
   Returns the updated bibliography as a list of structured entries.
   Requires authentication with access to the article (as owner, contributor, or via a workspace).
@@ -757,6 +805,11 @@ type Mutation {
   Requires authentication with access to the article.
   """
   createArticleVersion(articleId: ID!, articleVersionInput: ArticleVersionInput!): Article
+
+  """
+  Rename a version by ID (updates its message).
+  """
+  renameVersion(versionId: ID!, name: String): Boolean
 }`
 
 module.exports = makeExecutableSchema({ typeDefs, resolvers })


### PR DESCRIPTION
Termine la migration entamée dans #1940 (déjà faite pour `User`, `Article` et `Workspace`).

- addCorpusArticle
- removeCorpusArticle
- moveCorpusArticle
- renameCorpus
-  updateCorpusMetadata
- updateCorpus
- deleteCorpus
- updateCorpusArticlesOrder
- renameVersion

Les anciens champs imbriqués sont conservés et marqués `@deprecated`, en délégant à des méthodes d'instance sur les modèles Corpus/Version pour éviter la duplication de logique. Le frontend utilise désormais les mutations racine (et `renameVersion`, qui était appelée via une query, est corrigée en mutation).